### PR TITLE
Add maximize option to command line and the editor

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,5 +1,6 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
+  "should_maximize":false,
   "should_exit":true,
   "ignore_pause":true,
   "log": 1,

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -35,6 +35,7 @@ extends "res://addons/gut/gut_gui.gd"
 # ###########################
 # Editor Variables
 # ###########################
+export var _should_maximize = false setget set_should_maximize, get_should_maximize
 export var _run_on_load = false
 export(String) var _select_script = null
 export(String) var _tests_like = null
@@ -155,7 +156,7 @@ func _ready():
 	set_it_up()
 	set_process_input(true)
 	_connect_controls()
-	set_position(get_position() + Vector2(0, 20))
+	set_position(get_position() + title_offset)
 
 	add_child(_wait_timer)
 	_wait_timer.set_wait_time(1)
@@ -190,6 +191,10 @@ func _ready():
 
 	if(_run_on_load):
 		test_scripts(_select_script == null)
+
+	if(_should_maximize):
+		maximize()
+
 	show()
 
 #####################
@@ -701,6 +706,21 @@ func select_script(script_name):
 # MISC
 #
 ################
+# ------------------------------------------------------------------------------
+# Maximize test runner window to fit the viewport.
+# ------------------------------------------------------------------------------
+func set_should_maximize(should):
+	_should_maximize = should
+
+func get_should_maximize():
+	return _should_maximize
+
+func maximize():
+	if(is_inside_tree()):
+		set_position(title_offset)
+		var vp_size_offset = get_viewport().size - title_offset
+		set_size(vp_size_offset)
+
 func disable_strict_datatype_checks(should):
 	_disable_strict_datatype_checks = should
 

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -226,6 +226,7 @@ var _opts = []
 # that I don't make any dumb typos and get the neat code-sense when I
 # type a dot.
 var options = {
+	should_maximize = false,
 	should_exit = false,
 	log_level = 1,
 	ignore_pause_before_teardown = false,
@@ -239,7 +240,7 @@ var options = {
 	show_help = false,
 	config_file = '',
 	inner_class = '',
-        opacity = 100
+	opacity = 100
 }
 
 # flag to say if we should run the scripts or not.  It is only
@@ -261,6 +262,7 @@ func setup_options():
 	opts.add('-gdir', [], 'Comma delimited list of directories to add tests from.')
 	opts.add('-gprefix', 'test_', 'Prefix used to find tests when specifying -gdir.  Default "[default]"')
 	opts.add('-gsuffix', '.gd', 'Suffix used to find tests when specifying -gdir.  Default "[default]"')
+	opts.add('-gmaximize', false, 'Maximizes test runner window to fit the viewport.')
 	opts.add('-gexit', false, 'Exit after running tests.  If not specified you have to manually close the window.')
 	opts.add('-glog', 1, 'Log level.  Default [default]')
 	opts.add('-gignore_pause', false, 'Ignores any calls to gut.pause_before_teardown.')
@@ -283,6 +285,7 @@ func setup_options():
 func extract_options(opt):
 	options.tests = opt.get_value('-gtest')
 	options.dirs = opt.get_value('-gdir')
+	options.should_maximize = opt.get_value('-gmaximize')
 	options.should_exit = opt.get_value('-gexit')
 	options.log_level = opt.get_value('-glog')
 	options.ignore_pause_before_teardown = opt.get_value('-gignore_pause')
@@ -324,6 +327,7 @@ func load_options_from_config_file(file_path):
 		return -1
 
 	options.dirs = get_value(results.result, 'dirs', [])
+	options.should_maximize = get_value(results.result, 'should_maximize', false)
 	options.should_exit = get_value(results.result, 'should_exit', false)
 	options.ignore_pause_before_teardown = get_value(results.result, 'ignore_pause', false)
 	options.log_level = get_value(results.result, 'log', 1)
@@ -341,6 +345,10 @@ func apply_options():
 	_tester.set_yield_between_tests(true)
 	_tester.set_modulate(Color(1.0, 1.0, 1.0, min(1.0, float(options.opacity) / 100)))
 	_tester.show()
+
+	if(options.should_maximize):
+		_tester.maximize()
+
 	if(options.inner_class != ''):
 		_tester.set_inner_class_name(options.inner_class)
 	_tester.set_log_level(options.log_level)

--- a/addons/gut/gut_gui.gd
+++ b/addons/gut/gut_gui.gd
@@ -42,6 +42,7 @@ var _summary = {
 
 var _is_running = false
 var min_size = Vector2(650, 400)
+var title_offset = Vector2(0, get_constant("title_height"))
 
 #controls
 var _ctrls = {

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -5,14 +5,12 @@
 [ext_resource path="res://addons/gut/icon.png" type="Texture" id=3]
 
 [node name="main" type="Node2D" index="0"]
-
 script = ExtResource( 1 )
 __meta__ = {
 "__editor_plugin_screen__": "Script"
 }
 
 [node name="Gut" type="WindowDialog" parent="." index="0"]
-
 visible = false
 anchor_left = 0.0
 anchor_top = 0.0
@@ -33,6 +31,7 @@ script = ExtResource( 2 )
 __meta__ = {
 "_editor_icon": ExtResource( 3 )
 }
+_should_maximize = false
 _run_on_load = false
 _select_script = null
 _tests_like = null
@@ -54,7 +53,6 @@ _directory5 = ""
 _directory6 = ""
 
 [node name="RunGutTestsButton" type="Button" parent="." index="1"]
-
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
@@ -79,5 +77,3 @@ flat = false
 align = 1
 
 [connection signal="pressed" from="RunGutTestsButton" to="." method="_on_RunGutTestsButton_pressed"]
-
-

--- a/templates/.gutconfig.json
+++ b/templates/.gutconfig.json
@@ -1,5 +1,6 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
+  "should_maximize":false,
   "should_exit":true,
   "ignore_pause":true,
   "log": 2,


### PR DESCRIPTION
This fits test runner window to the viewport. The fullscreen mode can be
toggled from the editor, from a command line and be fetched from the gut
configuration file.

Also defined `title_offset` variable to automatically fetch the window's
title bar height that was hardcoded and used for positioning the window.
