### PR TITLE
exits with 1 if configuration or path is wrong

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -968,6 +968,7 @@ func add_directory(path, prefix=_file_prefix, suffix=_file_extension):
 	var d = Directory.new()
 	if(!d.dir_exists(path)):
 		_lgr.error(str('The path [', path, '] does not exist.'))
+		OS.exit_code = 1
 	else:
 		var files = _get_files(path, prefix, suffix)
 		for i in range(files.size()):

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -346,10 +346,10 @@ func _run_gut():
 			load_options_from_config_file(opt_resolver.get_value('config_file'), opt_resolver.config_opts)
 
 	if(load_result == -1): # -1 indicates json parse error
-		quit()
+		quit(-1)
 	else:
 		if(!all_options_valid):
-			quit()
+			quit(-1)
 		elif(o.get_value('-gh')):
 			print(_utils.get_version_text())
 			o.print_help()

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -346,10 +346,10 @@ func _run_gut():
 			load_options_from_config_file(opt_resolver.get_value('config_file'), opt_resolver.config_opts)
 
 	if(load_result == -1): # -1 indicates json parse error
-		quit(-1)
+		quit(1)
 	else:
 		if(!all_options_valid):
-			quit(-1)
+			quit(1)
 		elif(o.get_value('-gh')):
 			print(_utils.get_version_text())
 			o.print_help()


### PR DESCRIPTION
After creating a GitHub Action for running GUT tests on GitHub CI I've noticed that the script does exit with error code 0 if the configuration is wrong, or the given path does not exist. And so this causes the CI passing, even tho no test is executed.

This PR address these situations by returning the -1 error code and so making CI fail.