### PR TITLE
Makes yield between tests using the autofree queue configurable

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -49,6 +49,7 @@ var _double_strategy = 1  setget set_double_strategy, get_double_strategy
 var _pre_run_script = '' setget set_pre_run_script, get_pre_run_script
 var _post_run_script = '' setget set_post_run_script, get_post_run_script
 var _color_output = false setget set_color_output, get_color_output
+var _autofree_yield_between_tests = 0.1 setget set_autofree_yield_between_tests, get_autofree_yield_between_tests
 # -- End Settings --
 
 
@@ -704,7 +705,7 @@ func _run_test(script_inst, test_name):
 	var aqf_count = _autofree.get_queue_free_count()
 	_autofree.free_all()
 	if(aqf_count > 0):
-		yield(_do_yield_between(0.1), 'timeout')
+		yield(_do_yield_between(_autofree_yield_between_tests), 'timeout')
 
 	if(_log_level > 0):
 		_orphan_counter.print_orphans('test', _lgr)
@@ -1545,6 +1546,16 @@ func get_color_output():
 func set_color_output(color_output):
 	_color_output = color_output
 	_lgr.disable_formatting(!color_output)
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func get_autofree_yield_between_tests():
+	return _autofree_yield_between_tests
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func set_autofree_yield_between_tests(yield_time):
+	_autofree_yield_between_tests = yield_time
 
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -123,6 +123,7 @@ var _final_opts = []
 # that I don't make any dumb typos and get the neat code-sense when I
 # type a dot.
 var options = {
+	autofree_yield_between_tests = 0.1,
 	background_color = Color(.15, .15, .15, 1).to_html(),
 	config_file = 'res://.gutconfig.json',
 	dirs = [],
@@ -195,6 +196,8 @@ func setup_options():
 	opts.add('-gfont_size', options.font_size, 'Font size, default "[default]"')
 	opts.add('-gbackground_color', options.background_color, 'Background color as an html color, default "[default]"')
 	opts.add('-gfont_color',options.font_color, 'Font color as an html color, default "[default]"')
+	opts.add('-gautofree_yield_between_tests',options.autofree_yield_between_tests,('Adjusts delay between tests that use autofree to avoid ' +
+		                                                                            'erroneous orphans. Default "[default]"'))
 	return opts
 
 
@@ -226,6 +229,7 @@ func extract_command_line_options(from, to):
 	to.font_name = from.get_value('-gfont_name')
 	to.background_color = from.get_value('-gbackground_color')
 	to.font_color = from.get_value('-gfont_color')
+	to.autofree_yield_between_tests = from.get_value('-gautofree_yield_between_tests')
 
 
 func load_options_from_config_file(file_path, into):
@@ -306,6 +310,8 @@ func apply_options(opts):
 		_tester.get_gui().set_default_font_color(Color(opts.font_color))
 	if(opts.background_color != null and opts.background_color.is_valid_html_color()):
 		_tester.get_gui().set_background_color(Color(opts.background_color))
+
+	_tester.set_autofree_yield_between_tests(opts.autofree_yield_between_tests)
 
 
 func _print_gutconfigs(values):

--- a/addons/gut/plugin_control.gd
+++ b/addons/gut/plugin_control.gd
@@ -64,6 +64,10 @@ export(int, 'Fail/Errors', 'Errors/Warnings/Test Names', 'Everything') var _log_
 # Disabling this can make the program appear to hang and can have some
 # unwanted consequences with the timing of freeing objects
 export var _yield_between_tests = true
+# Configures how long GUT waits after freeing autofree queued items to prevent
+# them from being detected as orphans. Smaller values increase the risk of showing
+# incorrect orphans but decrease excess time between tests.
+export(float) var _autofree_yield_between_tests = 0.1
 # When GUT compares values it first checks the types to prevent runtime errors.
 # This behavior can be disabled if desired.  This flag was added early in
 # development to prevent any breaking changes and will likely be removed in
@@ -185,6 +189,7 @@ func _setup_gut():
 
 	_gut.set_should_maximize(_should_maximize)
 	_gut.set_yield_between_tests(_yield_between_tests)
+	_gut.set_autofree_yield_between_tests(_autofree_yield_between_tests)
 	_gut.disable_strict_datatype_checks(_disable_strict_datatype_checks)
 	_gut.set_export_path(_export_path)
 	_gut.set_include_subdirectories(_include_subdirectories)


### PR DESCRIPTION
My project has a large number of small tests that use `add_child_autoqfree` and the 0.1 second yield between tests ends up taking more time than the tests themselves (in a subset 5.2 seconds w/ `0.1`, 0.9 with `0.01`). 

On my test machines reducing the yield to `0.01` does not seem to trigger any incorrect orphans but I don't know if this is deterministic in other environments so I made it a configurable parameter.