### PR TITLE
Fixes #202 

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,7 +1,7 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
-  "should_exit":false,
+  "should_exit":true,
   "ignore_pause":true,
   "log_level":2,
   "opacity":100,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Bug Fixes
 * Command Line now returns 1 if no sripts could be loaded.
-* __Issue 195__ Parameterized tests generated deprecated warnings.
-
+* __Issue 195__ Parameterized Tests generated deprecated warnings.
+* __Issue 202__ `before_each` and `after_each` now work as expected with Parameterized Tests.
 
 # 7.0.0
 ## Breaking Changes

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -627,10 +627,13 @@ func _parameterized_call(test_script):
 		_fail(str('Parameterized test ', _current_test.name, ' did not call use_parameters for the default value of the parameter.'))
 	else:
 		while(!_parameter_handler.is_done()):
+			test_script.after_each() # after first call, caller of this will do  ast  call
+			test_script.before_each()
 			script_result = test_script.call(_current_test.name)
 			if(_is_function_state(script_result)):
 				_wait_for_done(script_result)
 				yield(self, 'done_waiting')
+
 		script_result = null
 	_parameter_handler = null
 	emit_signal(SIGNAL_PRAMETERIZED_YIELD_DONE)

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -627,7 +627,7 @@ func _parameterized_call(test_script):
 		_fail(str('Parameterized test ', _current_test.name, ' did not call use_parameters for the default value of the parameter.'))
 	else:
 		while(!_parameter_handler.is_done()):
-			test_script.after_each() # after first call, caller of this will do  ast  call
+			test_script.after_each() # after first call, caller of this will do last call
 			test_script.before_each()
 			script_result = test_script.call(_current_test.name)
 			if(_is_function_state(script_result)):

--- a/test/resources/parsing_and_loading_samples/test_with_parameters.gd
+++ b/test/resources/parsing_and_loading_samples/test_with_parameters.gd
@@ -30,3 +30,28 @@ class TestInnerClass:
 
 	func test_inner_no_parameters():
 		assert_true(true, 'this one passes')
+
+
+class TestWithBeforeEach:
+	extends "res://addons/gut/test.gd"
+
+	var before_count = 0
+	var func_params = [1, 2, 3]
+
+	func before_each():
+		before_count += 1
+
+	func test_run(p = use_parameters(func_params)):
+		assert_eq(before_count, p)
+
+class TestWithAfterEach:
+	extends "res://addons/gut/test.gd"
+
+	var after_count = 0
+	var func_params = [0, 1, 2]
+
+	func after_each():
+		after_count += 1
+
+	func test_run(p = use_parameters(func_params)):
+		assert_eq(after_count, p)

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -427,8 +427,18 @@ func test_when_post_hook_set_to_invalid_script_no_tests_are_ran():
 # ------------------------------
 # Parameterized Test Tests
 # ------------------------------
+const TEST_WITH_PARAMETERS = 'res://test/resources/parsing_and_loading_samples/test_with_parameters.gd'
+func _get_test_script_object_of_type(the_gut, the_type):
+	var objs = gr.test_gut._test_script_objects
+	var obj = null
+	for i in range(objs.size()):
+		if(objs[i] is the_type):
+			obj = objs[i]
+		print('- ', _str(objs[i]))
+	return obj
+
 func test_can_run_tests_with_parameters():
-	gr.test_gut.add_script('res://test/resources/parsing_and_loading_samples/test_with_parameters.gd')
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
 	gr.test_gut.set_unit_test_name('test_has_one_defaulted_parameter')
 	gr.test_gut.test_scripts()
 	var totals = gr.test_gut.get_summary().get_totals()
@@ -436,20 +446,20 @@ func test_can_run_tests_with_parameters():
 	assert_eq(totals.tests, 1, 'test count')
 
 func test_too_many_parameters_generates_an_error():
-	gr.test_gut.add_script('res://test/resources/parsing_and_loading_samples/test_with_parameters.gd')
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
 	gr.test_gut.set_unit_test_name('test_has_two_parameters')
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_logger().get_errors().size(), 1, 'error size')
 	assert_eq(gr.test_gut.get_summary().get_totals().tests, 0, 'test count')
 
 func test_parameterized_tests_are_called_multiple_times():
-	gr.test_gut.add_script('res://test/resources/parsing_and_loading_samples/test_with_parameters.gd')
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
 	gr.test_gut.set_unit_test_name('test_has_three_values_for_parameters')
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_pass_count(), 3)
 
 func test_when_use_parameters_is_not_called_then_error_is_generated():
-	gr.test_gut.add_script('res://test/resources/parsing_and_loading_samples/test_with_parameters.gd')
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
 	gr.test_gut.set_unit_test_name('test_does_not_use_use_parameters')
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_logger().get_errors().size(), 1, 'error size')
@@ -457,11 +467,27 @@ func test_when_use_parameters_is_not_called_then_error_is_generated():
 
 # if you really think about this is a very very inception like test.
 func test_parameterized_test_that_yield_are_called_correctly():
-	gr.test_gut.add_script('res://test/resources/parsing_and_loading_samples/test_with_parameters.gd')
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
 	gr.test_gut.set_unit_test_name('test_three_values_and_a_yield')
 	gr.test_gut.test_scripts()
 	yield(yield_to(gr.test_gut, gr.test_gut.SIGNAL_PRAMETERIZED_YIELD_DONE, 10), YIELD)
 	assert_eq(gr.test_gut.get_pass_count(), 3)
+
+func test_parameterized_test_calls_before_each_before_each_test():
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
+	gr.test_gut.set_inner_class_name('TestWithBeforeEach')
+	gr.test_gut.test_scripts()
+	assert_eq(gr.test_gut.get_pass_count(), 3)
+	var obj = _get_test_script_object_of_type(gr.test_gut, load(TEST_WITH_PARAMETERS).TestWithBeforeEach)
+	assert_eq(obj.before_count, 3, 'test class:  before_count')
+
+func test_parameterized_test_calls_after_each_after_each_test():
+	gr.test_gut.add_script(TEST_WITH_PARAMETERS)
+	gr.test_gut.set_inner_class_name('TestWithAfterEach')
+	gr.test_gut.test_scripts()
+	assert_eq(gr.test_gut.get_pass_count(), 3)
+	var obj = _get_test_script_object_of_type(gr.test_gut, load(TEST_WITH_PARAMETERS).TestWithAfterEach)
+	assert_eq(obj.after_count, 3, 'test class:  after_count')
 
 # ------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Fixes 202.   `before_each` and `after_each` are now called before and after each parameterized test.