### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,20 @@
-.fscache
-.DS_Store
-*.import
+
+# Godot-specific ignores
+.import/
+export.cfg
 export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
+.DS_Store
 exported_tests.cfg
-.vscode
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "godot_tools.editor_path": "/Applications/Godot.app/Contents/MacOS/Godot"
-}

--- a/addons/gut/icon.png.import
+++ b/addons/gut/icon.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon.png-91b084043b8aaf2f1c906e7b9fa92969.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/gut/icon.png"
+dest_files=[ "res://.import/icon.png-91b084043b8aaf2f1c906e7b9fa92969.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/icon.png.import
+++ b/icon.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://icon.png"
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0


### PR DESCRIPTION
The gitignore was missing a few things and was a bit outdated, so I updated it.

* I removed `.fscache` from the gitignore since this file hasn't existed since Godot 2.1.

* I removed `*.import` from the gitignore because these files control import settings.

I also deleted the `.vscode/` folder since that was in the gitignore already, but was committed for some reason, and I committed the two `icon.png.import` files.