### PR TITLE
File paths for GDNative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * __Issue 195__ Parameterized Tests generated deprecated warnings.
 * Fixed various issues with parameterized tests.  All  test execution is now treated exactly the same (__Issue 196__, __Issue 197__, __Issue 202__)
 * __Issue 200__ If you pass a non-doubled instance to `stub` and error is generated.
-
+* __Issue 211__ GDNative scripts cause `Error calling built-in function 'inst2dict': Not a script with an instance` when used in assertions
 
 # 7.0.0
 ## Breaking Changes

--- a/addons/gut/strutils.gd
+++ b/addons/gut/strutils.gd
@@ -72,6 +72,10 @@ func _get_obj_filename(thing):
 			# If it isn't a packed scene and it doesn't have a script then
 			# we do nothing.  This just read better.
 			pass
+	elif(thing.get_script() is NativeScript):
+		# Work with GDNative scripts:
+		# inst2dict fails with "Not a script with an instance" on GDNative script instances
+		filename = _get_filename(thing.get_script().resource_path)
 	elif(!_utils.is_native_class(thing)):
 		var dict = inst2dict(thing)
 		filename = _get_filename(dict['@path'])


### PR DESCRIPTION
Special case when determining object filename of a GDNative script.  
Calling inst2dict fails for GDNative scripts, but we can directly obtain the resource path from the script instance.

Fixes #211