### PR TITLE
Check for object validity earlier in signal watcher

### DIFF
--- a/addons/gut/signal_watcher.gd
+++ b/addons/gut/signal_watcher.gd
@@ -149,8 +149,8 @@ func is_watching(object, signal_name):
 
 func clear():
 	for obj in _watched_signals:
-		for signal_name in _watched_signals[obj]:
-			if(_utils.is_not_freed(obj)):
+		if(_utils.is_not_freed(obj)):
+			for signal_name in _watched_signals[obj]:
 				obj.disconnect(signal_name, self, '_on_watched_signal')
 	_watched_signals.clear()
 


### PR DESCRIPTION
In Godot 3.2.2-beta I've been getting this error (while `yield_for` test):

```
* test_state
    Testing: test_body_state
    /# Yielding to signal "completed" or for 5 seconds #/ 

Debugger Break, Reason: 'Invalid get index '[Deleted Object]' (on base: 'Dictionary').'
*Frame 0 - res://addons/gut/signal_watcher.gd:152 in function 'clear'
```

I'm not sure what was merged to 3.2.2 that emits this error, yet I've reordered the object validity check and tests pass now. I wonder whether that's a symptom or a solution.

This might be quite related to godotengine/godot#38322, so this might have just revealed a hidden bug in GUT.

Also, consider switching to [`is_instance_valid`](https://docs.godotengine.org/en/3.2/classes/class_@gdscript.html#class-gdscript-method-is-instance-valid) method, works reliably for checking validity in 3.2.