### PR TITLE
assert_has_editor_property

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -90,6 +90,9 @@ func _init_types_dictionary():
 	types[TYPE_COLOR_ARRAY] = 'TYPE_COLOR_ARRAY'
 	types[TYPE_MAX] = 'TYPE_MAX'
 
+const EDITOR_PROPERTY = PROPERTY_USAGE_SCRIPT_VARIABLE | PROPERTY_USAGE_DEFAULT
+const VARIABLE_PROPERTY = PROPERTY_USAGE_SCRIPT_VARIABLE
+
 # Summary counts for the test.
 var _summary = {
 	asserts = 0,
@@ -337,6 +340,38 @@ func assert_get_set_methods(obj, property, default, set_to):
 	assert_eq(obj.call(get), default, 'It should have the expected default value.')
 	obj.call(set, set_to)
 	assert_eq(obj.call(get), set_to, 'The set value should have been returned.')
+
+# ---------------------------------------------------------------------------
+# Property search helper.  Used to retrieve Dictionary of specified property
+# from passed object. Returns null if not found.
+# If provided, property_usage constrains the type of property returned by
+# passing either:
+# EDITOR_PROPERTY for properties defined as: export(int) var some_value
+# VARIABLE_PROPERTY for properties definded as: var another_value
+# ---------------------------------------------------------------------------
+func _find_object_property(obj, property_name, property_usage=null):
+	for property in obj.get_property_list():
+		if property['name'] == property_name:
+			if property_usage == null or property['usage'] == property_usage:
+				return property
+			# No duplicate property names possible.
+			break
+	return null
+
+# ------------------------------------------------------------------------------
+# Asserts the object has the specified editor property
+# ------------------------------------------------------------------------------
+func assert_has_editor_property(obj, property_name, type):
+	var disp = 'expected %s to have editor property [%s]' % [obj, property_name]
+	var property = _find_object_property(obj, property_name, EDITOR_PROPERTY)
+	if property != null:
+		disp += ' of type [%s]. Got type [%s].' % [types[type], types[property['type']]]
+		if property['type'] == type:
+			_pass(disp)
+		else:
+			_fail(disp)
+	else:
+		_fail(disp)
 
 # ------------------------------------------------------------------------------
 # Signal assertion helper.  Do not call directly, use _can_make_signal_assertions

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -350,13 +350,17 @@ func assert_get_set_methods(obj, property, default, set_to):
 # VARIABLE_PROPERTY for properties definded as: var another_value
 # ---------------------------------------------------------------------------
 func _find_object_property(obj, property_name, property_usage=null):
-	for property in obj.get_property_list():
+	var result = null
+	var found = false
+	var properties = obj.get_property_list()
+
+	while !found and !properties.empty():
+		var property = properties.pop_back()
 		if property['name'] == property_name:
 			if property_usage == null or property['usage'] == property_usage:
-				return property
-			# No duplicate property names possible.
-			break
-	return null
+				result = property
+				found = true
+	return result
 
 # ------------------------------------------------------------------------------
 # Asserts the object has the specified editor property

--- a/test/samples/test_readme_examples.gd
+++ b/test/samples/test_readme_examples.gd
@@ -233,6 +233,24 @@ func test_assert_has_method():
 	assert_has_method(some_class, 'method_does_not_exist')
 
 # ------------------------------------------------------------------------------
+class ExportClass:
+	export var some_number = 5
+	export(PackedScene) var some_scene
+	var some_variable = 1
+
+func test_assert_has_editor_property():
+	var obj = ExportClass.new()
+
+	gut.p('-- passing --')
+	assert_has_editor_property(obj, "some_number", TYPE_INT)
+	assert_has_editor_property(obj, "some_scene", TYPE_OBJECT)
+
+	gut.p('-- failing --')
+	assert_has_editor_property(obj, 'some_number', TYPE_VECTOR2)
+	assert_has_editor_property(obj, 'some_scene', TYPE_AABB)
+	assert_has_editor_property(obj, 'some_variable', TYPE_INT)
+# ------------------------------------------------------------------------------
+
 class MovingNode:
 	extends Node2D
 	var _speed = 2

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -472,7 +472,7 @@ func test_fail_if_editor_property_present_with_incorrect_type():
 	gr.test.assert_has_editor_property(obj, "bool_property", TYPE_REAL)
 	assert_fail(gr.test)
 
-func test__object_derived_type__editored_as_object_type():
+func test__object_derived_type__exported_as_object_type():
 	var obj = HasObjectDerivedPropertyType.new()
 	gr.test.assert_has_editor_property(obj, "scene_property", TYPE_OBJECT)
 	assert_pass(gr.test)

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -422,6 +422,60 @@ func test_pass_if_all_get_sets_are_aligned():
 	gr.test.assert_get_set_methods(obj, 'thing', 'something', 'another thing')
 	assert_pass(gr.test, 4)
 
+# -----------------------------------------------
+# Classes used for has editor property assert
+# -----------------------------------------------
+class NoProperty:
+	func _unused():
+		pass
+
+class NotEditorProperty:
+	var some_property = 1
+
+class HasCorrectEditorPropertyAndExplicitType:
+	export(int) var int_property
+
+class HasCorrectEditorPropertyAndImplicitType:
+	export var vec2_property = Vector2(0.0, 0.0)
+
+class HasCorrectEditorPropertyNotType:
+	export(bool) var bool_property
+
+class HasObjectDerivedPropertyType:
+	export(PackedScene) var scene_property
+
+# ------------------------------
+# Has Editor Property Assert
+# ------------------------------
+func test_fail_if_property_not_found():
+	var obj = NoProperty.new()
+	gr.test.assert_has_editor_property(obj, "some_property", TYPE_BOOL)
+	assert_fail(gr.test)
+
+func test_fail_if_not_editor_property():
+	var obj = NotEditorProperty.new()
+	gr.test.assert_has_editor_property(obj, "some_property", TYPE_INT)
+	assert_fail(gr.test)
+
+func test_pass_if_editor_property_present_with_correct_explicit_type():
+	var obj = HasCorrectEditorPropertyAndExplicitType.new()
+	gr.test.assert_has_editor_property(obj, "int_property", TYPE_INT)
+	assert_pass(gr.test)
+
+func test_pass_if_editor_property_present_with_correct_implicit_type():
+	var obj = HasCorrectEditorPropertyAndImplicitType.new()
+	gr.test.assert_has_editor_property(obj, "vec2_property", TYPE_VECTOR2)
+	assert_pass(gr.test)
+
+func test_fail_if_editor_property_present_with_incorrect_type():
+	var obj = HasCorrectEditorPropertyNotType.new()
+	gr.test.assert_has_editor_property(obj, "bool_property", TYPE_REAL)
+	assert_fail(gr.test)
+
+func test__object_derived_type__editored_as_object_type():
+	var obj = HasObjectDerivedPropertyType.new()
+	gr.test.assert_has_editor_property(obj, "scene_property", TYPE_OBJECT)
+	assert_pass(gr.test)
 
 # ------------------------------
 # File asserts


### PR DESCRIPTION
Hey there.
First off, gotta say this is a fantastic utility you're cooking up here. :+1:

Anyway, I usually start new node scripts thinking about what signals and/or editor properties they might need. So I wanted a counterpart to assert_has_signal. Probably some overlap with assert_get_set_methods, but I don't always need getters/setters and I like to have a check that the property itself exists on the object.

assert_has_editor_property(obj, property_name, type)
Asserts that passed object has an exported property named 'property_name' of built-in type 'type'
```GDScript
class ExportClass:
	export var some_number = 5
	export(PackedScene) var some_scene
	var some_variable = 1

func test_assert_has_editor_property():
	var obj = ExportClass.new()

	gut.p('-- passing --')
	assert_has_editor_property(obj, "some_number", TYPE_INT)
	assert_has_editor_property(obj, "some_scene", TYPE_OBJECT)
	
	gut.p('-- failing --')
	assert_has_editor_property(obj, 'some_number', TYPE_VECTOR2)
	assert_has_editor_property(obj, 'some_scene', TYPE_AABB)
	assert_has_editor_property(obj, 'some_variable', TYPE_INT)
```
Didn't see a need for it myself, but it would be trivial to make assert_has_variable_property as well.