### PR TITLE
fixed memory leaks

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -453,6 +453,12 @@ func _end_run():
 	yield(_yield_between.timer, 'timeout')
 	_gui.get_text_box().cursor_set_line(_gui.get_text_box().get_line_count())
 
+	for test_script in _test_script_objects:
+		assert(not test_script.is_inside_tree())
+		test_script.free()
+
+	_test_script_objects = []
+
 	_is_running = false
 	update()
 	_run_hook_script(_post_run_script_instance)

--- a/addons/gut/logger.gd
+++ b/addons/gut/logger.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Reference
 
 var _gut = null
 

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -158,6 +158,7 @@ func _parse_inner_class_tests(script):
 			t.name = name
 			script.tests.append(t)
 
+	inst.free()
 	return true
 # -----------------
 # Public


### PR DESCRIPTION
I was experiencing some orphaned nodes after tests were finished.

There's this comment in the code i don't fully understand:
```
		# This might end up being very resource intensive if the scripts
		# don't clean up after themselves.  Might have to consolidate output
		# into some other structure and kill the script objects with
		# test_script.free() instead of remove child.
		remove_child(test_script)
```
My code frees those test_scripts but i don't know if anything else needs to be done.