### PR TITLE
6.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.import
 export_presets.cfg
+exported_tests.cfg

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -2,7 +2,7 @@
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
   "should_exit":true,
-  "ignore_pause":false,
+  "ignore_pause":true,
   "log_level": 1,
   "opacity":100,
   "double_strategy":"partial",

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,7 +1,7 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
-  "should_exit":false,
+  "should_exit":true,
   "ignore_pause":true,
   "log_level": 1,
   "opacity":100,

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,7 +1,7 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
-  "should_exit":true,
+  "should_exit":false,
   "ignore_pause":true,
   "log_level": 1,
   "opacity":100,

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -2,7 +2,7 @@
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
   "should_exit":true,
-  "ignore_pause":true,
+  "ignore_pause":false,
   "log_level": 1,
   "opacity":100,
   "double_strategy":"partial",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Release notes
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+# 6.8.1
+## Features
+* Godot 3.2 compatible.
+* __Issue 124__ CodeDarigan added the `assert_freed` and `assert_not_freed` methods.
+* __Issue 130__ GUT now lists the exact line number of a failing test in all cases instead of just the method number in non-inner classes.  Thanks to mschulzeLpz for adding `get_stack` magic.
+*
+
 # 6.8.0
 ## Features
 * __Issue 98__ Added Stubbing method `to_call_super` so that you can force a doubled object to call its super method instead of being stubbed out.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Release notes
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+
 # 6.8.1
 ## Features
 * Godot 3.2 compatible.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Godot 3.2 compatible.
 * __Issue 124__ CodeDarigan added the `assert_freed` and `assert_not_freed` methods.
 * __Issue 130__ GUT now lists the exact line number of a failing test in all cases instead of just the method number in non-inner classes.  Thanks to mschulzeLpz for adding `get_stack` magic.
+* __Issue 133__ You can now double/partial_double/stub/spy Native classes like `Node2D` and `Raycast2D`.  Syntax is the same.
 
 ## Bug Fixes
 * __Issue 127__ The method `ignore_method_when_doubling` was added as a workaround for doubling scripts that have static methods.  The "Doubles" wiki page has more info about this method.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * __Issue 115__ Partial doubles can now be created with the `partial_double` method.  This will give you an object that has all of its methods stubbed `to_call_super`.  So it will act the same as a normal object, but you can spy and stub methods on it as well.
 * Experimental FULL doubling is now working in Godot 3.1.
 * Experimental FULL doubling now stubs all supported built-ins `to_call_super` under the covers.  This means you can stub methods you haven't overloaded in your class (before you could only spy on them).
+* __Issue 105__ Added `-gexit_on_success` option to the command line to only exit if all tests passed.
 
 ## Bug Fixes
 * Housekeeping, typos and some unused variables.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Release notes
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
-# 6.7.1
+# 6.8.0
 ## Features
 * __Issue 98__ Added Stubbing method `to_call_super` so that you can force a doubled object to call its super method instead of being stubbed out.
 * Added Stubbing method `to_do_nothing`.  This allows you to be a little more deliberate in your stubbing and is more readable than `to_return(null)` which is basically all it does.  It also suppresses un-stubbed method messages.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Godot 3.2 compatible.
 * __Issue 124__ CodeDarigan added the `assert_freed` and `assert_not_freed` methods.
 * __Issue 130__ GUT now lists the exact line number of a failing test in all cases instead of just the method number in non-inner classes.  Thanks to mschulzeLpz for adding `get_stack` magic.
-*
+
+## Bug Fixes
+* __Issue 127__ The method `ignore_method_when_doubling` was added as a workaround for doubling scripts that have static methods.  The "Doubles" wiki page has more info about this method.
 
 # 6.8.0
 ## Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Xrayez fixed __Issue 109__.
 * __Issue 117__ The Spying related methods now fail if you don't pass an array for the list of expected parameters.  Something I forgot about when making "TDD and P O N G" episode 2.  You can watch it and enjoy me forgetting how to use my own tool.
 * Exporting tests in 3.1 appears to be working now.  Could not reproduce original issue.
+* __Issue 111__ Tests are now sorted.
 
 
 # 6.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,17 +4,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # 6.7.1
 ## Features
 * __Issue 98__ Added Stubbing method `to_call_super` so that you can force a doubled object to call its super method instead of being stubbed out.
-* Added Stubbing method `to_do_nothing`.  This allows you to be a little more deliberate in your stubbing and is more readable than `to_return(null)` which is bascially all it does.  It also suppresses unstubbed method messages.
+* Added Stubbing method `to_do_nothing`.  This allows you to be a little more deliberate in your stubbing and is more readable than `to_return(null)` which is basically all it does.  It also suppresses un-stubbed method messages.
 * __Issue 115__ Partial doubles can now be created with the `partial_double` method.  This will give you an object that has all of its methods stubbed `to_call_super`.  So it will act the same as a normal object, but you can spy and stub methods on it as well.
 * Experimental FULL doubling is now working in Godot 3.1.
 * Experimental FULL doubling now stubs all supported built-ins `to_call_super` under the covers.  This means you can stub methods you haven't overloaded in your class (before you could only spy on them).
 * __Issue 105__ Added `-gexit_on_success` option to the command line to only exit if all tests passed.
+* Added `get_version` method to `Gut.gd`.  
 
 ## Bug Fixes
 * Housekeeping, typos and some unused variables.
 * __Issue 108__ Maximize doesn't move back to 0,0.
 * Xrayez fixed __Issue 109__.
 * __Issue 117__ The Spying related methods now fail if you don't pass an array for the list of expected parameters.  Something I forgot about when making "TDD and P O N G" episode 2.  You can watch it and enjoy me forgetting how to use my own tool.
+* Exporting tests in 3.1 appears to be working now.  Could not reproduce original issue.
 
 
 # 6.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Bug Fixes
 * __Issue 127__ The method `ignore_method_when_doubling` was added as a workaround for doubling scripts that have static methods.  The "Doubles" wiki page has more info about this method.
+* __Issue 136__ Bug can happen when yielding where a `attempt to disconnect signal...while emitting` can occur.  Disconnecting from signals is now done via `call_deferred`.
 
 # 6.8.0
 ## Features

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ __Please upgrade to the latest version.__
 GUT (Godot Unit Test) is a utility for writing tests for your Godot Engine game.  It allows you to write tests for your gdscript in gdscript.
 
 ## Features
-* Godot 3.0 and 3.1 compatible (There are some minor issues with 3.1 though, [check them out here](https://github.com/bitwes/Gut/wiki/Godot-3.1-Issues).)
+* Godot 3.0 and 3.1 compatible (There are some minor issues with 3.1 though, [check them out here](https://github.com/bitwes/Gut/wiki/Godot-3.1-Issues).
 * [Simple install via the Asset Library.](https://github.com/bitwes/Gut/wiki/Install)
 * [A plethora of asserts and utility methods to help make your tests simple and concise.](https://github.com/bitwes/Gut/wiki/Methods)
 * [Support for Inner Test Classes to give your tests some extra context and maintainability.](https://github.com/bitwes/Gut/wiki/Inner-Test-Classes)
-* [Doubling](https://github.com/bitwes/Gut/wiki/Doubles)
+* Doubling:  [Full](https://github.com/bitwes/Gut/wiki/Doubles) and [Partial](https://github.com/bitwes/Gut/wiki/Partial-Doubles)
 * [Stubbing](https://github.com/bitwes/Gut/wiki/Stubbing)
 * [Spying](https://github.com/bitwes/Gut/wiki/Spies)
 * [Export tests with your project and run them on any platform Godot supports.](https://github.com/bitwes/Gut/wiki/Exporting-Tests)

--- a/README.md
+++ b/README.md
@@ -27,5 +27,4 @@ Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`
 
 ## [Tutorials](https://github.com/bitwes/Gut/wiki/Tutorials)
 * [Here's a short setup tutorial provided by Rainware](https://www.youtube.com/watch?v=vBbqlfmcAlc)
-* [TDD and P O N G Episode 1](https://www.youtube.com/watch?v=nF2gPF69Dc4&t=3s)
-* [TDD and P O N G Episode 2](https://www.youtube.com/watch?v=rNN0Xw1R_1E&t=2s)
+* [TDD and P O N G Series](https://www.youtube.com/channel/UCkGO6guRt_5fOh3oDHbfg9w/playlists)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-# Godot 3.2
-There is the `godot_3_2` branch which is now working with 3.2 alpha 2.  Any 3.2 related bugs will be fixed here then double checked for backwards compatibility with 3.1.  I'll merge the branch into master when 3.2 is live.
-
-# 6.6.0 has a potentially bad bug
-__Please upgrade to the latest version.__
-
-6.6.0 has a bug that can, if everything goes wrong just right, delete files in the root of the project.  I only saw it happen when running the test suite for Gut and only the `test_doubler.gd` test script.  I don't recall ever seeing it happen in my own game, but just to be safe you should upgrade.
-
-# Gut 6.8.0
+# Gut 6.8.1
 GUT (Godot Unit Test) is a utility for writing tests for your Godot Engine game.  It allows you to write tests for your gdscript in gdscript.
 
 ## Features
-* Godot 3.0 and 3.1 compatible (There are some minor issues with 3.1 though, [check them out here](https://github.com/bitwes/Gut/wiki/Godot-3.1-Issues).
+* Godot 3.0, 3.1 and 3.2 compatible (There are some minor issues with 3.1/2 though, [check them out here](https://github.com/bitwes/Gut/wiki/Godot-3.1-Issues).
 * [Simple install via the Asset Library.](https://github.com/bitwes/Gut/wiki/Install)
 * [A plethora of asserts and utility methods to help make your tests simple and concise.](https://github.com/bitwes/Gut/wiki/Methods)
 * [Support for Inner Test Classes to give your tests some extra context and maintainability.](https://github.com/bitwes/Gut/wiki/Inner-Test-Classes)
@@ -22,10 +14,6 @@ GUT (Godot Unit Test) is a utility for writing tests for your Godot Engine game.
 * [Integration testing made easier with `yield`s](https://github.com/bitwes/Gut/wiki/Yielding)
 
 More info can be found in the [wiki](https://github.com/bitwes/Gut/wiki).
-
-## Upgrading to 6.8.0 from any 6.6.x version
-* It is not required, but you should remove the existing Gut node for any scenes you have that use it and then re-add it and re-configure it.  Re-adding will get rid of the caution symbol next to the control (this is due to changes in inheritance, Gut changed from a `WindowDialog` to a `Control`)
-* For the command line, note that the `log` option in the `.gutconfig.json` file has changed to `log_level` for consistency.
 
 # License
 Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@ __Please upgrade to the latest version.__
 
 6.6.0 has a bug that can, if everything goes wrong just right, delete files in the root of the project.  I only saw it happen when running the test suite for Gut and only the `test_doubler.gd` test script.  I don't recall ever seeing it happen in my own game, but just to be safe you should upgrade.
 
-# Gut 6.7.0
+# Gut 6.8.0
 GUT (Godot Unit Test) is a utility for writing tests for your Godot Engine game.  It allows you to write tests for your gdscript in gdscript.
 
 ## Features
 * Godot 3.0 and 3.1 compatible (There are some minor issues with 3.1 though, [check them out here](https://github.com/bitwes/Gut/wiki/Godot-3.1-Issues).)
 * [Simple install via the Asset Library.](https://github.com/bitwes/Gut/wiki/Install)
+* [A plethora of asserts and utility methods to help make your tests simple and concise.](https://github.com/bitwes/Gut/wiki/Methods)
+* [Support for Inner Test Classes to give your tests some extra context and maintainability.](https://github.com/bitwes/Gut/wiki/Inner-Test-Classes)
 * [Doubling](https://github.com/bitwes/Gut/wiki/Doubles)
 * [Stubbing](https://github.com/bitwes/Gut/wiki/Stubbing)
 * [Spying](https://github.com/bitwes/Gut/wiki/Spies)
-* [A plethora of asserts and utility methods to help make your tests simple and concise.](https://github.com/bitwes/Gut/wiki/Methods)
 * [Export tests with your project and run them on any platform Godot supports.](https://github.com/bitwes/Gut/wiki/Exporting-Tests)
 * [Command Line Interface (CLI)](https://github.com/bitwes/Gut/wiki/Command-Line)
-* [Support for Inner Test Classes to give your tests some extra context and maintainability.](https://github.com/bitwes/Gut/wiki/Inner-Test-Classes)
 * [Integration testing made easier with `yield`s](https://github.com/bitwes/Gut/wiki/Yielding)
 
 More info can be found in the [wiki](https://github.com/bitwes/Gut/wiki).
 
-## Upgrading to 6.7.0 from any 6.x version
+## Upgrading to 6.8.0 from any 6.6.x version
 * It is not required, but you should remove the existing Gut node for any scenes you have that use it and then re-add it and re-configure it.  Re-adding will get rid of the caution symbol next to the control (this is due to changes in inheritance, Gut changed from a `WindowDialog` to a `Control`)
 * For the command line, note that the `log` option in the `.gutconfig.json` file has changed to `log_level` for consistency.
 
@@ -28,18 +28,13 @@ More info can be found in the [wiki](https://github.com/bitwes/Gut/wiki).
 Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`
 
 # Getting Started
-Here's a short setup tutorial provided by Rainware https://www.youtube.com/watch?v=vBbqlfmcAlc
 
-TDD and P O N G Episode 1
-
-https://www.youtube.com/watch?v=nF2gPF69Dc4&t=3s
-
-TDD and P O N G Episode 2
-
-https://www.youtube.com/watch?v=rNN0Xw1R_1E&t=2s
-
-
-Here's a couple more [wiki](https://github.com/bitwes/Gut/wiki) links to get you started.
+## [Wiki](https://github.com/bitwes/Gut/wiki)
 * [Install](https://github.com/bitwes/Gut/wiki/Install)
 * [Creating Tests](https://github.com/bitwes/Gut/wiki/Creating-Tests)
 * [Methods](https://github.com/bitwes/Gut/wiki/Methods)
+
+## [Tutorials](https://github.com/bitwes/Gut/wiki/Methods)
+* [Here's a short setup tutorial provided by Rainware](https://www.youtube.com/watch?v=vBbqlfmcAlc)
+* [TDD and P O N G Episode 1](https://www.youtube.com/watch?v=nF2gPF69Dc4&t=3s)
+* [TDD and P O N G Episode 2](https://www.youtube.com/watch?v=rNN0Xw1R_1E&t=2s)

--- a/addons/gut/GutScene.gd
+++ b/addons/gut/GutScene.gd
@@ -35,7 +35,9 @@ var _mouse = {
 	in_handle = false
 }
 var _is_running = false
-var _time = 0
+var _start_time = 0.0
+var _time = 0.0
+
 const DEFAULT_TITLE = 'Gut: The Godot Unit Testing tool.'
 var _utils = load('res://addons/gut/utils.gd').new()
 var _text_box_blocker_enabled = true
@@ -62,7 +64,7 @@ func _ready():
 
 func _process(delta):
 	if(_is_running):
-		_time += delta
+		_time = OS.get_unix_time() - _start_time
 		var disp_time = round(_time * 100)/100
 		$TitleBar/Time.set_text(str(disp_time))
 
@@ -211,7 +213,8 @@ func _on_Maximize_pressed():
 # ####################
 func _run_mode(is_running=true):
 	if(is_running):
-		_time = 0
+		_start_time = OS.get_unix_time()
+		_time = _start_time
 		_summary.failing.set_text("0")
 		_summary.passing.set_text("0")
 	_is_running = is_running
@@ -342,3 +345,4 @@ func maximize():
 		var vp_size_offset = get_viewport().size
 		rect_size = vp_size_offset / get_scale()
 		set_position(Vector2(0, 0))
+

--- a/addons/gut/GutScene.tscn
+++ b/addons/gut/GutScene.tscn
@@ -3,567 +3,197 @@
 [ext_resource path="res://addons/gut/GutScene.gd" type="Script" id=1]
 
 [sub_resource type="StyleBoxFlat" id=1]
-
-content_margin_left = -1.0
-content_margin_right = -1.0
-content_margin_top = -1.0
-content_margin_bottom = -1.0
 bg_color = Color( 0.193863, 0.205501, 0.214844, 1 )
-draw_center = true
-border_width_left = 0
-border_width_top = 0
-border_width_right = 0
-border_width_bottom = 0
-border_color = Color( 0.8, 0.8, 0.8, 1 )
-border_blend = false
 corner_radius_top_left = 20
 corner_radius_top_right = 20
-corner_radius_bottom_right = 0
-corner_radius_bottom_left = 0
-corner_detail = 8
-expand_margin_left = 0.0
-expand_margin_right = 0.0
-expand_margin_top = 0.0
-expand_margin_bottom = 0.0
-shadow_color = Color( 0, 0, 0, 0.6 )
-shadow_size = 0
-anti_aliasing = true
-anti_aliasing_size = 1
-_sections_unfolded = [ "Corner Radius" ]
 
 [sub_resource type="StyleBoxFlat" id=2]
-
-content_margin_left = -1.0
-content_margin_right = -1.0
-content_margin_top = -1.0
-content_margin_bottom = -1.0
 bg_color = Color( 1, 1, 1, 1 )
-draw_center = true
-border_width_left = 0
-border_width_top = 0
-border_width_right = 0
-border_width_bottom = 0
 border_color = Color( 0, 0, 0, 1 )
-border_blend = false
 corner_radius_top_left = 5
 corner_radius_top_right = 5
-corner_radius_bottom_right = 0
-corner_radius_bottom_left = 0
-corner_detail = 8
-expand_margin_left = 0.0
-expand_margin_right = 0.0
-expand_margin_top = 0.0
-expand_margin_bottom = 0.0
-shadow_color = Color( 0, 0, 0, 0.6 )
-shadow_size = 0
-anti_aliasing = true
-anti_aliasing_size = 1
-_sections_unfolded = [ "Border", "Corner Radius" ]
 
 [sub_resource type="Theme" id=3]
-
 resource_local_to_scene = true
 Panel/styles/panel = SubResource( 2 )
 Panel/styles/panelf = null
 Panel/styles/panelnc = null
-_sections_unfolded = [ "Panel", "Panel/colors", "Panel/styles", "Resource" ]
 
-[node name="Gut" type="Panel" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Gut" type="Panel"]
 margin_right = 740.0
 margin_bottom = 320.0
 rect_min_size = Vector2( 740, 250 )
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 custom_styles/panel = SubResource( 1 )
 script = ExtResource( 1 )
-_sections_unfolded = [ "Theme", "Transform", "Z Index", "custom_styles" ]
 
-[node name="TitleBar" type="Panel" parent="." index="0"]
-
-editor/display_folded = true
-anchor_left = 0.0
-anchor_top = 0.0
+[node name="TitleBar" type="Panel" parent="."]
 anchor_right = 1.0
-anchor_bottom = 0.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 theme = SubResource( 3 )
-_sections_unfolded = [ "Rect", "Theme" ]
 
-[node name="Title" type="Label" parent="TitleBar" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
+[node name="Title" type="Label" parent="TitleBar"]
 anchor_right = 1.0
-anchor_bottom = 0.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "Gut"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-_sections_unfolded = [ "Anchor", "custom_colors", "custom_fonts" ]
 
-[node name="Time" type="Label" parent="TitleBar" index="1"]
-
+[node name="Time" type="Label" parent="TitleBar"]
 anchor_left = 1.0
-anchor_top = 0.0
 anchor_right = 1.0
-anchor_bottom = 0.0
 margin_left = -114.0
 margin_right = -53.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "9999.99"
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-_sections_unfolded = [ "Anchor", "custom_colors" ]
 
-[node name="Maximize" type="Button" parent="TitleBar" index="2"]
-
+[node name="Maximize" type="Button" parent="TitleBar"]
 anchor_left = 1.0
-anchor_top = 0.0
 anchor_right = 1.0
-anchor_bottom = 0.0
 margin_left = -30.0
 margin_top = 10.0
 margin_right = -6.0
 margin_bottom = 30.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 custom_colors/font_color = Color( 0, 0, 0, 1 )
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "M"
 flat = true
-align = 1
-_sections_unfolded = [ "Anchor", "custom_colors" ]
 
-[node name="ScriptProgress" type="ProgressBar" parent="." index="1"]
-
+[node name="ScriptProgress" type="ProgressBar" parent="."]
 editor/display_folded = true
-anchor_left = 0.0
 anchor_top = 1.0
-anchor_right = 0.0
 anchor_bottom = 1.0
 margin_left = 70.0
 margin_top = -100.0
 margin_right = 180.0
 margin_bottom = -70.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 0
-min_value = 0.0
-max_value = 100.0
 step = 1.0
-page = 0.0
-value = 0.0
-exp_edit = false
-rounded = false
-percent_visible = true
 
-[node name="Label" type="Label" parent="ScriptProgress" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Label" type="Label" parent="ScriptProgress"]
 margin_left = -70.0
 margin_right = -10.0
 margin_bottom = 24.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 text = "Script"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
 
-[node name="TestProgress" type="ProgressBar" parent="." index="2"]
-
+[node name="TestProgress" type="ProgressBar" parent="."]
 editor/display_folded = true
-anchor_left = 0.0
 anchor_top = 1.0
-anchor_right = 0.0
 anchor_bottom = 1.0
 margin_left = 70.0
 margin_top = -70.0
 margin_right = 180.0
 margin_bottom = -40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 0
-min_value = 0.0
-max_value = 100.0
 step = 1.0
-page = 0.0
-value = 0.0
-exp_edit = false
-rounded = false
-percent_visible = true
 
-[node name="Label" type="Label" parent="TestProgress" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Label" type="Label" parent="TestProgress"]
 margin_left = -70.0
 margin_right = -10.0
 margin_bottom = 24.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 text = "Tests"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
 
-[node name="TextDisplay" type="Panel" parent="." index="3"]
-
+[node name="TextDisplay" type="Panel" parent="."]
 editor/display_folded = true
-anchor_left = 0.0
-anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_top = 40.0
 margin_bottom = -107.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Anchor", "Grow Direction", "Visibility" ]
 __meta__ = {
 "_edit_group_": true
 }
 
-[node name="RichTextLabel" type="TextEdit" parent="TextDisplay" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
+[node name="RichTextLabel" type="TextEdit" parent="TextDisplay"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
 mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-text = ""
 readonly = true
-highlight_current_line = false
 syntax_highlighting = true
-show_line_numbers = false
-highlight_all_occurrences = false
-override_selected_font_color = false
-context_menu_enabled = true
 smooth_scrolling = true
-v_scroll_speed = 80.0
-hiding_enabled = 0
-wrap_lines = false
-caret_block_mode = false
-caret_blink = false
-caret_blink_speed = 0.65
-caret_moving_by_right_click = true
-_sections_unfolded = [ "Anchor", "Caret", "Grow Direction", "Margin", "Visibility", "custom_colors" ]
 
-[node name="FocusBlocker" type="Panel" parent="TextDisplay" index="1"]
-
+[node name="FocusBlocker" type="Panel" parent="TextDisplay"]
 self_modulate = Color( 1, 1, 1, 0 )
-anchor_left = 0.0
-anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_right = -10.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Anchor", "Visibility" ]
 
-[node name="Navigation" type="Panel" parent="." index="4"]
-
+[node name="Navigation" type="Panel" parent="."]
 editor/display_folded = true
 self_modulate = Color( 1, 1, 1, 0 )
-anchor_left = 0.0
 anchor_top = 1.0
-anchor_right = 0.0
 anchor_bottom = 1.0
 margin_left = 220.0
 margin_top = -100.0
 margin_right = 580.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Visibility" ]
 
-[node name="Previous" type="Button" parent="Navigation" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Previous" type="Button" parent="Navigation"]
 margin_left = -30.0
 margin_right = 50.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "<"
-flat = false
-align = 1
 
-[node name="Next" type="Button" parent="Navigation" index="1"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Next" type="Button" parent="Navigation"]
 margin_left = 230.0
 margin_right = 310.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = ">"
-flat = false
-align = 1
 
-[node name="Run" type="Button" parent="Navigation" index="2"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Run" type="Button" parent="Navigation"]
 margin_left = 60.0
 margin_right = 220.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "Run"
-flat = false
-align = 1
 
-[node name="CurrentScript" type="Button" parent="Navigation" index="3"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="CurrentScript" type="Button" parent="Navigation"]
 margin_left = -30.0
 margin_top = 50.0
 margin_right = 310.0
 margin_bottom = 90.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "res://test/unit/test_gut.gd"
-flat = false
 clip_text = true
-align = 1
 
-[node name="ShowScripts" type="Button" parent="Navigation" index="4"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="ShowScripts" type="Button" parent="Navigation"]
 margin_left = 320.0
 margin_top = 50.0
 margin_right = 360.0
 margin_bottom = 90.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "..."
-flat = false
-align = 1
 
-[node name="LogLevelSlider" type="HSlider" parent="." index="5"]
-
+[node name="LogLevelSlider" type="HSlider" parent="."]
 editor/display_folded = true
-anchor_left = 0.0
 anchor_top = 1.0
-anchor_right = 0.0
 anchor_bottom = 1.0
 margin_left = 80.0
 margin_top = -40.0
 margin_right = 130.0
 margin_bottom = -20.0
 rect_scale = Vector2( 2, 2 )
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 0
-min_value = 0.0
 max_value = 2.0
-step = 1.0
-page = 0.0
-value = 0.0
-exp_edit = false
-rounded = false
-editable = true
 tick_count = 3
 ticks_on_borders = true
-focus_mode = 2
-_sections_unfolded = [ "Rect" ]
 
-[node name="Label" type="Label" parent="LogLevelSlider" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Label" type="Label" parent="LogLevelSlider"]
 margin_left = -35.0
 margin_top = 5.0
 margin_right = 25.0
 margin_bottom = 25.0
 rect_scale = Vector2( 0.5, 0.5 )
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 text = "Log Level"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-_sections_unfolded = [ "Rect" ]
 
-[node name="ScriptsList" type="ItemList" parent="." index="6"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
+[node name="ScriptsList" type="ItemList" parent="."]
 anchor_bottom = 1.0
 margin_left = 180.0
 margin_top = 40.0
 margin_right = 620.0
 margin_bottom = -108.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = true
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-items = [  ]
-select_mode = 0
 allow_reselect = true
-icon_mode = 1
-fixed_icon_size = Vector2( 0, 0 )
-_sections_unfolded = [ "Anchor", "Columns", "Grow Direction", "Icon", "Margin", "Mouse", "Rect", "Size Flags", "Theme", "Visibility", "custom_colors", "custom_constants" ]
 
-[node name="ExtraOptions" type="Panel" parent="." index="7"]
-
+[node name="ExtraOptions" type="Panel" parent="."]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -571,112 +201,40 @@ anchor_bottom = 1.0
 margin_left = -210.0
 margin_top = -246.0
 margin_bottom = -106.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 custom_styles/panel = SubResource( 1 )
-_sections_unfolded = [ "Anchor", "Visibility" ]
 
-[node name="IgnorePause" type="CheckBox" parent="ExtraOptions" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="IgnorePause" type="CheckBox" parent="ExtraOptions"]
 margin_left = 10.0
 margin_top = 10.0
 margin_right = 128.0
 margin_bottom = 34.0
 rect_scale = Vector2( 1.5, 1.5 )
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = true
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "Ignore Pauses"
-flat = false
-align = 0
-_sections_unfolded = [ "Rect" ]
 
-[node name="DisableBlocker" type="CheckBox" parent="ExtraOptions" index="1"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="DisableBlocker" type="CheckBox" parent="ExtraOptions"]
 margin_left = 10.0
 margin_top = 50.0
 margin_right = 130.0
 margin_bottom = 74.0
 rect_scale = Vector2( 1.5, 1.5 )
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = true
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "Selectable"
-flat = false
-align = 0
-_sections_unfolded = [ "Rect", "Size Flags" ]
 
-[node name="Copy" type="Button" parent="ExtraOptions" index="2"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Copy" type="Button" parent="ExtraOptions"]
 margin_left = 20.0
 margin_top = 90.0
 margin_right = 200.0
 margin_bottom = 130.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "Copy"
-flat = false
-align = 1
 
-[node name="ResizeHandle" type="Control" parent="." index="8"]
-
+[node name="ResizeHandle" type="Control" parent="."]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = -40.0
 margin_top = -40.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Anchor", "Grow Direction", "Material", "Visibility" ]
 
-[node name="Continue" type="Panel" parent="." index="9"]
-
+[node name="Continue" type="Panel" parent="."]
 self_modulate = Color( 1, 1, 1, 0 )
 anchor_left = 1.0
 anchor_top = 1.0
@@ -686,157 +244,63 @@ margin_left = -150.0
 margin_top = -100.0
 margin_right = -30.0
 margin_bottom = -10.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Anchor", "Visibility" ]
 
-[node name="Continue" type="Button" parent="Continue" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Continue" type="Button" parent="Continue"]
 margin_top = 50.0
 margin_right = 119.0
 margin_bottom = 90.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 disabled = true
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "Continue"
-flat = false
-align = 1
 
-[node name="ShowExtras" type="Button" parent="Continue" index="1"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="ShowExtras" type="Button" parent="Continue"]
 margin_left = 50.0
 margin_right = 120.0
 margin_bottom = 40.0
 rect_pivot_offset = Vector2( 35, 20 )
-rect_clip_content = false
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 toggle_mode = true
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "_"
-flat = false
-align = 1
-_sections_unfolded = [ "Rect" ]
 
-[node name="Summary" type="Node2D" parent="." index="10"]
-
+[node name="Summary" type="Node2D" parent="."]
 editor/display_folded = true
 position = Vector2( 0, 3 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Passing" type="Label" parent="Summary" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Passing" type="Label" parent="Summary"]
 margin_top = 10.0
 margin_right = 40.0
 margin_bottom = 24.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "0"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
 
-[node name="Failing" type="Label" parent="Summary" index="1"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Failing" type="Label" parent="Summary"]
 margin_left = 40.0
 margin_top = 10.0
 margin_right = 80.0
 margin_bottom = 24.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "0"
 align = 1
 valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
 
 [connection signal="mouse_entered" from="TitleBar" to="." method="_on_TitleBar_mouse_entered"]
-
 [connection signal="mouse_exited" from="TitleBar" to="." method="_on_TitleBar_mouse_exited"]
-
 [connection signal="draw" from="TitleBar/Maximize" to="." method="_on_Maximize_draw"]
-
 [connection signal="pressed" from="TitleBar/Maximize" to="." method="_on_Maximize_pressed"]
-
 [connection signal="gui_input" from="TextDisplay/RichTextLabel" to="." method="_on_RichTextLabel_gui_input"]
-
 [connection signal="gui_input" from="TextDisplay/FocusBlocker" to="." method="_on_FocusBlocker_gui_input"]
-
 [connection signal="pressed" from="Navigation/Previous" to="." method="_on_Previous_pressed"]
-
 [connection signal="pressed" from="Navigation/Next" to="." method="_on_Next_pressed"]
-
 [connection signal="pressed" from="Navigation/Run" to="." method="_on_Run_pressed"]
-
 [connection signal="pressed" from="Navigation/CurrentScript" to="." method="_on_CurrentScript_pressed"]
-
 [connection signal="pressed" from="Navigation/ShowScripts" to="." method="_on_ShowScripts_pressed"]
-
 [connection signal="value_changed" from="LogLevelSlider" to="." method="_on_LogLevelSlider_value_changed"]
-
 [connection signal="item_selected" from="ScriptsList" to="." method="_on_ScriptsList_item_selected"]
-
 [connection signal="pressed" from="ExtraOptions/IgnorePause" to="." method="_on_IgnorePause_pressed"]
-
 [connection signal="toggled" from="ExtraOptions/DisableBlocker" to="." method="_on_DisableBlocker_toggled"]
-
 [connection signal="pressed" from="ExtraOptions/Copy" to="." method="_on_Copy_pressed"]
-
 [connection signal="mouse_entered" from="ResizeHandle" to="." method="_on_ResizeHandle_mouse_entered"]
-
 [connection signal="mouse_exited" from="ResizeHandle" to="." method="_on_ResizeHandle_mouse_exited"]
-
 [connection signal="pressed" from="Continue/Continue" to="." method="_on_Continue_pressed"]
-
 [connection signal="draw" from="Continue/ShowExtras" to="." method="_on_ShowExtras_draw"]
-
 [connection signal="toggled" from="Continue/ShowExtras" to="." method="_on_ShowExtras_toggled"]
-
-

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -120,7 +120,7 @@ var _output_dir = null
 var _double_count = 0 # used in making files names unique
 var _use_unique_names = true
 var _spy = null
-var  _ignored_methods = {}
+var  _ignored_methods = _utils.OneToMany.new()
 
 var _stubber = _utils.Stubber.new()
 var _lgr = _utils.get_logger()
@@ -218,7 +218,7 @@ func _get_methods(object_info):
 	for i in range(methods.size()):
 		# 65 is a magic number for methods in script, though documentation
 		# says 64.  This picks up local overloads of base class methods too.
-		if(methods[i].flags == 65):
+		if(methods[i].flags == 65 and !_ignored_methods.has(object_info.get_path(), methods[i]['name'])):
 			script_methods.add_local_method(methods[i])
 
 
@@ -227,7 +227,7 @@ func _get_methods(object_info):
 		for i in range(methods.size()):
 			# 65 is a magic number for methods in script, though documentation
 			# says 64.  This picks up local overloads of base class methods too.
-			if(methods[i].flags != 65):
+			if(methods[i].flags != 65 and !_ignored_methods.has(object_info.get_path(), methods[i]['name'])):
 				script_methods.add_built_in_method(methods[i])
 
 	return script_methods
@@ -423,7 +423,7 @@ func set_use_unique_names(should):
 	_use_unique_names = should
 
 func add_ignored_method(path, method_name):
-	pass
+	_ignored_methods.add(path, method_name)
 
 func get_ignored_methods():
-	return []
+	return _ignored_methods

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -114,12 +114,14 @@ class ObjectInfo:
 # ------------------------------------------------------------------------------
 # START Doubler
 # ------------------------------------------------------------------------------
+var _utils = load('res://addons/gut/utils.gd').new()
+
 var _output_dir = null
 var _double_count = 0 # used in making files names unique
 var _use_unique_names = true
 var _spy = null
+var  _ignored_methods = {}
 
-var _utils = load('res://addons/gut/utils.gd').new()
 var _stubber = _utils.Stubber.new()
 var _lgr = _utils.get_logger()
 var _method_maker = _utils.MethodMaker.new()
@@ -419,3 +421,9 @@ func delete_output_directory():
 # weird, hard to track down problems.
 func set_use_unique_names(should):
 	_use_unique_names = should
+
+func add_ignored_method(path, method_name):
+	pass
+
+func get_ignored_methods():
+	return []

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -320,7 +320,7 @@ func _get_temp_path(object_info):
 	var extension = null
 	if(object_info.is_native()):
 		file_name = object_info.get_native_class_name()
-		extension = '.gd'
+		extension = 'gd'
 	else:
 		file_name = object_info.get_path().get_file().get_basename()
 		extension = object_info.get_path().get_extension()
@@ -436,11 +436,15 @@ func partial_double_inner(path, subpath, strategy=_strategy):
 func double_inner(path, subpath, strategy=_strategy):
 	return _double_inner(path, subpath, false, strategy)
 
-func double_gdnative(native_class, strategy=_strategy):
-	return _double_gdnative(native_class, false, strategy)
+# must always use FULL strategy since this is a native class and you won't get
+# any methods if you don't use FULL
+func double_gdnative(native_class):
+	return _double_gdnative(native_class, false, _utils.DOUBLE_STRATEGY.FULL)
 
-func partial_double_gdnative(native_class, strategy=_strategy):
-	return _double_gdnative(native_class, true, strategy)
+# must always use FULL strategy since this is a native class and you won't get
+# any methods if you don't use FULL
+func partial_double_gdnative(native_class):
+	return _double_gdnative(native_class, true, _utils.DOUBLE_STRATEGY.FULL)
 
 func clear_output_directory():
 	var did = false

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -271,7 +271,10 @@ func _on_log_level_changed(value):
 # ------------------------------------------------------------------------------
 func _yielding_callback(from_obj=false):
 	if(_yielding_to.obj):
-		_yielding_to.obj.disconnect(_yielding_to.signal_name, self, '_yielding_callback')
+		_yielding_to.obj.call_deferred(
+			"disconnect",
+			_yielding_to.signal_name, self,
+			'_yielding_callback')
 		_yielding_to.obj = null
 		_yielding_to.signal_name = ''
 

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -28,12 +28,12 @@
 ################################################################################
 # View readme for usage details.
 #
-# Version 6.7.0
+# Version 6.8.0
 ################################################################################
 #extends "res://addons/gut/gut_gui.gd"
 tool
 extends Control
-var _version = '6.7.0'
+var _version = '6.8.0'
 
 var _utils = load('res://addons/gut/utils.gd').new()
 var _lgr = _utils.get_logger()

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -33,6 +33,7 @@
 #extends "res://addons/gut/gut_gui.gd"
 tool
 extends Control
+var _version = '6.7.0'
 
 var _utils = load('res://addons/gut/utils.gd').new()
 var _lgr = _utils.get_logger()
@@ -197,6 +198,10 @@ func _ready():
 	# hide the panel that IS gut so that only the GUI is seen
 	self.self_modulate = Color(1,1,1,0)
 	show()
+	var v_info = Engine.get_version_info()
+	p(str('Godot version:  ', v_info.major,  '.',  v_info.minor,  '.',  v_info.patch))
+	p(str('GUT version:  ', get_version()))
+
 
 ################################################################################
 #
@@ -1193,3 +1198,8 @@ func get_export_path():
 # ------------------------------------------------------------------------------
 func set_export_path(export_path):
 	_export_path = export_path
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func get_version():
+	return _version

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -28,12 +28,12 @@
 ################################################################################
 # View readme for usage details.
 #
-# Version 6.8.0
+# Version 6.8.1
 ################################################################################
 #extends "res://addons/gut/gut_gui.gd"
 tool
 extends Control
-var _version = '6.8.0'
+var _version = '6.8.1'
 
 var _utils = load('res://addons/gut/utils.gd').new()
 var _lgr = _utils.get_logger()

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -331,7 +331,7 @@ func _get_summary_text():
 
 	if(_new_summary.get_totals().tests > 0):
 		to_return +=  '+++ ' + str(_new_summary.get_totals().passing) + ' passed ' + str(_new_summary.get_totals().failing) + ' failed.  ' + \
-		              "Tests finished in:  " + str(_gui.get_run_duration()) + ' +++'
+					  "Tests finished in:  " + str(_gui.get_run_duration()) + ' +++'
 		var c = Color(0, 1, 0)
 		if(_new_summary.get_totals().failing > 0):
 			c = Color(1, 0, 0)
@@ -453,8 +453,8 @@ func _end_run():
 # ------------------------------------------------------------------------------
 func _is_function_state(script_result):
 	return script_result != null and \
-	       typeof(script_result) == TYPE_OBJECT and \
-	       script_result is GDScriptFunctionState
+		   typeof(script_result) == TYPE_OBJECT and \
+		   script_result is GDScriptFunctionState
 
 # ------------------------------------------------------------------------------
 # Print out the heading for a new script
@@ -481,7 +481,7 @@ func _print_script_heading(script):
 # ------------------------------------------------------------------------------
 func _should_yield_now():
 	var should = _yield_between.should and \
-	             _yield_between.tests_since_last_yield == _yield_between.after_x_tests
+				 _yield_between.tests_since_last_yield == _yield_between.after_x_tests
 	if(should):
 		_yield_between.tests_since_last_yield = 0
 	else:
@@ -585,8 +585,15 @@ func _test_the_scripts(indexes=[]):
 	var is_valid = _init_run()
 	if(!is_valid):
 		_lgr.error('Something went wrong and the run was aborted.')
+		emit_signal(SIGNAL_TESTS_FINISHED)
 		return
+
 	_run_hook_script(_pre_run_script_instance)
+	if(_pre_run_script_instance!= null and _pre_run_script_instance.should_abort()):
+		_lgr.error('pre-run abort')
+		emit_signal(SIGNAL_TESTS_FINISHED)
+		return
+
 	_gui.run_mode()
 
 	var indexes_to_run = []
@@ -1296,17 +1303,32 @@ func set_export_path(export_path):
 func get_version():
 	return _version
 
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 func get_pre_run_script():
 	return _pre_run_script
 
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 func set_pre_run_script(pre_run_script):
 	_pre_run_script = pre_run_script
 
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 func get_post_run_script():
 	return _post_run_script
 
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 func set_post_run_script(post_run_script):
 	_post_run_script = post_run_script
 
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 func get_pre_run_script_instance():
 	return _pre_run_script_instance
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func get_post_run_script_instance():
+	return _post_run_script_instance

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -617,6 +617,7 @@ func _test_the_scripts(indexes=[]):
 					_gui.get_text_box().add_keyword_color(_current_test.name, Color(1, 0, 0))
 
 				_gui.set_progress_test_value(i + 1)
+				_doubler.get_ignored_methods().clear()
 
 		# call both post-all-tests methods until postrun_teardown is removed.
 		if(_does_class_name_match(_inner_class_name, the_script.inner_class_name)):

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -37,7 +37,7 @@
 # See the readme for a list of options and examples.  You can also use the -gh
 # option to get more information about how to use the command line interface.
 #
-# Version 6.7.0
+# Version 6.8.0
 ################################################################################
 extends SceneTree
 

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -37,7 +37,7 @@
 # See the readme for a list of options and examples.  You can also use the -gh
 # option to get more information about how to use the command line interface.
 #
-# Version 6.8.0
+# Version 6.8.1
 ################################################################################
 extends SceneTree
 

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -43,6 +43,8 @@ extends SceneTree
 
 
 var Optparse = load('res://addons/gut/optparse.gd')
+var Gut = load('res://addons/gut/gut.gd')
+
 #-------------------------------------------------------------------------------
 # Helper class to resolve the various different places where an option can
 # be set.  Using the get_value method will enforce the order of precedence of:
@@ -234,7 +236,7 @@ func load_options_from_config_file(file_path, into):
 # Apply all the options specified to _tester.  This is where the rubber meets
 # the road.
 func apply_options(opts):
-	_tester = load('res://addons/gut/gut.gd').new()
+	_tester = Gut.new()
 	get_root().add_child(_tester)
 	_tester.connect('tests_finished', self, '_on_tests_finished', [opts.should_exit, opts.should_exit_on_success])
 	_tester.set_yield_between_tests(true)
@@ -311,6 +313,10 @@ func _init():
 		if(!all_options_valid):
 			quit()
 		elif(o.get_value('-gh')):
+			var v_info = Engine.get_version_info()
+			print(str('Godot version:  ', v_info.major,  '.',  v_info.minor,  '.',  v_info.patch))
+			print(str('GUT version:  ', Gut.new().get_version()))
+
 			o.print_help()
 			quit()
 		elif(o.get_value('-gpo')):

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -345,6 +345,11 @@ func _on_tests_finished(should_exit, should_exit_on_success):
 	if(_tester.get_fail_count()):
 		OS.exit_code = 1
 
+	# Overwrite the exit code with the post_script
+	var post_inst = _tester.get_post_run_script_instance()
+	if(post_inst != null and post_inst.get_exit_code() != null):
+		OS.exit_code = post_inst.get_exit_code()
+
 	if(should_exit or (should_exit_on_success and _tester.get_fail_count() == 0)):
 		quit()
 	else:

--- a/addons/gut/hook_script.gd
+++ b/addons/gut/hook_script.gd
@@ -8,7 +8,28 @@
 # script is instantiated.
 var gut  = null
 
+# the exit code to be used by gut_cmdln.  See set method.
+var _exit_code = null
+
+var _should_abort =  false
 # Virtual method that will be called by GUT after instantiating
 # this script.
 func run():
 	pass
+
+# Set the exit code when running from the command line.  If not set then the
+# default exit code will be returned (0 when no tests fail, 1 when any tests
+# fail).
+func set_exit_code(code):
+	_exit_code  = code
+
+func get_exit_code():
+	return _exit_code
+
+# Usable by pre-run script to cause the run to end AFTER the run() method
+# finishes.  post-run script will not be ran.
+func abort():
+	_should_abort = true
+
+func should_abort():
+	return _should_abort

--- a/addons/gut/one_to_many.gd
+++ b/addons/gut/one_to_many.gd
@@ -30,3 +30,9 @@ func has(one, many_item):
 	if(_items.has(one)):
 		to_return = _items[one].has(many_item)
 	return to_return
+
+func to_s():
+	var to_return = ''
+	for key in _items:
+		to_return += str(key, ":  ", _items[key], "\n")
+	return to_return

--- a/addons/gut/one_to_many.gd
+++ b/addons/gut/one_to_many.gd
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------------------
+# This datastructure represents a simple one-to-many relationship.  It manages
+# a dictionary of value/array pairs.  It ignores duplicates of both the "one"
+# and the "many".
+# ------------------------------------------------------------------------------
+var _items = {}
+
+# return the size of _items or the size of an element in _items if "one" was
+# specified.
+func size(one=null):
+	var to_return = 0
+	if(one == null):
+		to_return = _items.size()
+	elif(_items.has(one)):
+		to_return = _items[one].size()
+	return to_return
+
+# Add an element to "one" if it does not already exist
+func add(one, many_item):
+	if(_items.has(one) and !_items[one].has(many_item)):
+		_items[one].append(many_item)
+	else:
+		_items[one] = [many_item]
+
+func clear():
+	_items.clear()
+
+func has(one, many_item):
+	var to_return = false
+	if(_items.has(one)):
+		to_return = _items[one].has(many_item)
+	return to_return

--- a/addons/gut/optparse.gd
+++ b/addons/gut/optparse.gd
@@ -46,11 +46,18 @@
 #-------------------------------------------------------------------------------
 class CmdLineParser:
 	var _used_options = []
+	# an array of arrays.  Each element in this array will contain an option
+	# name and if that option contains a value then it will have a sedond
+	# element.  For example:
+	# 	[[-gselect, test.gd], [-gexit]]
 	var _opts = []
 
 	func _init():
 		for i in range(OS.get_cmdline_args().size()):
-			_opts.append(OS.get_cmdline_args()[i])
+			var opt_val = OS.get_cmdline_args()[i].split('=')
+
+			_opts.append(opt_val)
+			print(opt_val)
 
 	# Parse out multiple comma delimited values from a command line
 	# option.  Values are separated from option name with "=" and
@@ -63,10 +70,8 @@ class CmdLineParser:
 	# Parse out the value of an option.  Values are separated from
 	# the option name with "="
 	func _parse_option_value(full_option):
-		var split = full_option.split('=')
-
-		if(split.size() > 1):
-			return split[1]
+		if(full_option.size() > 1):
+			return full_option[1]
 		else:
 			return null
 
@@ -77,7 +82,7 @@ class CmdLineParser:
 		var idx = 0
 
 		while(idx < _opts.size() and !found):
-			if(_opts[idx].find(name) == 0):
+			if(_opts[idx][0] == name):
 				found = true
 			else:
 				idx += 1
@@ -123,7 +128,7 @@ class CmdLineParser:
 	func get_unused_options():
 		var to_return = []
 		for i in range(_opts.size()):
-			to_return.append(_opts[i].split('=')[0])
+			to_return.append(_opts[i][0])
 
 		var script_option = to_return.find('-s')
 		if script_option != -1:

--- a/addons/gut/optparse.gd
+++ b/addons/gut/optparse.gd
@@ -37,7 +37,7 @@
 # See the readme for a list of options and examples.  You can also use the -gh
 # option to get more information about how to use the command line interface.
 #
-# Version 6.8.0
+# Version 6.8.1
 ################################################################################
 
 #-------------------------------------------------------------------------------

--- a/addons/gut/optparse.gd
+++ b/addons/gut/optparse.gd
@@ -37,7 +37,7 @@
 # See the readme for a list of options and examples.  You can also use the -gh
 # option to get more information about how to use the command line interface.
 #
-# Version 6.7.0
+# Version 6.8.0
 ################################################################################
 
 #-------------------------------------------------------------------------------

--- a/addons/gut/optparse.gd
+++ b/addons/gut/optparse.gd
@@ -55,9 +55,7 @@ class CmdLineParser:
 	func _init():
 		for i in range(OS.get_cmdline_args().size()):
 			var opt_val = OS.get_cmdline_args()[i].split('=')
-
 			_opts.append(opt_val)
-			print(opt_val)
 
 	# Parse out multiple comma delimited values from a command line
 	# option.  Values are separated from option name with "=" and

--- a/addons/gut/plugin.cfg
+++ b/addons/gut/plugin.cfg
@@ -3,5 +3,5 @@
 name="Gut"
 description="Unit Testing tool for Godot."
 author="Butch Wesley"
-version="6.7.0"
+version="6.8.0"
 script="gut_plugin.gd"

--- a/addons/gut/plugin.cfg
+++ b/addons/gut/plugin.cfg
@@ -3,5 +3,5 @@
 name="Gut"
 description="Unit Testing tool for Godot."
 author="Butch Wesley"
-version="6.8.0"
+version="6.8.1"
 script="gut_plugin.gd"

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -36,6 +36,8 @@ func _make_key_from_variant(obj, subpath=null):
 		TYPE_OBJECT:
 			if(_is_instance(obj)):
 				to_return = _make_key_from_metadata(obj)
+			elif(_utils.is_native_class(obj)):
+				to_return = _utils.get_native_class_name(obj)
 			else:
 				to_return = obj.resource_path
 	return to_return

--- a/addons/gut/summary.gd
+++ b/addons/gut/summary.gd
@@ -1,4 +1,6 @@
 # ------------------------------------------------------------------------------
+# Contains all the results of a single test.  Allows for multiple asserts results
+# and pending calls.
 # ------------------------------------------------------------------------------
 class Test:
 	var pass_texts = []
@@ -15,9 +17,12 @@ class Test:
 		return to_return
 
 # ------------------------------------------------------------------------------
+# Contains all the results for a single test-script/inner class.  Persists the
+# names of the tests and results and the order in which  the tests were run.
 # ------------------------------------------------------------------------------
 class TestScript:
 	var name = 'NOT_SET'
+	#
 	var _tests = {}
 	var _test_order = []
 
@@ -61,8 +66,11 @@ class TestScript:
 		t.pending_texts.append(reason)
 
 # ------------------------------------------------------------------------------
-# Main class
-# ------------------------------------------------------------------------------
+# Summary Class
+#
+# This class holds the results of all the test scripts and Inner Classes that
+# were run.
+# -------------------------------------------d-----------------------------------
 var _scripts = []
 
 func add_script(name):

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -815,7 +815,7 @@ func assert_freed(obj, title):
 # -----------------------------------------------------------------------------
 func assert_not_freed(obj, title):
 	assert_true(is_instance_valid(obj), "Object %s is not freed" % title)
-	
+
 # ------------------------------------------------------------------------------
 # Mark the current test as pending.
 # ------------------------------------------------------------------------------
@@ -964,6 +964,22 @@ func double_script(path, strategy=null):
 func double_inner(path, subpath, strategy=null):
 	var override_strat = _utils.nvl(strategy, gut.get_doubler().get_strategy())
 	return gut.get_doubler().double_inner(path, subpath, override_strat)
+
+# ------------------------------------------------------------------------------
+# Add a method that the doubler will ignore.  You can pass this the path to a
+# script or scene or a loaded script or scene.  When running tests, these
+# ignores are cleared after every test.
+# ------------------------------------------------------------------------------
+func ignore_method_when_doubling(thing, method_name):
+	var double_info = DoubleInfo.new(thing)
+	var path = double_info.path
+
+	if(double_info.extension == 'tscn'):
+		var inst = thing.instance()
+		if(inst.get_script()):
+			path = inst.get_script().get_path()
+
+	gut.get_doubler().add_ignored_method(path, method_name)
 
 # ------------------------------------------------------------------------------
 # Stub something.

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -48,6 +48,8 @@ class DoubleInfo:
 	var strategy
 	var make_partial
 	var extension
+	var _utils = load('res://addons/gut/utils.gd').new()
+	var _is_native = false
 
 	# Flexible init method.  p2 can be subpath or stategy unless p3 is
 	# specified, then p2 must be subpath and p3 is strategy.
@@ -65,17 +67,26 @@ class DoubleInfo:
 			subpath = p2
 
 		if(typeof(thing) == TYPE_OBJECT):
-			path = thing.resource_path
+			if(_utils.is_native_class(thing)):
+				path = thing
+				_is_native = true
+				extension = 'native_class_not_used'
+			else:
+				path = thing.resource_path
 		else:
 			path = thing
 
-		extension = path.get_extension()
+		if(!_is_native):
+			extension = path.get_extension()
 
 	func is_scene():
 		return extension == 'tscn'
 
 	func is_script():
 		return extension == 'gd'
+
+	func is_native():
+		return _is_native
 
 # ------------------------------------------------------------------------------
 # Begin test.gd
@@ -936,6 +947,13 @@ func _smart_double(double_info):
 			to_return =  gut.get_doubler().partial_double_scene(double_info.path, override_strat)
 		else:
 			to_return =  gut.get_doubler().double_scene(double_info.path, override_strat)
+
+	elif(double_info.is_native()):
+		if(double_info.make_partial):
+			to_return = gut.get_doubler().partial_double_gdnative(double_info.path)
+		else:
+			to_return = gut.get_doubler().double_gdnative(double_info.path)
+
 	elif(double_info.is_script()):
 		if(double_info.subpath == null):
 			if(double_info.make_partial):

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -37,6 +37,50 @@
 ################################################################################
 extends Node
 
+# ------------------------------------------------------------------------------
+# Helper class to hold info for objects to double.  This extracts info and has
+# some convenience methods.  This is key in being able to make the "smart double"
+# method which makes doubling much easier for the user.
+# ------------------------------------------------------------------------------
+class DoubleInfo:
+	var path
+	var subpath
+	var strategy
+	var make_partial
+	var extension
+
+	# Flexible init method.  p2 can be subpath or stategy unless p3 is
+	# specified, then p2 must be subpath and p3 is strategy.
+	#
+	# Examples:
+	#   (object_to_double)
+	#   (object_to_double, subpath)
+	#   (object_to_double, strategy)
+	#   (object_to_double, subpath, strategy)
+	func _init(thing, p2=null, p3=null):
+		strategy = p2
+
+		if(typeof(p2) == TYPE_STRING):
+			strategy = p3
+			subpath = p2
+
+		if(typeof(thing) == TYPE_OBJECT):
+			path = thing.resource_path
+		else:
+			path = thing
+
+		extension = path.get_extension()
+
+	func is_scene():
+		return extension == 'tscn'
+
+	func is_script():
+		return extension == 'gd'
+
+# ------------------------------------------------------------------------------
+# Begin test.gd
+# ------------------------------------------------------------------------------
+
 # constant for signal when calling yield_for
 const YIELD = 'timeout'
 
@@ -105,34 +149,6 @@ var _signal_watcher = load('res://addons/gut/signal_watcher.gd').new()
 
 # Convenience copy of _utils.DOUBLE_STRATEGY
 var DOUBLE_STRATEGY = null
-
-class DoubleInfo:
-	var path
-	var subpath
-	var strategy
-	var make_partial
-	var extension
-
-	func _init(thing, p2=null, p3=null):
-		strategy = p2
-
-		if(typeof(p2) == TYPE_STRING):
-			strategy = p3
-			subpath = p2
-
-		if(typeof(thing) == TYPE_OBJECT):
-			path = thing.resource_path
-		else:
-			path = thing
-
-		extension = path.get_extension()
-
-	func is_scene():
-		return extension == 'tscn'
-
-	func is_script():
-		return extension == 'gd'
-
 var _utils = load('res://addons/gut/utils.gd').new()
 var _lgr = _utils.get_logger()
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -127,6 +127,12 @@ class DoubleInfo:
 
 		extension = path.get_extension()
 
+	func is_scene():
+		return extension == 'tscn'
+
+	func is_script():
+		return extension == 'gd'
+
 var _utils = load('res://addons/gut/utils.gd').new()
 var _lgr = _utils.get_logger()
 
@@ -909,12 +915,12 @@ func _smart_double(double_info):
 	var override_strat = _utils.nvl(double_info.strategy, gut.get_doubler().get_strategy())
 	var to_return = null
 
-	if(double_info.extension == 'tscn'):
+	if(double_info.is_scene()):
 		if(double_info.make_partial):
 			to_return =  gut.get_doubler().partial_double_scene(double_info.path, override_strat)
 		else:
 			to_return =  gut.get_doubler().double_scene(double_info.path, override_strat)
-	elif(double_info.extension == 'gd'):
+	elif(double_info.is_script()):
 		if(double_info.subpath == null):
 			if(double_info.make_partial):
 				to_return = gut.get_doubler().partial_double(double_info.path, override_strat)
@@ -974,7 +980,7 @@ func ignore_method_when_doubling(thing, method_name):
 	var double_info = DoubleInfo.new(thing)
 	var path = double_info.path
 
-	if(double_info.extension == 'tscn'):
+	if(double_info.is_scene()):
 		var inst = thing.instance()
 		if(inst.get_script()):
 			path = inst.get_script().get_path()

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -215,10 +215,6 @@ func has_script(path):
 	return found
 
 func export_tests(path):
-	if(_utils.is_version_31()):
-		_lgr.error("Exporting and importing not supported in 3.1 yet.  There is a workaround, check the wiki.")
-		return false
-		
 	var success = true
 	var f = ConfigFile.new()
 	for i in range(scripts.size()):
@@ -230,9 +226,6 @@ func export_tests(path):
 	return success
 
 func import_tests(path):
-	if(_utils.is_version_31()):
-		_lgr.error("Exporting and importing not supported in 3.1 yet.  There is a workaround, check the wiki.")
-		return false
 	var success = false
 	var f = ConfigFile.new()
 	var result = f.load(path)

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -9,6 +9,7 @@ var Summary = load('res://addons/gut/summary.gd')
 var Test = load('res://addons/gut/test.gd')
 var TestCollector = load('res://addons/gut/test_collector.gd')
 var ThingCounter = load('res://addons/gut/thing_counter.gd')
+var OneToMany = load('res://addons/gut/one_to_many.gd')
 
 const GUT_METADATA = '__gut_metadata_'
 

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -107,3 +107,15 @@ func write_file(path, content):
 
 func is_null_or_empty(text):
 	return text == null or text == ''
+
+func get_native_class_name(thing):
+	var to_return = null
+	if(is_native_class(thing)):
+		to_return = thing.new().get_class()
+	return to_return
+
+func is_native_class(thing):
+	var it_is = false
+	if(typeof(thing) == TYPE_OBJECT):
+		it_is = str(thing).begins_with("[GDScriptNativeClass:")
+	return it_is

--- a/default_env.tres
+++ b/default_env.tres
@@ -12,4 +12,3 @@ sun_energy = 16.0
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
-

--- a/default_env.tres
+++ b/default_env.tres
@@ -12,3 +12,4 @@ sun_energy = 16.0
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
+

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -36,6 +36,7 @@ __meta__ = {
 _should_maximize = true
 _yield_between_tests = false
 _disable_strict_datatype_checks = true
+_export_path = "res://exported_tests/exported.cfg"
 _directory1 = "res://test/unit"
 _directory2 = "res://test/integration"
 _double_strategy = 1

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -33,12 +33,29 @@ script = ExtResource( 2 )
 __meta__ = {
 "_editor_icon": ExtResource( 3 )
 }
+_select_script = ""
+_tests_like = ""
+_inner_class_name = ""
+_run_on_load = false
 _should_maximize = true
+_should_print_to_console = true
+_log_level = 1
 _yield_between_tests = false
 _disable_strict_datatype_checks = true
+_test_prefix = "test_"
+_file_prefix = "test_"
+_file_extension = ".gd"
+_inner_class_prefix = "Test"
+_temp_directory = "user://gut_temp_directory"
 _export_path = "res://exported_tests.cfg"
+_include_subdirectories = false
 _directory1 = "res://test/unit"
 _directory2 = "res://test/integration"
+_directory3 = ""
+_directory4 = ""
+_directory5 = ""
+_directory6 = ""
 _double_strategy = 1
+
 [connection signal="pressed" from="RunGutTestsButton" to="." method="_on_RunGutTestsButton_pressed"]
 [connection signal="pressed" from="ExportTests" to="." method="_on_ExportTests_pressed"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -34,9 +34,8 @@ __meta__ = {
 "_editor_icon": ExtResource( 3 )
 }
 _should_maximize = true
-_yield_between_tests = false
 _disable_strict_datatype_checks = true
-_export_path = "res://exported_tests/exported.cfg"
+_export_path = "res://exported_tests.cfg"
 _directory1 = "res://test/unit"
 _directory2 = "res://test/integration"
 _double_strategy = 1

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -56,6 +56,5 @@ _directory4 = ""
 _directory5 = ""
 _directory6 = ""
 _double_strategy = 1
-
 [connection signal="pressed" from="RunGutTestsButton" to="." method="_on_RunGutTestsButton_pressed"]
 [connection signal="pressed" from="ExportTests" to="." method="_on_ExportTests_pressed"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -33,28 +33,11 @@ script = ExtResource( 2 )
 __meta__ = {
 "_editor_icon": ExtResource( 3 )
 }
-_select_script = ""
-_tests_like = ""
-_inner_class_name = ""
-_run_on_load = false
 _should_maximize = true
-_should_print_to_console = true
-_log_level = 1
 _yield_between_tests = false
 _disable_strict_datatype_checks = true
-_test_prefix = "test_"
-_file_prefix = "test_"
-_file_extension = ".gd"
-_inner_class_prefix = "Test"
-_temp_directory = "user://gut_temp_directory"
-_export_path = ""
-_include_subdirectories = false
 _directory1 = "res://test/unit"
 _directory2 = "res://test/integration"
-_directory3 = ""
-_directory4 = ""
-_directory5 = ""
-_directory6 = ""
 _double_strategy = 1
 
 [connection signal="pressed" from="RunGutTestsButton" to="." method="_on_RunGutTestsButton_pressed"]

--- a/scratch/get_info.gd
+++ b/scratch/get_info.gd
@@ -117,41 +117,6 @@ func class_db_stuff():
 	# print(ClassDB.get_class_list())
 
 func _init():
-	var obj2 = RayCast2D.new()
-	print(typeof(obj2))
-	print(RayCast2D)
-	print(str(RayCast2D))
-	print(ExtendsNode2D)
-
-	print(obj2.get_class())
-	var obj3 = ExtendsNode2D.new()
-	print(typeof(obj3))
-	print(typeof(ExtendsNode2D))
-	print(ExtendsNode2D.new().get_class())
-	#print(obj2.get_meta_list())
-	var meta = obj2.get_meta_list()
-	# for key in meta:
-	# 	print(key)
-
-	quit()
-	return
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 	# var double_me = load('res://test/resources/doubler_test_objects/double_me.gd').new()
 	# print_method_info(double_me)
 	# print("-------------\n-\n-\n-\n-------------")

--- a/scratch/get_info.gd
+++ b/scratch/get_info.gd
@@ -117,6 +117,40 @@ func class_db_stuff():
 	# print(ClassDB.get_class_list())
 
 func _init():
+	var obj2 = RayCast2D.new()
+	print(typeof(obj2))
+	print(RayCast2D)
+	print(str(RayCast2D))
+	print(ExtendsNode2D)
+
+	print(obj2.get_class())
+	var obj3 = ExtendsNode2D.new()
+	print(typeof(obj3))
+	print(typeof(ExtendsNode2D))
+	print(ExtendsNode2D.new().get_class())
+	#print(obj2.get_meta_list())
+	var meta = obj2.get_meta_list()
+	# for key in meta:
+	# 	print(key)
+
+	quit()
+	return
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 	# var double_me = load('res://test/resources/doubler_test_objects/double_me.gd').new()
 	# print_method_info(double_me)
@@ -125,7 +159,7 @@ func _init():
 	# print_methods_by_flags(methods)
 
 	#print_a_bunch_of_methods_by_flags()
-	var obj = ExtendsNode2D.new()
+	var obj = RayCast2D.new() #ExtendsNode2D.new()
 	#var obj = load('res://addons/gut/gut.gd').new()
 	#var obj = load('res://test/resources/doubler_test_objects/double_extends_window_dialog.gd').new()
 	ExtendsNode2D.set_meta('gut_ignore', 'something')

--- a/scratch/get_info.gd
+++ b/scratch/get_info.gd
@@ -15,6 +15,9 @@ const ARGS = 'args'
 class ExtendsNode2D:
 	extends Node2D
 
+	static func a_static_func():
+		return true
+
 	func my_function():
 		return 7
 
@@ -113,15 +116,17 @@ func _init():
 	# print_methods_by_flags(methods)
 
 	#print_a_bunch_of_methods_by_flags()
-	#var obj = ExtendsNode2D.new()
+	var obj = ExtendsNode2D.new()
 	#var obj = load('res://addons/gut/gut.gd').new()
-	var obj = load('res://test/resources/doubler_test_objects/double_extends_window_dialog.gd').new()
-	#print_method_info(obj)
-	print_method_info(obj)
-	var methods = obj.get_method_list()
+	#var obj = load('res://test/resources/doubler_test_objects/double_extends_window_dialog.gd').new()
 
-	for i in range(methods.size()):
-		if(methods[i][DEFAULT_ARGS].size() > 0):
-			pass#print(get_defaults_and_types(methods[i]))
+	print_method_info(obj)
+	print(obj.get_meta_list())
+	#print_method_info(ExtendsNode2D)
+
+	var methods = obj.get_method_list()
+	# for i in range(methods.size()):
+	# 	if(methods[i][DEFAULT_ARGS].size() > 0):
+	# 		pass#print(get_defaults_and_types(methods[i]))
 
 	quit()

--- a/scratch/get_info.gd
+++ b/scratch/get_info.gd
@@ -74,6 +74,7 @@ func print_method_info(obj):
 			print(" *** here be defaults ***")
 
 		for key in methods[i]:
+
 			if(key == 'args'):
 				print('  args:')
 				for argname in range(methods[i][key].size()):
@@ -108,7 +109,15 @@ func get_defaults_and_types(method_meta):
 	return text
 
 
+func class_db_stuff():
+	print(ClassDB.class_exists('Node2D'))
+	print('category = ',  ClassDB.class_get_category('Node2D'))
+	#print(str(JSON.print(ClassDB.class_get_method_list('Node2D'), ' ')))
+	# print(ClassDB.class_get_integer_constant_list('Node2D'))
+	# print(ClassDB.get_class_list())
+
 func _init():
+
 	# var double_me = load('res://test/resources/doubler_test_objects/double_me.gd').new()
 	# print_method_info(double_me)
 	# print("-------------\n-\n-\n-\n-------------")
@@ -119,12 +128,15 @@ func _init():
 	var obj = ExtendsNode2D.new()
 	#var obj = load('res://addons/gut/gut.gd').new()
 	#var obj = load('res://test/resources/doubler_test_objects/double_extends_window_dialog.gd').new()
-
+	ExtendsNode2D.set_meta('gut_ignore', 'something')
 	print_method_info(obj)
+	#print_method_info(ExtendsNode2D)
 	print(obj.get_meta_list())
+	print(ExtendsNode2D.get_meta_list())
 	#print_method_info(ExtendsNode2D)
 
 	var methods = obj.get_method_list()
+	#print(str(JSON.print(methods, ' ')))
 	# for i in range(methods.size()):
 	# 	if(methods[i][DEFAULT_ARGS].size() > 0):
 	# 		pass#print(get_defaults_and_types(methods[i]))

--- a/test/integration/test_doubler_and_spy.gd
+++ b/test/integration/test_doubler_and_spy.gd
@@ -48,3 +48,9 @@ class TestBoth:
 		inst.add_user_signal('signal_with_params', ['a', 'b'])
 		assert_true(_spy.was_called(inst, 'add_user_signal'), 'added first signal')
 		assert_true(_spy.was_called(inst, 'add_user_signal', ['signal_with_params', ['a', 'b']]), 'second signal added')
+
+	func test_can_spy_on_native_doubles():
+		var inst  = _doubler.partial_double_gdnative(Node2D).new()
+		inst.set_position(Vector2(20, 20))
+		assert_true(_spy.was_called(inst, 'set_position'))
+		assert_true(_spy.was_called(inst, 'set_position', [Vector2(20, 20)]))

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -85,3 +85,19 @@ func test_when_stubbed_to_call_super_then_super_is_called():
 	gr.stubber.add_stub(params)
 	doubled.set_value(99)
 	assert_eq(doubled._value, 99)
+
+func test_can_stub_native_methods():
+	gr.doubler.set_stubber(gr.stubber)
+	var d_node2d = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
+	var params = _utils.StubParams.new(d_node2d, 'get_position').to_return(-1)
+	gr.stubber.add_stub(params)
+	assert_eq(d_node2d.get_position(), -1)
+
+func test_can_stub_all_Node2D_doubles():
+	gr.doubler.set_stubber(gr.stubber)
+	var d_node2d_1 = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
+	var d_node2d_2 = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
+	var params = _utils.StubParams.new(Node2D, 'get_position').to_return(-1)
+	gr.stubber.add_stub(params)
+	assert_eq(d_node2d_1.get_position(), -1)
+	assert_eq(d_node2d_2.get_position(), -1)

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -22,8 +22,12 @@ var gr = {
 func before_each():
 	gr.doubler = Doubler.new()
 	gr.doubler.set_output_dir(TEMP_FILES)
-	gr.stubber = Stubber.new()
 	gr.doubler.clear_output_directory()
+
+	gr.stubber = Stubber.new()
+
+# func after_each():
+# 	gr.doubler.clear_output_directory()
 
 func test_doubled_have_ref_to_stubber():
 	gr.doubler.set_stubber(gr.stubber)
@@ -88,16 +92,38 @@ func test_when_stubbed_to_call_super_then_super_is_called():
 
 func test_can_stub_native_methods():
 	gr.doubler.set_stubber(gr.stubber)
-	var d_node2d = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
+	var d_node2d = gr.doubler.double_gdnative(Node2D).new()
+	print(d_node2d.__gut_metadata_.stubber)
 	var params = _utils.StubParams.new(d_node2d, 'get_position').to_return(-1)
 	gr.stubber.add_stub(params)
 	assert_eq(d_node2d.get_position(), -1)
 
+func test_partial_double_of_Node2D_returns_super_values():
+	gr.doubler.set_stubber(gr.stubber)
+	var pd_node_2d  = gr.doubler.partial_double_gdnative(Node2D).new()
+	# see big ass comment in next test.
+	pd_node_2d  = gr.doubler.partial_double_gdnative(Node2D).new()
+	assert_eq(pd_node_2d.is_blocking_signals(), false)
+
 func test_can_stub_all_Node2D_doubles():
 	gr.doubler.set_stubber(gr.stubber)
-	var d_node2d_1 = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
-	var d_node2d_2 = gr.doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL).new()
+	var d_node2d = gr.doubler.double_gdnative(Node2D).new()
+	# !!!!!!!!!!!!!!!
+	# TODO figure this mystery out.  Probably has something to do with the
+	# comment at the top of this file.
+	#
+	# I don't know why this does not work if we don't do it twice.  If it isn't
+	# done twice then it  will fail w/ a null stubber.  If you swap this method
+	# with the previous one, then that one will fail and this will pass w/o
+	# having to do it twice.  If  you run this test by itself it passes w/o
+	# doing it twice.  I'm not sure what is going on.
+	#
+	# The stubber instances match up (via  print statements) but d_node2d always
+	# has a null stubber after the first call and the real one after the 2nd.
+	# !!!!!!!!!!!!!!!
+	d_node2d = gr.doubler.double_gdnative(Node2D).new()
+	d_node2d = gr.doubler.double_gdnative(Node2D).new()
+	print(d_node2d.__gut_metadata_.stubber)
 	var params = _utils.StubParams.new(Node2D, 'get_position').to_return(-1)
 	gr.stubber.add_stub(params)
-	assert_eq(d_node2d_1.get_position(), -1)
-	assert_eq(d_node2d_2.get_position(), -1)
+	assert_eq(d_node2d.get_position(), -1)

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -170,6 +170,10 @@ class TestTestsSmartDoubleMethod:
 		assert_eq(inst.__gut_metadata_.path, INNER_CLASSES_PATH, 'check path')
 		assert_eq(inst.__gut_metadata_.subpath, 'InnerA', 'check subpath')
 
+	func test_can_double_native_classes():
+		var inst = _test.double(Node2D).new()
+		assert_not_null(inst)
+
 class TestPartialDoubleMethod:
 	extends "res://test/gut_test.gd"
 
@@ -212,8 +216,21 @@ class TestPartialDoubleMethod:
 		assert_eq(inst.get_a(), null)
 
 	func test_can_spy_on_partial_doubles():
+		var pass_count = _test.get_pass_count()
 		var inst = _test.partial_double(DOUBLE_ME_PATH).new()
 		inst.set_value(10)
 		_test.assert_called(inst, 'set_value')
 		_test.assert_called(inst, 'set_value', [10])
-		assert_eq(_test.get_pass_count(), 2)
+		assert_eq(_test.get_pass_count(), pass_count + 2)
+
+	func test_can_stub_partial_doubled_native_class():
+		var inst = _test.partial_double(Node2D).new()
+		_test.stub(inst, 'get_position').to_return(-1)
+		assert_eq(inst.get_position(), -1)
+
+	func test_can_spy_on_partial_doubled_native_class():
+		var pass_count = _test.get_pass_count()
+		var inst = _test.partial_double(Node2D).new()
+		inst.set_position(Vector2(100, 100))
+		_test.assert_called(inst, 'set_position', [Vector2(100, 100)])
+		assert_eq(_test.get_pass_count(), pass_count + 1, 'tests have passed')

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -194,9 +194,11 @@ class TestPartialDoubleMethod:
 		inst.set_value(10)
 		assert_eq(inst.get_value(), 10)
 
+	# TODO this test is tempramental.  It has something to do with the loading
+	# of the doubles I think.  Should be fixed.
 	func test_partial_double_scene():
 		var inst = _test.partial_double(DOUBLE_ME_SCENE_PATH).instance()
-		assert_eq(inst.return_hello(), 'hello')
+		assert_eq(inst.return_hello(), 'hello', 'sometimes fails, should be fixed.')
 
 	func test_partial_double_inner():
 		var inst = _test.partial_double(INNER_CLASSES_PATH, 'InnerA').new()

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -146,10 +146,11 @@ class TestPartialDoubleMethod:
 	func before_all():
 		_gut = Gut.new()
 		_test = Test.new()
-		_test.gut = gut
+		_test.gut = _gut
 
 	func after_each():
 		_gut.get_stubber().clear()
+		_gut.get_doubler().clear_output_directory()
 
 	func test_parital_double_script():
 		var inst = _test.partial_double(DOUBLE_ME_PATH).new()
@@ -176,3 +177,10 @@ class TestPartialDoubleMethod:
 	func test_double_inner_not_a_partial():
 		var inst = _test.double(INNER_CLASSES_PATH, 'InnerA').new()
 		assert_eq(inst.get_a(), null)
+
+	func test_can_spy_on_partial_doubles():
+		var inst = _test.partial_double(DOUBLE_ME_PATH).new()
+		inst.set_value(10)
+		_test.assert_called(inst, 'set_value')
+		_test.assert_called(inst, 'set_value', [10])
+		assert_eq(_test.get_pass_count(), 2)

--- a/test/resources/doubler_test_objects/has_static_method.gd
+++ b/test/resources/doubler_test_objects/has_static_method.gd
@@ -1,0 +1,5 @@
+static func this_is_a_static_method():
+	return true
+
+func this_is_not_static():
+	return true

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -419,11 +419,3 @@ class TestDoubleGDNaviteClasses:
 	func test_can_partial_double_Node2D():
 		var pd_node_2d  = _doubler.partial_double_gdnative(Node2D)
 		assert_not_null(pd_node_2d)
-
-	func test_can_double_Node2D_with_FULL_strategy():
-		var d_node_2d = _doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL)
-		assert_not_null(d_node_2d)
-
-	func test_can_partial_double_Node2D_with_FULL_strategy():
-		var pd_node_2d  = _doubler.partial_double_gdnative(Node2D, DOUBLE_STRATEGY.FULL)
-		assert_not_null(pd_node_2d)

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -396,3 +396,34 @@ class TestPartialDoubles:
 		var inst = doubler.double_scene(DOUBLE_ME_SCENE_PATH).instance()
 		assert_eq(inst.return_hello(), null)
 		pause_before_teardown()
+
+class TestDoubleGDNaviteClasses:
+	extends BaseTest
+
+	var _doubler = null
+	var _stubber = _utils.Stubber.new()
+
+	func before_each():
+		_stubber.clear()
+		_doubler = Doubler.new()
+		_doubler.set_output_dir(TEMP_FILES)
+		_doubler.set_stubber(_stubber)
+
+	func after_each():
+		_doubler.clear_output_directory()
+
+	func test_can_double_Node2D():
+		var d_node_2d = _doubler.double_gdnative(Node2D)
+		assert_not_null(d_node_2d)
+
+	func test_can_partial_double_Node2D():
+		var pd_node_2d  = _doubler.partial_double_gdnative(Node2D)
+		assert_not_null(pd_node_2d)
+
+	func test_can_double_Node2D_with_FULL_strategy():
+		var d_node_2d = _doubler.double_gdnative(Node2D, DOUBLE_STRATEGY.FULL)
+		assert_not_null(d_node_2d)
+
+	func test_can_partial_double_Node2D_with_FULL_strategy():
+		var pd_node_2d  = _doubler.partial_double_gdnative(Node2D, DOUBLE_STRATEGY.FULL)
+		assert_not_null(pd_node_2d)

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -114,7 +114,6 @@ class TestTheBasics:
 		add_child(inst)
 		assert_ne(inst.label, null)
 		remove_child(inst)
-		#print(gr.doubler.get_spy().get_call_list_as_string(inst))
 
 	func test_metadata_for_scenes_script_points_to_scene_not_script():
 		var inst = gr.doubler.double_scene(DOUBLE_ME_SCENE_PATH).instance()
@@ -156,16 +155,25 @@ class TestTheBasics:
 		assert_has_signal(d, 'signal_signal')
 		assert_has_signal(d, 'user_signal')
 
-
 	func test_can_add_to_ignore_list():
 		assert_eq(gr.doubler.get_ignored_methods().size(), 0, 'initial size')
 		gr.doubler.add_ignored_method(DOUBLE_WITH_STATIC, 'some_method')
 		assert_eq(gr.doubler.get_ignored_methods().size(), 1, 'after add')
 
+	func test_when_ignored_methods_are_a_local_method_mthey_are_not_present_in_double_code():
+		gr.doubler.add_ignored_method(DOUBLE_ME_PATH, 'has_one_param')
+		gr.doubler.double(DOUBLE_ME_PATH)
+		var text = gut.get_file_as_text(TEMP_FILES.plus_file('double_me.gd'))
+		assert_eq(text.find('has_one_param'), -1)
 
+	func test_when_ignored_methods_are_a_super_method_mthey_are_not_present_in_double_code():
+		gr.doubler.add_ignored_method(DOUBLE_ME_PATH, 'is_connected')
+		gr.doubler.double(DOUBLE_ME_PATH, _utils.DOUBLE_STRATEGY.FULL)
+		var text = gut.get_file_as_text(TEMP_FILES.plus_file('double_me.gd'))
+		assert_eq(text.find('is_connected'), -1)
 
 	func test_can_double_classes_with_static_methods():
-		pending('must do ignores first');return
+		gr.doubler.add_ignored_method(DOUBLE_WITH_STATIC, 'this_is_a_static_method')
 		var d = gr.doubler.double(DOUBLE_WITH_STATIC).new()
 		assert_null(d.this_is_not_static())
 
@@ -385,7 +393,6 @@ class TestPartialDoubles:
 		assert_eq(inst.return_hello(), 'hello')
 
 	func test_double_scene_does_not_call_supers():
-		print(doubler.get_stubber().get_instance_id())
 		var inst = doubler.double_scene(DOUBLE_ME_SCENE_PATH).instance()
 		assert_eq(inst.return_hello(), null)
 		pause_before_teardown()

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -10,6 +10,8 @@ class BaseTest:
 	const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_me_scene.tscn'
 	const DOUBLE_EXTENDS_NODE2D = 'res://test/resources/doubler_test_objects/double_extends_node2d.gd'
 	const DOUBLE_EXTENDS_WINDOW_DIALOG = 'res://test/resources/doubler_test_objects/double_extends_window_dialog.gd'
+	const DOUBLE_WITH_STATIC = 'res://test/resources/doubler_test_objects/has_static_method.gd'
+
 	var Doubler = load('res://addons/gut/doubler.gd')
 
 	func _get_temp_file_as_text(filename):
@@ -154,7 +156,9 @@ class TestTheBasics:
 		assert_has_signal(d, 'signal_signal')
 		assert_has_signal(d, 'user_signal')
 
-
+	func test_can_double_classes_with_static_methods():
+		var d = gr.doubler.double(DOUBLE_WITH_STATIC).new()
+		assert_null(d.this_is_not_static())
 
 class TestBuiltInOverloading:
 	extends BaseTest

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -156,9 +156,19 @@ class TestTheBasics:
 		assert_has_signal(d, 'signal_signal')
 		assert_has_signal(d, 'user_signal')
 
+
+	func test_can_add_to_ignore_list():
+		assert_eq(gr.doubler.get_ignored_methods().size(), 0, 'initial size')
+		gr.doubler.add_ignored_method(DOUBLE_WITH_STATIC, 'some_method')
+		assert_eq(gr.doubler.get_ignored_methods().size(), 1, 'after add')
+
+
+
 	func test_can_double_classes_with_static_methods():
+		pending('must do ignores first');return
 		var d = gr.doubler.double(DOUBLE_WITH_STATIC).new()
 		assert_null(d.this_is_not_static())
+
 
 class TestBuiltInOverloading:
 	extends BaseTest

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -137,7 +137,7 @@ func test_get_set_export_path():
 	assert_accessors(gr.test_gut, 'export_path', '', 'res://somewhere')
 
 # ------------------------------
-# Double Strategy
+# Doubler
 # ------------------------------
 func test_get_set_double_strategy():
 	assert_accessors(gr.test_gut, 'double_strategy', 1, 2)
@@ -148,6 +148,14 @@ func test_when_test_overrides_strategy_it_is_reset_after_test_finishes():
 	gr.test_gut.get_doubler().set_strategy(_utils.DOUBLE_STRATEGY.FULL)
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_double_strategy(), _utils.DOUBLE_STRATEGY.PARTIAL)
+
+func test_clears_ignored_methods_between_tests():
+	gr.test_gut.get_doubler().add_ignored_method('ignore_script', 'ignore_method')
+	gr.test_gut.add_script('res://test/samples/test_sample_one.gd')
+	gr.test_gut._tests_like = 'test_assert_eq_number_not_equal'
+	gr.test_gut.test_scripts()
+	assert_eq(gr.test_gut.get_doubler().get_ignored_methods().size(), 0)
+
 
 # ------------------------------
 # disable strict datatype comparisons

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -412,11 +412,13 @@ func test_post_hook_is_run_after_tests():
 	assert_true(gr.test_gut._post_run_script_instance.run_called, 'run was called')
 
 func test_when_post_hook_set_to_invalid_script_no_tests_are_ran():
+	watch_signals(gr.test_gut)
 	gr.test_gut.set_post_run_script('res://does_not_exist.gd')
 	gr.test_gut.add_script(SAMPLES_DIR + 'test_sample_all_passed.gd')
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_summary().get_totals().tests, 0, 'test should not be run')
 	assert_gt(gr.test_gut.get_logger().get_errors().size(), 0, 'there should be errors')
+	assert_signal_emitted(gr.test_gut, 'tests_finished')
 
 
 # ------------------------------------------------------------------------------

--- a/test/unit/test_gut_yielding.gd
+++ b/test/unit/test_gut_yielding.gd
@@ -118,6 +118,9 @@ func test_yield_to__will_disconnect_after_yield_finishes_and_signal_wasnt_emitte
 	var signaler = TimedSignaler.new()
 	add_child(signaler)
 	yield(yield_to(signaler, 'the_signal', 1), YIELD)
+	# Changing the yield to be deferred means that we have to wait again for
+	# the deferred to kick in before checking this.
+	yield(yield_for(.1), YIELD)
 	assert_false(signaler.is_connected('the_signal', gut, '_yielding_callback'))
 	remove_child(signaler)
 

--- a/test/unit/test_one_to_many.gd
+++ b/test/unit/test_one_to_many.gd
@@ -1,0 +1,52 @@
+extends "res://addons/gut/test.gd"
+
+var OneToMany = _utils.OneToMany
+
+func test_can_make_one():
+	assert_not_null(OneToMany.new())
+
+func test_size():
+	var otm  = OneToMany.new()
+	assert_eq(otm.size(), 0)
+
+func test_can_add_one():
+	var otm = OneToMany.new()
+	otm.add('one', 'many1')
+	assert_eq(otm.size(), 1)
+
+func test_size_with_name():
+	var otm = OneToMany.new()
+	otm.add('one', 'many1')
+	otm.add('one', 'many2')
+	otm.add('one', 'many3')
+	otm.add('two', 'two-1')
+	assert_eq(otm.size('one'), 3, 'checking one')
+	assert_eq(otm.size('two'), 1, 'checking two')
+
+func test_size_when_name_does_not_exist_returns_0():
+	var otm = OneToMany.new()
+	assert_eq(otm.size('missing'), 0)
+
+func test_ignores_duplicate_many():
+	var otm = OneToMany.new()
+	otm.add('one', 'many1')
+	otm.add('one', 'many1')
+	otm.add('one', 'many2')
+	assert_eq(otm.size('one'), 2)
+
+func test_clear():
+	var otm = OneToMany.new()
+	otm.add('one', 'many1')
+	otm.add('two', 'many2')
+	otm.add('three', 'many3')
+	assert_eq(otm.size(), 3, 'check before clear')
+	otm.clear()
+	assert_eq(otm.size(), 0)
+
+func test_has():
+	var otm = OneToMany.new()
+	otm.add('one', 'one-1')
+	otm.add('two', 'two-1')
+	otm.add('two', 'two-2')
+	assert_true(otm.has('two', 'two-2'), 'has two/two-2')
+	assert_false(otm.has('not', 'in-there'), 'does not exist')

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -42,7 +42,7 @@ class BaseTestClass:
 	# convenience method to assert the number of failures on the gr.test_gut object.
 	func assert_fail(t, count=1, msg=''):
 		var self_fail_count = get_fail_count()
-		assert_eq(t.get_fail_count(), count, 'Bad FAIL COUNT:  ' + msg)
+		assert_eq(t.get_fail_count(), count, 'Expected FAIL COUNT:  ' + msg)
 		if(t.get_pass_count() > 0 and count != t.get_assert_count()):
 			assert_eq(t.get_pass_count(), 0, 'When checking for failures there should be no passing')
 		if(get_fail_count() != self_fail_count or _print_all_subtests):
@@ -51,7 +51,7 @@ class BaseTestClass:
 	# convenience method to assert the number of passes on the gr.test_gut object.
 	func assert_pass(t, count=1, msg=''):
 		var self_fail_count = get_fail_count()
-		assert_eq(t.get_pass_count(), count, 'Bad PASS COUNT:  ' + msg)
+		assert_eq(t.get_pass_count(), count, 'Expected PASS COUNT:  ' + msg)
 		if(t.get_fail_count() != 0 and count != t.get_assert_count()):
 			assert_eq(t.get_fail_count(), 0, 'When checking for passes there should be no failures.')
 		if(get_fail_count() != self_fail_count or _print_all_subtests):

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1263,3 +1263,10 @@ class TestIsFreed:
 		obj.free()
 		gr.test.assert_not_freed(obj, "Object4")
 		assert_fail(gr.test)
+
+	func test_queued_free_is_not_freed():
+		var obj = Node.new()
+		add_child(obj)
+		obj.queue_free()
+		gr.test.assert_not_freed(obj, "Object4")
+		assert_pass(gr.test)


### PR DESCRIPTION
# 6.8.1
## Features
* Godot 3.2 (RC 1 at least) compatible.
* __Issue 124__ CodeDarigan added the `assert_freed` and `assert_not_freed` methods.
* __Issue 130__ GUT now lists the exact line number of a failing test in all cases instead of just the method number in non-inner classes.  Thanks to mschulzeLpz for adding `get_stack` magic.
* __Issue 133__ You can now double/partial_double/stub/spy Native classes like `Node2D` and `Raycast2D`.  Syntax is the same.
* __Issue 139__ There are now `pre` and `post` run script hooks that allow you to run your own code before any tests are run and after all tests are run.  This can be useful in setting global values before a run or investigating the results of the run for CICD pipelines and  the like.  [Check the wiki for more info](https://github.com/bitwes/Gut/wiki/Hooks)

## Bug Fixes
* __Issue 127__ The method `ignore_method_when_doubling` was added as a workaround for doubling scripts that have static methods.  The [Doubles wiki](https://github.com/bitwes/Gut/wiki/Doubles) page has more info about this method.
* __Issue 136__ Bug can happen when yielding where a `attempt to disconnect signal...while emitting` can occur.  Disconnecting from signals is now done via `call_deferred`.
