### PR TITLE
Set exit code on failed tests despite `should_exit` option

### DIFF
--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -396,9 +396,7 @@ func _init():
 
 # exit if option is set.
 func _on_tests_finished():
+	if(_tester.get_fail_count()):
+		OS.exit_code = 1
 	if(options.should_exit):
-		if _tester.get_fail_count() == 0:
-			OS.exit_code = 0
-		else:
-			OS.exit_code = 1
 		quit()


### PR DESCRIPTION
When running gut from command line, it becomes possible to accidentaly
push changes that didn't pass the tests when using continuous integration
if `should_exit` option is not set.

This fixes the described issue by ensuring that the exit code is set regardless
of possible options. It's also not necessary to set exit code to zero because
the program exits with zero by default.