### PR TITLE
Added quit_on_finish option to GUI allow automated testing

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -37,6 +37,7 @@ extends "res://addons/gut/gut_gui.gd"
 # Editor Variables
 # ###########################
 export var _run_on_load = false
+export var _quit_on_finish = false
 export(String) var _select_script = null
 export(String) var _tests_like = null
 export var _should_print_to_console = true setget set_should_print_to_console, get_should_print_to_console
@@ -414,6 +415,9 @@ func _end_run():
 	_update_controls()
 	emit_signal(SIGNAL_TESTS_FINISHED)
 	set_title("Finished.  " + str(get_fail_count()) + " failures.")
+
+	if _quit_on_finish:
+		get_tree().quit()
 
 # ------------------------------------------------------------------------------
 # Checks the passed in thing to see if it is a "function state" object that gets


### PR DESCRIPTION
Added this option:
![finish](https://user-images.githubusercontent.com/13490050/36477975-5effa6d8-1703-11e8-92b6-250e157871be.png)


This means you can run (for example):
godot tests/test_all.tscn

This can be done via the command line interface (-gexit flag) but I wanted a way to do this via the GUI. If you think this isn't a good thing to add, then feel free to close the pull request.