### PR TITLE
Set exit code based on failed tests

### DIFF
--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -384,4 +384,8 @@ func _init():
 # exit if option is set.
 func _on_tests_finished():
 	if(options.should_exit):
+		if _tester.get_fail_count() == 0:
+			OS.exit_code = 0
+		else:
+			OS.exit_code = 1
 		quit()


### PR DESCRIPTION
This allows continuous integration services to detect whether or not the tests
ran through successfully.