### PR TITLE
V6.7.1 issue98

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`
 # Getting Started
 Here's a short setup tutorial provided by Rainware https://www.youtube.com/watch?v=vBbqlfmcAlc
 
+TDD and P O N G Episode 1
+
+https://www.youtube.com/watch?v=nF2gPF69Dc4&t=3s
+
+TDD and P O N G Episode 2
+
+https://www.youtube.com/watch?v=rNN0Xw1R_1E&t=2s
+
+
 Here's a couple more [wiki](https://github.com/bitwes/Gut/wiki) links to get you started.
 * [Install](https://github.com/bitwes/Gut/wiki/Install)
 * [Creating Tests](https://github.com/bitwes/Gut/wiki/Creating-Tests)

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -244,7 +244,11 @@ func _get_func_text(method_hash):
 	ftxt += _get_spy_text(method_hash)
 
 	if(_stubber and method_hash.name != '_init'):
-		ftxt += "\treturn __gut_metadata_.stubber.get_return(self, '" + method_hash.name + "', " + called_with + ")\n"
+		var call_method = _method_maker.get_super_call_text(method_hash)
+		ftxt += "\tif(__gut_metadata_.stubber.should_call_super(self, '" + method_hash.name + "', " + called_with + ")):\n"
+		ftxt += "\t\treturn " + call_method + "\n"
+		ftxt += "\telse:\n"
+		ftxt += "\t\treturn __gut_metadata_.stubber.get_return(self, '" + method_hash.name + "', " + called_with + ")\n"
 	else:
 		ftxt += "\tpass\n"
 

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -365,7 +365,6 @@ func clear_output_directory():
 		# out res:// which is SUPER BAD.
 		if(result == OK):
 			d.list_dir_begin(true)
-			var files = []
 			var f = d.get_next()
 			while(f != ''):
 				d.remove(f)

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -3,6 +3,8 @@ var stub_target = null
 var target_subpath = null
 var parameters = null
 var stub_method = null
+var call_super = false
+
 const NOT_SET = '|_1_this_is_not_set_1_|'
 
 func _init(target=null, method=null, subpath=null):
@@ -12,6 +14,10 @@ func _init(target=null, method=null, subpath=null):
 
 func to_return(val):
 	return_val = val
+	return self
+
+func to_call_super():
+	call_super = true
 	return self
 
 func when_passed(p1=NOT_SET,p2=NOT_SET,p3=NOT_SET,p4=NOT_SET,p5=NOT_SET,p6=NOT_SET,p7=NOT_SET,p8=NOT_SET,p9=NOT_SET,p10=NOT_SET):
@@ -25,4 +31,4 @@ func when_passed(p1=NOT_SET,p2=NOT_SET,p3=NOT_SET,p4=NOT_SET,p5=NOT_SET,p6=NOT_S
 	return self
 
 func to_s():
-	return str(stub_target, '(', target_subpath, ').', stub_method, ' with (', parameters, ') = ', return_val) 
+	return str(stub_target, '(', target_subpath, ').', stub_method, ' with (', parameters, ') = ', return_val)

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -14,7 +14,11 @@ func _init(target=null, method=null, subpath=null):
 
 func to_return(val):
 	return_val = val
+	call_super = false
 	return self
+
+func to_do_nothing():
+	return to_return(null)
 
 func to_call_super():
 	call_super = true

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -69,22 +69,8 @@ func add_stub(stub_params):
 	var key = _add_obj_method(stub_params.stub_target, stub_params.stub_method, stub_params.target_subpath)
 	returns[key][stub_params.stub_method].append(stub_params)
 
-# Gets a stubbed return value for the object and method passed in.  If the
-# instance was stubbed it will use that, otherwise it will use the path and
-# subpath of the object to try to find a value.
-#
-# It will also use the optional list of parameter values to find a value.  If
-# the object was stubbed with no parameters than any parameters will match.
-# If it was stubbed with specific parameter values then it will try to match.
-# If the parameters do not match BUT there was also an empty parameter list stub
-# then it will return those.
-# If it cannot find anything that matches then null is returned.for
-#
-# Parameters
-# obj:  this should be an instance of a doubled object.
-# method:  the method called
-# parameters:  optional array of parameter vales to find a return value for.
-func get_return(obj, method, parameters=null):
+
+func _find_stub(obj, method, parameters=null):
 	var key = _make_key_from_variant(obj)
 	var to_return = null
 
@@ -106,18 +92,47 @@ func get_return(obj, method, parameters=null):
 
 		# We have matching parameter values so return the stub value for that
 		if(param_idx != -1):
-			to_return = returns[key][method][param_idx].return_val
+			to_return = returns[key][method][param_idx]
 		# We found a case where the parameters were not specified so return
 		# parameters for that
 		elif(null_idx != -1):
-			to_return = returns[key][method][null_idx].return_val
+			to_return = returns[key][method][null_idx]
 		else:
 			_lgr.warn(str('Call to [', method, '] was not stubbed for the supplied parameters ', parameters, '.  Null was returned.'))
 	else:
 		_lgr.info('Unstubbed call to ' + method)
 
-
 	return to_return
+
+# Gets a stubbed return value for the object and method passed in.  If the
+# instance was stubbed it will use that, otherwise it will use the path and
+# subpath of the object to try to find a value.
+#
+# It will also use the optional list of parameter values to find a value.  If
+# the object was stubbed with no parameters than any parameters will match.
+# If it was stubbed with specific parameter values then it will try to match.
+# If the parameters do not match BUT there was also an empty parameter list stub
+# then it will return those.
+# If it cannot find anything that matches then null is returned.for
+#
+# Parameters
+# obj:  this should be an instance of a doubled object.
+# method:  the method called
+# parameters:  optional array of parameter vales to find a return value for.
+func get_return(obj, method, parameters=null):
+	var params = _find_stub(obj, method, parameters)
+	if(params != null):
+		return params.return_val
+	else:
+		return null
+
+func should_call_super(obj, method, parameters=null):
+	var params = _find_stub(obj, method, parameters)
+	if(params != null):
+		return params.call_super
+	else:
+		return false
+
 
 func clear():
 	returns.clear()

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -12,6 +12,7 @@ const DOUBLE_ME_PATH = 'res://test/resources/doubler_test_objects/double_me.gd'
 const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_me_scene.tscn'
 const DOUBLE_EXTENDS_NODE2D = 'res://test/resources/doubler_test_objects/double_extends_node2d.gd'
 const TEMP_FILES = 'user://test_doubler_temp_file'
+const TO_STUB_PATH = 'res://test/resources/stub_test_objects/to_stub.gd'
 
 var gr = {
 	doubler = null,
@@ -80,3 +81,11 @@ func test_can_stub_doubled_scenes():
 	gr.stubber.set_return(DOUBLE_ME_SCENE_PATH, 'return_hello', 'world')
 	var inst = gr.doubler.double_scene(DOUBLE_ME_SCENE_PATH).instance()
 	assert_eq(inst.return_hello(), 'world')
+
+func test_when_stubbed_to_call_super_then_super_is_called():
+	gr.doubler.set_stubber(gr.stubber)
+	var doubled = gr.doubler.double(DOUBLE_ME_PATH).new()
+	var params = _utils.StubParams.new(doubled, 'set_value').to_call_super()
+	gr.stubber.add_stub(params)
+	doubled.set_value(99)
+	assert_eq(doubled._value, 99)

--- a/test/resources/stub_test_objects/to_stub.gd
+++ b/test/resources/stub_test_objects/to_stub.gd
@@ -8,4 +8,7 @@ var __gut_metadata_ = {
 	spy=null
 }
 func get_value():
-    return value
+	return value
+
+func set_value(val):
+	value = val

--- a/test/unit/test_stub_params.gd
+++ b/test/unit/test_stub_params.gd
@@ -27,7 +27,7 @@ func test_init_sets_stub_target():
 func test_init_sets_subpath():
 	var s = StubParamsClass.new('thing', 'method', 'inner1/inner2')
 	assert_eq(s.target_subpath, 'inner1/inner2')
-	
+
 func test_init_sets_method():
 	var s = StubParamsClass.new('thing', 'method')
 	assert_eq(s.stub_method, 'method')
@@ -47,3 +47,11 @@ func test_parameters_turn_values_into_array():
 func test_can_take_up_to_10_parameters():
 	gr.stub_params.when_passed(1,2,3,4,5,6,7,8,9,10)
 	assert_eq(gr.stub_params.parameters.size(), 10)
+
+func test_can_set_to_call_super():
+	gr.stub_params.to_call_super()
+	assert_eq(gr.stub_params.call_super, true)
+
+func test_to_call_super_returns_self():
+	var val = gr.stub_params.to_call_super()
+	assert_eq(val, gr.stub_params)

--- a/test/unit/test_stubber.gd
+++ b/test/unit/test_stubber.gd
@@ -166,3 +166,11 @@ func test_withStubParams_param_layering_works():
 	assert_eq(sp1_r, 10, 'When passed 10 it gets 10')
 	assert_eq(sp2_r, 5, 'When passed 5 it gets 5')
 	assert_eq(sp3_r, 'nothing', 'When params do not match it sends default back.')
+
+func test_should_call_super_returns_false_by_default():
+	assert_false(gr.stubber.should_call_super('thing', 'method'))
+
+func test_should_call_super_returns_true_when_stubbed_to_do_so():
+	var sp = StubParamsClass.new('thing', 'method').to_call_super()
+	gr.stubber.add_stub(sp)
+	assert_true(gr.stubber.should_call_super('thing', 'method'))

--- a/test/unit/test_stubber.gd
+++ b/test/unit/test_stubber.gd
@@ -174,3 +174,13 @@ func test_should_call_super_returns_true_when_stubbed_to_do_so():
 	var sp = StubParamsClass.new('thing', 'method').to_call_super()
 	gr.stubber.add_stub(sp)
 	assert_true(gr.stubber.should_call_super('thing', 'method'))
+
+func test_should_call_super_overriden_by_setting_return():
+	var sp = StubParamsClass.new('thing', 'method').to_call_super()
+	sp.to_return(null)
+	gr.stubber.add_stub(sp)
+	assert_false(gr.stubber.should_call_super('thing', 'method'))
+
+func test_to_do_nothing_returns_self():
+	var sp = StubParamsClass.new('thing', 'method')
+	assert_eq(sp.to_do_nothing(), sp)

--- a/test_doubler_temp_file/double_me__dbl0__.gd
+++ b/test_doubler_temp_file/double_me__dbl0__.gd
@@ -1,0 +1,39 @@
+extends 'res://test/resources/doubler_test_objects/double_me.gd'
+var __gut_metadata_ = {
+	path='res://test/resources/doubler_test_objects/double_me.gd',
+	subpath='',
+	stubber=instance_from_id(4048),
+	spy=null
+}
+func get_position():
+	if(__gut_metadata_.stubber.should_call_super(self, 'get_position', null)):
+		return .get_position()
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'get_position', null)
+func set_value(p_arg0=null):
+	if(__gut_metadata_.stubber.should_call_super(self, 'set_value', [p_arg0])):
+		return .set_value(p_arg0)
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'set_value', [p_arg0])
+func get_value():
+	if(__gut_metadata_.stubber.should_call_super(self, 'get_value', null)):
+		return .get_value()
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'get_value', null)
+func _init():
+	pass
+func has_two_params_one_default(p_arg0=null, p_arg1=null):
+	if(__gut_metadata_.stubber.should_call_super(self, 'has_two_params_one_default', [p_arg0, p_arg1])):
+		return .has_two_params_one_default(p_arg0, p_arg1)
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'has_two_params_one_default', [p_arg0, p_arg1])
+func has_one_param(p_arg0=null):
+	if(__gut_metadata_.stubber.should_call_super(self, 'has_one_param', [p_arg0])):
+		return .has_one_param(p_arg0)
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'has_one_param', [p_arg0])
+func has_string_and_array_defaults(p_arg0=null, p_arg1=null):
+	if(__gut_metadata_.stubber.should_call_super(self, 'has_string_and_array_defaults', [p_arg0, p_arg1])):
+		return .has_string_and_array_defaults(p_arg0, p_arg1)
+	else:
+		return __gut_metadata_.stubber.get_return(self, 'has_string_and_array_defaults', [p_arg0, p_arg1])


### PR DESCRIPTION
Stubbing enhancements
* adds `to_do_nothing` so that you can suppress warnings about unstubbed methods.
* adds `to_call_super` so that the method will call the super method instead of being stubbed out.
* modifies `to_return` so that any call to it will negate a call to `to_call_super`.  This is so we can implement partial stubs later on.