### PR TITLE
Allow testing in exports

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -661,9 +661,8 @@ func add_script(script, select_this_one=false):
 # ------------------------------------------------------------------------------
 func add_directory(path, prefix=_file_prefix, suffix=_file_extension):
 	var d = Directory.new()
-	if(!d.dir_exists(path)):
+	if d.open(path) != OK:
 		return
-	d.open(path)
 	d.list_dir_begin()
 
 	# Traversing a directory is kinda odd.  You have to start the process of listing
@@ -675,7 +674,7 @@ func add_directory(path, prefix=_file_prefix, suffix=_file_extension):
 		full_path = path + "/" + thing
 		#file_exists returns fasle for directories
 		if(d.file_exists(full_path)):
-			if(thing.begins_with(prefix) and thing.find(suffix) != -1):
+			if(thing.begins_with(prefix) and thing.find(suffix) != -1 and thing.find(".remap") == -1):
 				add_script(full_path)
 		thing = d.get_next()
 	d.list_dir_end()

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -52,6 +52,20 @@ var _test_prefix = 'test_'
 var _test_class_prefix = 'Test'
 
 func _parse_script(script):
+	if script.path.ends_with(".gdc"):
+		_parse_gdc_script(script)
+	elif script.path.ends_with(".gd"):
+		_parse_gd_script(script)
+
+func _parse_gdc_script(script):
+	var test = load(script.path).new()
+	for method in test.get_method_list():
+		if(method["name"].begins_with(_test_prefix)):
+			var new_test = Test.new()
+			new_test.name = method["name"]
+			script.tests.append(new_test)
+
+func _parse_gd_script(script):
 	var file = File.new()
 	var line = ""
 	var line_count = 0


### PR DESCRIPTION
This fix is releated to issue #73.
* dir_exists returns false on directories in exports, using return code from open instead
* the export includes .gdc and .gc.remap files, excluding .remap files
* add a 'parser' for .gdc files, it only looks for test functions but not their line numbers