### PR TITLE
fix  #258

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Bug Fixes
 * __Issue 268__ Add message when `assert_signal_emitted_with_parameters` is passed bad parameters.
+* __Issue 258__ `yield_to` now supports signals with up to 9 parameters.  This is the same limit  supported by `watch_signals`.
 
 
 

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -301,8 +301,15 @@ func _on_log_level_changed(value):
 # ------------------------------------------------------------------------------
 # Timeout for the built in timer.  emits the timeout signal.  Start timer
 # with set_yield_time()
+#
+# signal_watcher._on_watched_signal supports up to 9 additional arguments.
+# This is the most number of parameters GUT supports on signals.  The comment
+# on _on_watched_signal explains reasoning.
 # ------------------------------------------------------------------------------
-func _yielding_callback(from_obj=false):
+func _yielding_callback(from_obj=false,
+		__arg1=null, __arg2=null, __arg3=null,
+		__arg4=null, __arg5=null, __arg6=null,
+		__arg7=null, __arg8=null, __arg9=null):
 	_lgr.end_yield()
 	if(_yielding_to.obj):
 		_yielding_to.obj.call_deferred(

--- a/test/unit/test_gut_yielding.gd
+++ b/test/unit/test_gut_yielding.gd
@@ -8,6 +8,7 @@ class TimedSignaler:
 	extends Node2D
 
 	signal the_signal
+
 	var _timer = null
 
 	func _ready():
@@ -22,6 +23,19 @@ class TimedSignaler:
 	func emit_after(time):
 		_timer.set_wait_time(time)
 		_timer.start()
+
+class TimeSignalerParam:
+	extends TimedSignaler
+
+	func _on_timer_timeout():
+		emit_signal('the_signal', 1)
+
+class TimedSignalerMaxParams:
+	extends TimedSignaler
+
+	func _on_timer_timeout():
+		emit_signal('the_signal', 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
 
 var timer = null
 
@@ -150,6 +164,20 @@ func test_yield_to__will_stop_timer_when_signal_emitted():
 
 func test_yield_to__watches_signals():
 	var signaler = add_child_autoqfree(TimedSignaler.new())
+	watch_signals(signaler)
+	signaler.emit_after(.5)
+	yield(yield_to(signaler, 'the_signal', 5), YIELD)
+	assert_signal_emitted(signaler, 'the_signal')
+
+func test_yield_to_works_on_signals_with_parameters():
+	var signaler = add_child_autoqfree(TimeSignalerParam.new())
+	watch_signals(signaler)
+	signaler.emit_after(.5)
+	yield(yield_to(signaler, 'the_signal', 5), YIELD)
+	assert_signal_emitted(signaler, 'the_signal')
+
+func test_yield_to_works_on_signals_with_max_parameters():
+	var signaler = add_child_autoqfree(TimedSignalerMaxParams.new())
 	watch_signals(signaler)
 	signaler.emit_after(.5)
 	yield(yield_to(signaler, 'the_signal', 5), YIELD)


### PR DESCRIPTION
Fixes #258 by adding 9 optional parameters to the `yield` callback method GUT uses.  see `signal_watcher. _on_watched_signal` for why 9 was chosen.