### PR TITLE
Remove unused variable from clear_output_directory

### DIFF
--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -361,7 +361,6 @@ func clear_output_directory():
 		# out res:// which is SUPER BAD.
 		if(result == OK):
 			d.list_dir_begin(true)
-			var files = []
 			var f = d.get_next()
 			while(f != ''):
 				d.remove(f)


### PR DESCRIPTION
Line 354. Method clear_output_directory creates "var files = []" but seems to never use or return it.