### PR TITLE
minor: Fixing typo in test name

### DIFF
--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -213,7 +213,7 @@ class TestPartialDoubleMethod:
 		_gut.free()
 		_test.free()
 
-	func test_parital_double_script():
+	func test_partial_double_script():
 		var inst = _test.partial_double(DOUBLE_ME_PATH).new()
 		inst.set_value(10)
 		assert_eq(inst.get_value(), 10)


### PR DESCRIPTION
Was looking at the wiki, and found this same typo on the code sample in the [Quick Start for Partial Doubles](https://github.com/bitwes/Gut/wiki/Quick-Start#partial-doubles) on the first line `var double_bar = parital_double('res://bar.tscn').instance() `

Couldn't find a way to do a PR on the wiki, so searched the code and found this one there as well.