### PR TITLE
Double and partial double singletons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,16 @@ func test_fireball_input():
   yield(sender, 'idle')
   assert_true(player.is_throwing_fireball())
 ```
+* Create doubles and partial doubles of Godot Singletons such as `Input`, `OS`, `JavaScript`.
+```
+func test_foo():
+  var player = Fighter.new()
+  var dbl_input = double_singleton('Input')
+  # For doubles of singletons to work, your classes must have a local reference
+  # to the singleton that can be overidden with the double.
+  player.local_input_ref = dbl_input
+  stub(dbl_input, 'is_action_just_pressed').to_return(true).when_passed('jump')
+```
 * In-Editor GUT Panel improvements
   * Smart buttons to run tests based on cursor location.
 * __Issue 215__ You can now use `extends GutTest` instead of `extends 'res://addons/gut/test.gd'` when creating test scripts.  That's 45% less text!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,11 +15,18 @@ func test_fireball_input():
   sender.action_down("down").hold_for(.1)\
     .action_down("down_forward").hold_for(.1)\
     .action_down("forward").key_down("FP")
+
   yield(sender, 'idle')
   assert_true(player.is_throwing_fireball())
 ```
 * In-Editor GUT Panel improvements
   * Smart buttons to run tests based on cursor location.
+* __Issue 215__ You can now use `extends GutTest` instead of `extends 'res://addons/gut/test.gd'` when creating test scripts.  That's 45% less text!
+* __Issue 310__ The summary output now lists the number of passing/failing tests as well as passing/failing assert counts.
+
+## Bug Fixes
+* __Issue 283__ The Gut Scene now has a theme with a font which prevents higher level font changes from applying to the Gut Scene.
+* __Issue 294__ GUT ignores the `res://addons/gut` directory if you accidently include it as a test directory.
 
 # 7.2.0
 

--- a/addons/gut/GutScene.tscn
+++ b/addons/gut/GutScene.tscn
@@ -43,7 +43,7 @@ corner_radius_top_left = 20
 corner_radius_top_right = 20
 
 [node name="Gut" type="Panel"]
-margin_right = 796.0
+margin_right = 740.0
 margin_bottom = 374.0
 rect_min_size = Vector2( 740, 250 )
 theme = ExtResource( 7 )

--- a/addons/gut/double_templates/script_template.txt
+++ b/addons/gut/double_templates/script_template.txt
@@ -1,11 +1,22 @@
+# ##############################################################################
+# Start Script
+# ##############################################################################
 {extends}
 
+{constants}
+
+{properties}
+# ------------------------------------------------------------------------------
+# GUT Double properties and methods
+# ------------------------------------------------------------------------------
 var __gut_metadata_ = {
 	path = '{path}',
 	subpath = '{subpath}',
 	stubber = __gut_instance_from_id({stubber_id}),
 	spy = __gut_instance_from_id({spy_id}),
 	gut = __gut_instance_from_id({gut_id}),
+	from_singleton = '{singleton_name}',
+	is_partial = {is_partial}
 }
 
 func __gut_instance_from_id(inst_id):
@@ -37,6 +48,7 @@ func __gut_default_val(method_name, p_index):
 		return __gut_metadata_.stubber.get_default_value(self, method_name, p_index)
 	else:
 		return null
+
 
 func  _init():
 	if(__gut_metadata_.gut != null):

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -1,3 +1,35 @@
+# ##############################################################################
+#(G)odot (U)nit (T)est class
+#
+# ##############################################################################
+# The MIT License (MIT)
+# =====================
+#
+# Copyright (c) 2020 Tom "Butch" Wesley
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ##############################################################################
+# Description
+# -----------
+# ##############################################################################
+
 # ------------------------------------------------------------------------------
 # Utility class to hold the local and built in methods separately.  Add all local
 # methods FIRST, then add built ins.
@@ -71,7 +103,6 @@ class ScriptMethods:
 			text += str("  ", built_ins[i].name, "\n")
 		return text
 
-
 # ------------------------------------------------------------------------------
 # Helper class to deal with objects and inner classes.
 # ------------------------------------------------------------------------------
@@ -79,26 +110,33 @@ class ObjectInfo:
 	var _path = null
 	var _subpaths = []
 	var _utils = load('res://addons/gut/utils.gd').get_instance()
+	var _lgr = _utils.get_logger()
 	var _method_strategy = null
 	var make_partial_double = false
 	var scene_path = null
 	var _native_class = null
 	var _native_class_name = null
+	var _singleton_instance = null
+	var _singleton_name = null
 
 	func _init(path, subpath=null):
 		_path = path
 		if(subpath != null):
 			_subpaths = Array(subpath.split('/'))
 
-
 	# Returns an instance of the class/inner class
 	func instantiate():
 		var to_return = null
-		if(is_native()):
+
+		if(_singleton_instance != null):
+			to_return = _singleton_instance
+		elif(is_native()):
 			to_return = _native_class.new()
 		else:
 			to_return = get_loaded_class().new()
+
 		return to_return
+
 
 	# Can't call it get_class because that is reserved so it gets this ugly name.
 	# Loads up the class and then any inner classes to give back a reference to
@@ -109,21 +147,70 @@ class ObjectInfo:
 			LoadedClass = LoadedClass.get(_subpaths[i])
 		return LoadedClass
 
+
 	func to_s():
 		return str(_path, '[', get_subpath(), ']')
+
 
 	func get_path():
 		return _path
 
+
 	func get_subpath():
 		return PoolStringArray(_subpaths).join('/')
+
 
 	func has_subpath():
 		return _subpaths.size() != 0
 
+
+	func get_method_strategy():
+		return _method_strategy
+
+
+	func set_method_strategy(method_strategy):
+		_method_strategy = method_strategy
+
+
+	func is_native():
+		return _native_class != null
+
+
+	func set_native_class(native_class):
+		_native_class = native_class
+		var inst = native_class.new()
+		_native_class_name = inst.get_class()
+		_path = _native_class_name
+		if(!inst is Reference):
+			inst.free()
+
+
+	func get_native_class_name():
+		return _native_class_name
+
+
+	func get_singleton_instance():
+		return _singleton_instance
+
+
+	func get_singleton_name():
+		return _singleton_name
+
+
+	func set_singleton_name(singleton_name):
+		_singleton_name = singleton_name
+		_singleton_instance = _utils.get_singleton_by_name(_singleton_name)
+
+
+	func is_singleton():
+		return _singleton_instance != null
+
+
 	func get_extends_text():
 		var extend = null
-		if(is_native()):
+		if(is_singleton()):
+			extend = str("# Double of singleton ", _singleton_name, ", base class is Reference")
+		elif(is_native()):
 			var native = get_native_class_name()
 			if(native.begins_with('_')):
 				native = native.substr(1)
@@ -136,25 +223,58 @@ class ObjectInfo:
 
 		return extend
 
-	func get_method_strategy():
-		return _method_strategy
 
-	func set_method_strategy(method_strategy):
-		_method_strategy = method_strategy
+	func get_constants_text():
+		if(!is_singleton()):
+			return ""
 
-	func is_native():
-		return _native_class != null
+		# do not include constants defined in the super class which for
+		# singletons stubs is Reference.
+		var exclude_constants = Array(ClassDB.class_get_integer_constant_list("Reference"))
+		var text = str("# -----\n# ", _singleton_name, " Constants\n# -----\n")
+		var constants = ClassDB.class_get_integer_constant_list(_singleton_name)
+		for c in constants:
+			if(!exclude_constants.has(c)):
+				var value = ClassDB.class_get_integer_constant(_singleton_name, c)
+				text += str("const ", c, " = ", value, "\n")
 
-	func set_native_class(native_class):
-		_native_class = native_class
-		var inst = native_class.new()
-		_native_class_name = inst.get_class()
-		_path = _native_class_name
-		if(!inst is Reference):
-			inst.free()
+		return text
 
-	func get_native_class_name():
-		return _native_class_name
+	func get_properties_text():
+		if(!is_singleton()):
+			return ""
+
+		var text = str("# -----\n# ", _singleton_name, " Properties\n# -----\n")
+		var props = ClassDB.class_get_property_list(_singleton_name)
+		for prop in props:
+			var accessors = {"setter":null, "getter":null}
+			var prop_text = str("var ", prop["name"])
+
+			var getter_name = "get_" + prop["name"]
+			if(ClassDB.class_has_method(_singleton_name, getter_name)):
+				accessors.getter = getter_name
+			else:
+				getter_name = "is_" + prop["name"]
+				if(ClassDB.class_has_method(_singleton_name, getter_name)):
+					accessors.getter = getter_name
+
+			var setter_name = "set_" + prop["name"]
+			if(ClassDB.class_has_method(_singleton_name, setter_name)):
+				accessors.setter = setter_name
+
+			var setget_text = ""
+			if(accessors.setter != null and accessors.getter != null):
+				setget_text = str("setget ", accessors.setter, ", ", accessors.getter)
+			else:
+				# never seen this message show up, but it should show up if we
+				# get misbehaving singleton.
+				_lgr.error(str("Could not find setget methods for property:  ",
+					_singleton_name, ".",  prop["name"]))
+
+			text += str(prop_text, " ", setget_text, "\n")
+
+		return text
+
 
 # ------------------------------------------------------------------------------
 # Allows for interacting with a file but only creating a string.  This was done
@@ -200,7 +320,6 @@ class FileOrString:
 		else:
 			return load(_path)
 
-
 # ------------------------------------------------------------------------------
 # A stroke of genius if I do say so.  This allows for doubling a scene without
 # having  to write any files.  By overloading the "instance" method  we can
@@ -225,6 +344,7 @@ class PackedSceneDouble:
 
 
 
+
 # ------------------------------------------------------------------------------
 # START Doubler
 # ------------------------------------------------------------------------------
@@ -242,20 +362,9 @@ var _gut = null
 var _strategy = null
 var _base_script_text = _utils.get_file_as_text('res://addons/gut/double_templates/script_template.txt')
 var _make_files = false
+# used by tests for debugging purposes.
+var _print_source = false
 
-# These methods all call super implicitly.  Stubbing them to call super causes
-# super to be called twice.
-var _non_super_methods = [
-	"_init",
-	"_ready",
-	"_notification",
-	"_enter_world",
-	"_exit_world",
-	"_process",
-	"_physics_process",
-	"_exit_tree",
-	"_gui_input	",
-]
 
 func _init(strategy=_utils.DOUBLE_STRATEGY.PARTIAL):
 	set_logger(_utils.get_logger())
@@ -272,14 +381,19 @@ func _get_indented_line(indents, text):
 
 
 func _stub_to_call_super(obj_info, method_name):
-	if(_non_super_methods.has(method_name)):
+	if(_utils.non_super_methods.has(method_name)):
 		return
+
 	var path = obj_info.get_path()
-	if(obj_info.scene_path != null):
+	if(obj_info.is_singleton()):
+		path = obj_info.get_singleton_name()
+	elif(obj_info.scene_path != null):
 		path = obj_info.scene_path
+
 	var params = _utils.StubParams.new(path, method_name, obj_info.get_subpath())
 	params.to_call_super()
 	_stubber.add_stub(params)
+
 
 func _get_base_script_text(obj_info, override_path):
 	var path = obj_info.get_path()
@@ -299,19 +413,31 @@ func _get_base_script_text(obj_info, override_path):
 		gut_id = _gut.get_instance_id()
 
 	var values = {
+		# Top  sections
+		"extends":obj_info.get_extends_text(),
+		"constants":obj_info.get_constants_text(),
+		"properties":obj_info.get_properties_text(),
+
+		# metadata values
 		"path":path,
 		"subpath":obj_info.get_subpath(),
 		"stubber_id":stubber_id,
 		"spy_id":spy_id,
-		"extends":obj_info.get_extends_text(),
-		"gut_id":gut_id
+		"gut_id":gut_id,
+		"singleton_name":_utils.nvl(obj_info.get_singleton_name(), ''),
+		"is_partial":str(obj_info.make_partial_double).to_lower()
 	}
 
 	return _base_script_text.format(values)
 
+
 func _write_file(obj_info, dest_path, override_path=null):
 	var base_script = _get_base_script_text(obj_info, override_path)
 	var script_methods = _get_methods(obj_info)
+	var super_name = ""
+
+	if(obj_info.is_singleton()):
+		super_name = obj_info.get_singleton_name()
 
 	var f = FileOrString.new()
 	f._do_file = _make_files
@@ -325,16 +451,17 @@ func _write_file(obj_info, dest_path, override_path=null):
 	f.store_string(base_script)
 
 	for i in range(script_methods.local_methods.size()):
-		if(obj_info.make_partial_double):
-			_stub_to_call_super(obj_info, script_methods.local_methods[i].name)
-		f.store_string(_get_func_text(script_methods.local_methods[i], obj_info.get_path()))
+		f.store_string(_get_func_text(script_methods.local_methods[i], super_name))
 
 	for i in range(script_methods.built_ins.size()):
 		_stub_to_call_super(obj_info, script_methods.built_ins[i].name)
-		f.store_string(_get_func_text(script_methods.built_ins[i], obj_info.get_path()))
+		f.store_string(_get_func_text(script_methods.built_ins[i], super_name))
 
 	f.close()
+	if(_print_source):
+		print(f.get_contents())
 	return f
+
 
 func _double_scene_and_script(scene_info):
 	var to_return = PackedSceneDouble.new()
@@ -355,37 +482,49 @@ func _double_scene_and_script(scene_info):
 
 	return to_return
 
+
 func _get_methods(object_info):
 	var obj = object_info.instantiate()
 	# any method in the script or super script
 	var script_methods = ScriptMethods.new()
 	var methods = obj.get_method_list()
-	if(!(obj is Reference)):
+
+	if(!object_info.is_singleton() and !(obj is Reference)):
 		obj.free()
 
 	# first pass is for local methods only
 	for i in range(methods.size()):
+		if(object_info.is_singleton()):
+			#print(methods[i].name, " :: ", methods[i].flags, " :: ", methods[i].id)
+			#print("    ", methods[i])
+			# It appears that id for class methods starts above 1000 and objects
+			# upstream of Input were below 100
+			if(methods[i].id > 1000 and methods[i].flags in [1, 9]):
+				script_methods.add_local_method(methods[i])
+
 		# 65 is a magic number for methods in script, though documentation
 		# says 64.  This picks up local overloads of base class methods too.
-		if(methods[i].flags == 65 and !_ignored_methods.has(object_info.get_path(), methods[i]['name'])):
+		# See MethodFlags in @GlobalScope
+		elif(methods[i].flags == 65 and !_ignored_methods.has(object_info.get_path(), methods[i]['name'])):
 			script_methods.add_local_method(methods[i])
-
 
 	if(object_info.get_method_strategy() == _utils.DOUBLE_STRATEGY.FULL):
 		# second pass is for anything not local
-		for i in range(methods.size()):
+		for j in range(methods.size()):
 			# 65 is a magic number for methods in script, though documentation
 			# says 64.  This picks up local overloads of base class methods too.
-			if(methods[i].flags != 65 and !_ignored_methods.has(object_info.get_path(), methods[i]['name'])):
-				script_methods.add_built_in_method(methods[i])
+			if(methods[j].flags != 65 and !_ignored_methods.has(object_info.get_path(), methods[j]['name'])):
+				script_methods.add_built_in_method(methods[j])
 
 	return script_methods
+
 
 func _get_inst_id_ref_str(inst):
 	var ref_str = 'null'
 	if(inst):
 		ref_str = str('instance_from_id(', inst.get_instance_id(),')')
 	return ref_str
+
 
 func _get_func_text(method_hash, path):
 	var override_count = null;
@@ -400,7 +539,11 @@ func _get_func_text(method_hash, path):
 func _get_temp_path(object_info):
 	var file_name = null
 	var extension = null
-	if(object_info.is_native()):
+
+	if(object_info.is_singleton()):
+		file_name = str(object_info.get_singleton_instance())
+		extension = "gd"
+	elif(object_info.is_native()):
 		file_name = object_info.get_native_class_name()
 		extension = 'gd'
 	else:
@@ -415,8 +558,10 @@ func _get_temp_path(object_info):
 	var to_return = _output_dir.plus_file(file_name)
 	return to_return
 
+
 func _load_double(fileOrString):
 	return fileOrString.load_it()
+
 
 func _double(obj_info, override_path=null):
 	var temp_path = _get_temp_path(obj_info)
@@ -424,11 +569,13 @@ func _double(obj_info, override_path=null):
 	_double_count += 1
 	return result
 
+
 func _double_script(path, make_partial, strategy):
 	var oi = ObjectInfo.new(path)
 	oi.make_partial_double = make_partial
 	oi.set_method_strategy(strategy)
 	return _double(oi).load_it()
+
 
 func _double_inner(path, subpath, make_partial, strategy):
 	var oi = ObjectInfo.new(path, subpath)
@@ -436,16 +583,26 @@ func _double_inner(path, subpath, make_partial, strategy):
 	oi.make_partial_double = make_partial
 	return _double(oi).load_it()
 
+
 func _double_scene(path, make_partial, strategy):
 	var oi = ObjectInfo.new(path)
 	oi.set_method_strategy(strategy)
 	oi.make_partial_double = make_partial
 	return _double_scene_and_script(oi)
 
+
 func _double_gdnative(native_class, make_partial, strategy):
 	var oi = ObjectInfo.new(null)
 	oi.set_native_class(native_class)
 	oi.set_method_strategy(strategy)
+	oi.make_partial_double = make_partial
+	return _double(oi).load_it()
+
+
+func _double_singleton(singleton_name, make_partial, strategy):
+	var oi = ObjectInfo.new(null)
+	oi.set_singleton_name(singleton_name)
+	oi.set_method_strategy(_utils.DOUBLE_STRATEGY.PARTIAL)
 	oi.make_partial_double = make_partial
 	return _double(oi).load_it()
 
@@ -455,6 +612,7 @@ func _double_gdnative(native_class, make_partial, strategy):
 func get_output_dir():
 	return _output_dir
 
+
 func set_output_dir(output_dir):
 	if(output_dir !=  null):
 		_output_dir = output_dir
@@ -462,67 +620,94 @@ func set_output_dir(output_dir):
 			var d = Directory.new()
 			d.make_dir_recursive(output_dir)
 
+
 func get_spy():
 	return _spy
+
 
 func set_spy(spy):
 	_spy = spy
 
+
 func get_stubber():
 	return _stubber
+
 
 func set_stubber(stubber):
 	_stubber = stubber
 
+
 func get_logger():
 	return _lgr
+
 
 func set_logger(logger):
 	_lgr = logger
 	_method_maker.set_logger(logger)
 
+
 func get_strategy():
 	return _strategy
+
 
 func set_strategy(strategy):
 	_strategy = strategy
 
+
 func get_gut():
 	return _gut
+
 
 func set_gut(gut):
 	_gut = gut
 
+
 func partial_double_scene(path, strategy=_strategy):
 	return _double_scene(path, true, strategy)
+
 
 # double a scene
 func double_scene(path, strategy=_strategy):
 	return _double_scene(path, false, strategy)
 
+
 # double a script/object
 func double(path, strategy=_strategy):
 	return _double_script(path, false, strategy)
 
+
 func partial_double(path, strategy=_strategy):
 	return _double_script(path, true, strategy)
+
 
 func partial_double_inner(path, subpath, strategy=_strategy):
 	return _double_inner(path, subpath, true, strategy)
 
+
 # double an inner class in a script
 func double_inner(path, subpath, strategy=_strategy):
 	return _double_inner(path, subpath, false, strategy)
+
 
 # must always use FULL strategy since this is a native class and you won't get
 # any methods if you don't use FULL
 func double_gdnative(native_class):
 	return _double_gdnative(native_class, false, _utils.DOUBLE_STRATEGY.FULL)
 
+
 # must always use FULL strategy since this is a native class and you won't get
 # any methods if you don't use FULL
 func partial_double_gdnative(native_class):
 	return _double_gdnative(native_class, true, _utils.DOUBLE_STRATEGY.FULL)
+
+
+func double_singleton(name):
+	return _double_singleton(name, false, _utils.DOUBLE_STRATEGY.PARTIAL)
+
+
+func partial_double_singleton(name):
+	return _double_singleton(name, true, _utils.DOUBLE_STRATEGY.PARTIAL)
+
 
 func clear_output_directory():
 	if(!_make_files):
@@ -550,14 +735,18 @@ func delete_output_directory():
 		var d = Directory.new()
 		d.remove(_output_dir)
 
+
 func add_ignored_method(path, method_name):
 	_ignored_methods.add(path, method_name)
+
 
 func get_ignored_methods():
 	return _ignored_methods
 
+
 func get_make_files():
 	return _make_files
+
 
 func set_make_files(make_files):
 	_make_files = make_files

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -438,6 +438,8 @@ func _write_file(obj_info, dest_path, override_path=null):
 
 	if(obj_info.is_singleton()):
 		super_name = obj_info.get_singleton_name()
+	else:
+		super_name = obj_info.get_path()
 
 	var f = FileOrString.new()
 	f._do_file = _make_files

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -365,7 +365,6 @@ var _make_files = false
 # used by tests for debugging purposes.
 var _print_source = false
 
-
 func _init(strategy=_utils.DOUBLE_STRATEGY.PARTIAL):
 	set_logger(_utils.get_logger())
 	_strategy = strategy

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -435,11 +435,12 @@ func _write_file(obj_info, dest_path, override_path=null):
 	var base_script = _get_base_script_text(obj_info, override_path)
 	var script_methods = _get_methods(obj_info)
 	var super_name = ""
+	var path = ""
 
 	if(obj_info.is_singleton()):
 		super_name = obj_info.get_singleton_name()
 	else:
-		super_name = obj_info.get_path()
+		path = obj_info.get_path()
 
 	var f = FileOrString.new()
 	f._do_file = _make_files
@@ -453,11 +454,11 @@ func _write_file(obj_info, dest_path, override_path=null):
 	f.store_string(base_script)
 
 	for i in range(script_methods.local_methods.size()):
-		f.store_string(_get_func_text(script_methods.local_methods[i], super_name))
+		f.store_string(_get_func_text(script_methods.local_methods[i], path, super_name))
 
 	for i in range(script_methods.built_ins.size()):
 		_stub_to_call_super(obj_info, script_methods.built_ins[i].name)
-		f.store_string(_get_func_text(script_methods.built_ins[i], super_name))
+		f.store_string(_get_func_text(script_methods.built_ins[i], path, super_name))
 
 	f.close()
 	if(_print_source):
@@ -528,12 +529,12 @@ func _get_inst_id_ref_str(inst):
 	return ref_str
 
 
-func _get_func_text(method_hash, path):
+func _get_func_text(method_hash, path, super=""):
 	var override_count = null;
 	if(_stubber != null):
 		override_count = _stubber.get_parameter_count(path, method_hash.name)
 
-	var text = _method_maker.get_function_text(method_hash, path, override_count) + "\n"
+	var text = _method_maker.get_function_text(method_hash, path, override_count, super) + "\n"
 
 	return text
 

--- a/addons/gut/gui/GutSceneTheme.tres
+++ b/addons/gut/gui/GutSceneTheme.tres
@@ -4,6 +4,7 @@
 font_path = "res://addons/gut/fonts/AnonymousPro-Regular.ttf"
 
 [sub_resource type="DynamicFont" id=10]
+size = 14
 font_data = SubResource( 9 )
 
 [resource]

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -202,14 +202,14 @@ func _get_arg_text(arg_array):
 
 
 # creates a call to the function in meta in the super's class.
-func _get_super_call_text(method_name, args):
+func _get_super_call_text(method_name, args, super_name=""):
 	var params = ''
 	for i in range(args.size()):
 		params += args[i].p_name
 		if(i != args.size() -1):
 			params += ', '
 
-	return str('.', method_name, '(', params, ')')
+	return str(super_name, '.', method_name, '(', params, ')')
 
 
 func _get_spy_call_parameters_text(args):
@@ -234,7 +234,7 @@ func _get_spy_call_parameters_text(args):
 # types whose defaults are supported will have their values.  If a datatype
 # is not supported and the parameter has a default, a warning message will be
 # printed and the declaration will return null.
-func get_function_text(meta, path=null, override_size=null):
+func get_function_text(meta, path=null, override_size=null, super_name=""):
 	var method_params = ''
 	var text = null
 	var result = _make_arg_array(meta, override_size)
@@ -260,7 +260,7 @@ func get_function_text(meta, path=null, override_size=null):
 			"func_decleration":decleration,
 			"method_name":meta.name,
 			"param_array":param_array,
-			"super_call":_get_super_call_text(meta.name, args)
+			"super_call":_get_super_call_text(meta.name, args, super_name)
 		})
 	return text
 

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -124,7 +124,7 @@ func _make_arg_array(method_meta, override_size):
 		if(i < dflt_start):
 			dflt_text = _make_stub_default(method_meta.name, i)
 		else:
-			var dflt_idx = dflt_start - i
+			var dflt_idx = i - dflt_start
 			var t = method_meta.args[i]['type']
 			if(_is_supported_default(t)):
 				# strings are special, they need quotes around the value
@@ -140,7 +140,7 @@ func _make_arg_array(method_meta, override_size):
 						dflt_text = str(_supported_defaults[t], str(method_meta.default_args[dflt_idx]).to_lower())
 				elif(t == TYPE_TRANSFORM):
 					#value will be 4 Vector3 and look like: 1, 0, 0, 0, 1, 0, 0, 0, 1 - 0, 0, 0
-					var sections = str(method_meta.default_args[i]).split("-")
+					var sections = str(method_meta.default_args[dflt_idx]).split("-")
 					var vecs = sections[0].split(",")
 					vecs.append_array(sections[1].split(","))
 					var v1 = str("Vector3(", vecs[0], ", ", vecs[1], ", ", vecs[2], ")")
@@ -150,7 +150,7 @@ func _make_arg_array(method_meta, override_size):
 					dflt_text = str(_supported_defaults[t], "(", v1, ", ", v2, ", ", v3, ", ", v4, ")")
 				elif(t == TYPE_TRANSFORM2D):
 					# value will look like:  ((1, 0), (0, 1), (0, 0))
-					var vectors = str(method_meta.default_args[i])
+					var vectors = str(method_meta.default_args[dflt_idx])
 					vectors = vectors.replace("((", "(")
 					vectors = vectors.replace("))", ")")
 					vectors = vectors.replace("(", "Vector2(")
@@ -262,6 +262,7 @@ func get_function_text(meta, path=null, override_size=null, super_name=""):
 			"param_array":param_array,
 			"super_call":_get_super_call_text(meta.name, args, super_name)
 		})
+
 	return text
 
 

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -53,20 +53,19 @@ const PARAM_PREFIX = 'p_'
 	# TYPE_DICTIONARY = 18 — Variable is of type Dictionary.
 	# TYPE_ARRAY = 19 — Variable is of type Array.
 	# TYPE_VECTOR2_ARRAY = 24 — Variable is of type PoolVector2Array.
+	# TYPE_TRANSFORM = 13 — Variable is of type Transform.
+	# TYPE_TRANSFORM2D = 8 — Variable is of type Transform2D.
+	# TYPE_RID = 16 — Variable is of type RID.
+	# TYPE_INT_ARRAY = 21 — Variable is of type PoolIntArray.
+	# TYPE_REAL_ARRAY = 22 — Variable is of type PoolRealArray.
 
 
-
-# TYPE_TRANSFORM2D = 8 — Variable is of type Transform2D.
 # TYPE_PLANE = 9 — Variable is of type Plane.
 # TYPE_QUAT = 10 — Variable is of type Quat.
 # TYPE_AABB = 11 — Variable is of type AABB.
 # TYPE_BASIS = 12 — Variable is of type Basis.
-# TYPE_TRANSFORM = 13 — Variable is of type Transform.
 # TYPE_NODE_PATH = 15 — Variable is of type NodePath.
-# TYPE_RID = 16 — Variable is of type RID.
 # TYPE_RAW_ARRAY = 20 — Variable is of type PoolByteArray.
-# TYPE_INT_ARRAY = 21 — Variable is of type PoolIntArray.
-# TYPE_REAL_ARRAY = 22 — Variable is of type PoolRealArray.
 # TYPE_STRING_ARRAY = 23 — Variable is of type PoolStringArray.
 # TYPE_VECTOR3_ARRAY = 25 — Variable is of type PoolVector3Array.
 # TYPE_COLOR_ARRAY = 26 — Variable is of type PoolColorArray.
@@ -88,12 +87,17 @@ func _init():
 	_supported_defaults[TYPE_STRING] = ''
 	_supported_defaults[TYPE_DICTIONARY] = ''
 	_supported_defaults[TYPE_VECTOR2_ARRAY] = ''
+	_supported_defaults[TYPE_RID] = ''
 
 	# These require a prefix for whatever default is provided
 	_supported_defaults[TYPE_VECTOR2] = 'Vector2'
 	_supported_defaults[TYPE_RECT2] = 'Rect2'
 	_supported_defaults[TYPE_VECTOR3] = 'Vector3'
 	_supported_defaults[TYPE_COLOR] = 'Color'
+	_supported_defaults[TYPE_TRANSFORM2D] = 'Transform2D'
+	_supported_defaults[TYPE_TRANSFORM] = 'Transform'
+	_supported_defaults[TYPE_INT_ARRAY] = 'PoolIntArray'
+	_supported_defaults[TYPE_REAL_ARRAY] = 'PoolRealArray'
 
 # ###############
 # Private
@@ -134,6 +138,27 @@ func _make_arg_array(method_meta, override_size):
 						dflt_text = str(_supported_defaults[t], 'null')
 					else:
 						dflt_text = str(_supported_defaults[t], str(method_meta.default_args[dflt_idx]).to_lower())
+				elif(t == TYPE_TRANSFORM):
+					#value will be 4 Vector3 and look like: 1, 0, 0, 0, 1, 0, 0, 0, 1 - 0, 0, 0
+					var sections = str(method_meta.default_args[i]).split("-")
+					var vecs = sections[0].split(",")
+					vecs.append_array(sections[1].split(","))
+					var v1 = str("Vector3(", vecs[0], ", ", vecs[1], ", ", vecs[2], ")")
+					var v2 = str("Vector3(", vecs[3], ", ", vecs[4], ", ", vecs[5], ")")
+					var v3 = str("Vector3(", vecs[6], ", ", vecs[7], ", ", vecs[8], ")")
+					var v4 = str("Vector3(", vecs[9], ", ", vecs[10], ", ", vecs[11], ")")
+					dflt_text = str(_supported_defaults[t], "(", v1, ", ", v2, ", ", v3, ", ", v4, ")")
+				elif(t == TYPE_TRANSFORM2D):
+					# value will look like:  ((1, 0), (0, 1), (0, 0))
+					var vectors = str(method_meta.default_args[i])
+					vectors = vectors.replace("((", "(")
+					vectors = vectors.replace("))", ")")
+					vectors = vectors.replace("(", "Vector2(")
+					dflt_text = str(_supported_defaults[t], "(", vectors, ")")
+				elif(t == TYPE_RID):
+					dflt_text = str(_supported_defaults[t], 'null')
+				elif(t in [TYPE_REAL_ARRAY, TYPE_INT_ARRAY]):
+					dflt_text = str(_supported_defaults[t], "()")
 
 				# Everything else puts the prefix (if one is there) form _supported_defaults
 				# in front.  The to_lower is used b/c for some reason the defaults for
@@ -176,6 +201,7 @@ func _get_arg_text(arg_array):
 	return text
 
 
+# creates a call to the function in meta in the super's class.
 func _get_super_call_text(method_name, args):
 	var params = ''
 	for i in range(args.size()):
@@ -198,6 +224,7 @@ func _get_spy_call_parameters_text(args):
 		called_with += ']'
 
 	return called_with
+
 
 # ###############
 # Public
@@ -238,11 +265,10 @@ func get_function_text(meta, path=null, override_size=null):
 	return text
 
 
+
+
 func get_logger():
 	return _lgr
 
-
 func set_logger(logger):
 	_lgr = logger
-
-

--- a/addons/gut/strutils.gd
+++ b/addons/gut/strutils.gd
@@ -121,8 +121,15 @@ func type2str(thing):
 			var double_path = _get_filename(thing.__gut_metadata_.path)
 			if(thing.__gut_metadata_.subpath != ''):
 				double_path += str('/', thing.__gut_metadata_.subpath)
+			elif(thing.__gut_metadata_.from_singleton != ''):
+				double_path = thing.__gut_metadata_.from_singleton + " Singleton"
 
-			str_thing += '(double of ' + double_path + ')'
+			var double_type = "double"
+			if(thing.__gut_metadata_.is_partial):
+				double_type = "partial-double"
+
+			str_thing += str("(", double_type, " of ", double_path, ")")
+
 			filename = null
 	elif(types.has(typeof(thing))):
 		if(!str_thing.begins_with('(')):

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -5,8 +5,22 @@ var target_subpath = null
 var parameters = null
 var stub_method = null
 var call_super = false
+
+# -- Paramter Override --
+# Parmater overrides are stored in here along with all the other stub info
+# so that you can chain stubbing parameter overrides along with all the
+# other stubbing.  This adds some complexity to the logic that tries to
+# find the correct stub for a call by a double.  Since an instance of this
+# class could be just a parameter override, or it could have been chained
+# we have to have _paramter_override_only so that we know when to tell the
+# difference.
 var parameter_count = -1
 var parameter_defaults = null
+# Anything that would make this stub not just an override of paramters
+# must set this flag to false.  This must be private bc the actual logic
+# to determine if this stub is only an override is more complicated.
+var _parameter_override_only = true
+# --
 
 const NOT_SET = '|_1_this_is_not_set_1_|'
 
@@ -18,6 +32,7 @@ func _init(target=null, method=null, subpath=null):
 func to_return(val):
 	return_val = val
 	call_super = false
+	_parameter_override_only = false
 	return self
 
 func to_do_nothing():
@@ -25,6 +40,7 @@ func to_do_nothing():
 
 func to_call_super():
 	call_super = true
+	_parameter_override_only = false
 	return self
 
 func when_passed(p1=NOT_SET,p2=NOT_SET,p3=NOT_SET,p4=NOT_SET,p5=NOT_SET,p6=NOT_SET,p7=NOT_SET,p8=NOT_SET,p9=NOT_SET,p10=NOT_SET):
@@ -49,13 +65,30 @@ func param_defaults(values):
 func has_param_override():
 	return parameter_count != -1
 
-func to_s():
-	var base_string = str(stub_target, '[', target_subpath, '].', stub_method)
+func is_param_override_only():
+	var to_return = false
 	if(has_param_override()):
-		base_string += str(' (params ', parameter_count, ' def=', parameter_defaults, ') ')
+		to_return = _parameter_override_only
+	return to_return
+
+func to_s():
+	var base_string = str(stub_target)
+	if(target_subpath != null):
+		base_string += str('[', target_subpath, '].')
+	else:
+		base_string += '.'
+	base_string += stub_method
+
+	if(has_param_override()):
+		base_string += str(' (param count override=', parameter_count, ' defaults=', parameter_defaults)
+		if(_parameter_override_only):
+			base_string += " ONLY"
+		base_string += ') '
 
 	if(call_super):
 		base_string += " to call SUPER"
-	else:
+
+	if(parameters != null):
 		base_string += str(' with params (', parameters, ') returns ', return_val)
+
 	return base_string

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -81,7 +81,7 @@ func to_s():
 
 	if(has_param_override()):
 		base_string += str(' (param count override=', parameter_count, ' defaults=', parameter_defaults)
-		if(_parameter_override_only):
+		if(is_param_override_only()):
 			base_string += " ONLY"
 		base_string += ') '
 

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -16,6 +16,7 @@ var _utils = load('res://addons/gut/utils.gd').get_instance()
 var _lgr = _utils.get_logger()
 var _strutils = _utils.Strutils.new()
 
+
 func _make_key_from_metadata(doubled):
 	var to_return = doubled.__gut_metadata_.path
 
@@ -25,6 +26,7 @@ func _make_key_from_metadata(doubled):
 		to_return += str('-', doubled.__gut_metadata_.subpath)
 
 	return to_return
+
 
 # Creates they key for the returns hash based on the type of object passed in
 # obj could be a string of a path to a script with an optional subpath or
@@ -80,40 +82,34 @@ func _find_stub(obj, method, parameters=null, find_overloads=false):
 			key = _make_key_from_metadata(obj)
 
 	if(returns.has(key) and returns[key].has(method)):
-		var param_idx = -1
-		var null_idx = -1
-		var overloads_idx = -1
+		var param_match = null
+		var null_match = null
+		var overload_match = null
 
 		for i in range(returns[key][method].size()):
 			if(returns[key][method][i].parameters == parameters):
-				param_idx = i
-			if(returns[key][method][i].parameters == null):
-				null_idx = i
-			if(returns[key][method][i].has_param_override()):
-				overloads_idx = i
+				param_match = returns[key][method][i]
 
-		if(find_overloads and overloads_idx != -1):
-			to_return = returns[key][method][overloads_idx]
+			if(returns[key][method][i].parameters == null):
+				null_match = returns[key][method][i]
+
+			if(returns[key][method][i].has_param_override()):
+				overload_match = returns[key][method][i]
+
+		if(find_overloads and overload_match != null):
+			to_return = overload_match
 		# We have matching parameter values so return the stub value for that
-		elif(param_idx != -1):
-			to_return = returns[key][method][param_idx]
+		elif(param_match != null):
+			to_return = param_match
 		# We found a case where the parameters were not specified so return
-		# parameters for that
-		elif(null_idx != -1):
-			to_return = returns[key][method][null_idx]
+		# parameters for that.  Only do this if the null match is not *just*
+		# a paramerter override stub.
+		elif(null_match != null and !null_match.is_param_override_only()):
+			to_return = null_match
 		else:
 			_lgr.warn(str('Call to [', method, '] was not stubbed for the supplied parameters ', parameters, '.  Null was returned.'))
 
 	return to_return
-
-# TODO: This method is only used in tests and should be refactored out.  It
-# does not support inner classes and isn't helpful.
-func set_return(obj, method, value, parameters=null):
-	var key = _add_obj_method(obj, method)
-	var sp = _utils.StubParams.new(key, method)
-	sp.parameters = parameters
-	sp.return_val = value
-	returns[key][method].append(sp)
 
 
 func add_stub(stub_params):
@@ -147,6 +143,7 @@ func get_return(obj, method, parameters=null):
 	else:
 		return null
 
+
 func should_call_super(obj, method, parameters=null):
 	if(_utils.non_super_methods.has(method)):
 		return false
@@ -156,18 +153,19 @@ func should_call_super(obj, method, parameters=null):
 	var is_partial = false
 	if(typeof(obj) != TYPE_STRING): # some stubber tests test with strings
 		is_partial = obj.__gut_metadata_.is_partial
-	var should_call_super = is_partial
+	var should = is_partial
 
 	if(stub_info != null):
-		should_call_super = stub_info.call_super
+		should = stub_info.call_super
 	elif(!is_partial):
 		# this log message is here because of how the generated doubled scripts
 		# are structured.  With this log msg here, you will only see one
 		# "unstubbed" info instead of multiple.
 		_lgr.info('Unstubbed call to ' + method + '::' + _strutils.type2str(obj))
-		should_call_super = false
+		should = false
 
-	return should_call_super
+	return should
+
 
 func get_parameter_count(obj, method):
 	var to_return = null
@@ -188,20 +186,20 @@ func get_default_value(obj, method, p_index):
 
 		to_return = stub_info.parameter_defaults[p_index]
 
-	# print('get_default ', obj, '.', method, '  ', p_index, ' = ', to_return)
 	return to_return
-
-
 
 
 func clear():
 	returns.clear()
 
+
 func get_logger():
 	return _lgr
 
+
 func set_logger(logger):
 	_lgr = logger
+
 
 func to_s():
 	var text = ''
@@ -211,4 +209,8 @@ func to_s():
 			text += str("\t", method, "\n")
 			for i in range(returns[thing][method].size()):
 				text += "\t\t" + returns[thing][method][i].to_s() + "\n"
+
+	if(text == ''):
+		text = 'Stubber is empty';
+
 	return text

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1082,6 +1082,22 @@ func _validate_assert_setget_called_input(type, name_property
 	obj.free()
 	return result
 
+# ------------------------------------------------------------------------------
+# Validates the singleton_name is a string and exists.  Errors when conditions
+# are not met.  Returns true/false if singleton_name is valid or not.
+# ------------------------------------------------------------------------------
+func _validate_singleton_name(singleton_name):
+	var is_valid = true
+	if(typeof(singleton_name) != TYPE_STRING):
+		_lgr.error("double_singleton requires a Godot singleton name, you passed " + _str(singleton_name))
+		is_valid = false
+	elif(!ClassDB.class_exists(singleton_name)):
+		var txt = str("The singleton [", singleton_name, "] could not be found.  ",
+					"Check the GlobalScope page for a list of singletons.")
+		_lgr.error(txt)
+		is_valid = false
+	return is_valid
+
 
 # ------------------------------------------------------------------------------
 # Asserts the given setter and getter methods are called when the given property
@@ -1350,6 +1366,23 @@ func partial_double(thing, p2=null, p3=null):
 
 	return _smart_double(double_info)
 
+# ------------------------------------------------------------------------------
+# Doubles a Godot singleton
+# ------------------------------------------------------------------------------
+func double_singleton(singleton_name):
+	var to_return = null
+	if(_validate_singleton_name(singleton_name)):
+		to_return = gut.get_doubler().double_singleton(singleton_name)
+	return to_return
+
+# ------------------------------------------------------------------------------
+# Partial Doubles a Godot singleton
+# ------------------------------------------------------------------------------
+func partial_double_singleton(singleton_name):
+	var to_return = null
+	if(_validate_singleton_name(singleton_name)):
+		to_return = gut.get_doubler().partial_double_singleton(singleton_name)
+	return to_return
 
 # ------------------------------------------------------------------------------
 # Specifically double a scene

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -295,8 +295,8 @@ func write_file(path, content):
 	if(result == OK):
 		f.store_string(content)
 		f.close()
-	return result
 
+	return result
 
 # ------------------------------------------------------------------------------
 # true if what is passed in is null or an empty string.
@@ -379,3 +379,11 @@ func pretty_print(dict):
 
 func get_script_text(obj):
 	return obj.get_script().get_source_code()
+
+
+func get_singleton_by_name(name):
+	var source = str("var singleton = ", name)
+	var script = GDScript.new()
+	script.set_source_code(source)
+	script.reload()
+	return script.new().singleton

--- a/test/integration/test_doubler_and_spy.gd
+++ b/test/integration/test_doubler_and_spy.gd
@@ -54,3 +54,8 @@ class TestBoth:
 		inst.set_position(Vector2(20, 20))
 		assert_true(_spy.was_called(inst, 'set_position'))
 		assert_true(_spy.was_called(inst, 'set_position', [Vector2(20, 20)]))
+
+	func test_can_spy_on_singleton_doubles():
+		var inst  = _doubler.partial_double_singleton("Input").new()
+		inst.is_action_just_pressed("foobar")
+		assert_true(_spy.was_called(inst, "is_action_just_pressed"))

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -2,6 +2,7 @@ extends "res://addons/gut/test.gd"
 
 var Stubber = load('res://addons/gut/stubber.gd')
 var Doubler = load('res://addons/gut/doubler.gd')
+var StubParams = load('res://addons/gut/stub_params.gd')
 
 const DOUBLE_ME_PATH = 'res://test/resources/doubler_test_objects/double_me.gd'
 const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_me_scene.tscn'
@@ -22,6 +23,8 @@ func before_each():
 
 	gr.stubber = Stubber.new()
 
+	gr.doubler.set_stubber(gr.stubber)
+
 func after_all():
 	gut.file_delete(TEMP_FILES)
 
@@ -29,60 +32,65 @@ func after_all():
 # 	gr.doubler.clear_output_directory()
 
 func test_doubled_have_ref_to_stubber():
-	gr.doubler.set_stubber(gr.stubber)
 	var d = gr.doubler.double(DOUBLE_ME_PATH).new()
 	assert_eq(d.__gut_metadata_.stubber, gr.stubber)
 
 func test_stubbing_method_returns_expected_value():
-	gr.doubler.set_stubber(gr.stubber)
 	var D = gr.doubler.double(DOUBLE_ME_PATH)
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'get_value', 7)
+	var sp = StubParams.new(DOUBLE_ME_PATH, 'get_value').to_return(7)
+	gr.stubber.add_stub(sp)
 	assert_eq(D.new().get_value(), 7)
 
 func test_can_stub_non_local_methods():
-	gr.doubler.set_stubber(gr.stubber)
 	var D = gr.doubler.double(DOUBLE_ME_PATH)
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'get_position', Vector2(11, 11))
+	var sp = StubParams.new(DOUBLE_ME_PATH, 'get_position').to_return(Vector2(11, 11))
+	gr.stubber.add_stub(sp)
 	assert_eq(D.new().get_position(), Vector2(11, 11))
 
 func test_when_non_local_methods_not_stubbed_super_is_returned():
-	gr.doubler.set_stubber(gr.stubber)
 	var D = gr.doubler.double(DOUBLE_EXTENDS_NODE2D)
 	var d = autofree(D.new())
 	assert_eq(d.get_rotation(), 0.0)
 
 func test_can_stub_doubled_instance_values():
-	gr.doubler.set_stubber(gr.stubber)
 	var D = gr.doubler.double(DOUBLE_ME_PATH)
 	var d1 = D.new()
 	var d2 = D.new()
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'get_value', 5)
-	gr.stubber.set_return(d1, 'get_value', 10)
+
+	var sp1 = StubParams.new(DOUBLE_ME_PATH, 'get_value').to_return(5)
+	gr.stubber.add_stub(sp1)
+	var sp2 = StubParams.new(d1, 'get_value').to_return(10)
+	gr.stubber.add_stub(sp2)
+
 	assert_eq(d1.get_value(), 10, 'instance gets right value')
 	assert_eq(d2.get_value(), 5, 'other instance gets class value')
 
 func test_stubbed_methods_send_parameters_in_callback():
-	gr.doubler.set_stubber(gr.stubber)
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'has_one_param', 10, [1])
+	var sp = StubParams.new(DOUBLE_ME_PATH, 'has_one_param')
+	sp.to_return(10).when_passed(1)
+	gr.stubber.add_stub(sp)
 	var d = gr.doubler.double(DOUBLE_ME_PATH).new()
 	assert_eq(d.has_one_param(1), 10)
 	assert_eq(d.has_one_param('asdf'), null)
 
 func test_stub_with_nothing_works_with_parameters():
-	gr.doubler.set_stubber(gr.stubber)
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'has_one_param', 5)
-	gr.stubber.set_return(DOUBLE_ME_PATH, 'has_one_param', 10, [1])
+	var sp1 = StubParams.new(DOUBLE_ME_PATH, 'has_one_param').to_return(5)
+	var sp2 = StubParams.new(DOUBLE_ME_PATH, 'has_one_param')
+	sp2.to_return(10).when_passed(1)
+	gr.stubber.add_stub(sp1)
+	gr.stubber.add_stub(sp2)
+
 	var d = gr.doubler.double(DOUBLE_ME_PATH).new()
 	assert_eq(d.has_one_param(), 5)
 
 func test_can_stub_doubled_scenes():
-	gr.doubler.set_stubber(gr.stubber)
-	gr.stubber.set_return(DOUBLE_ME_SCENE_PATH, 'return_hello', 'world')
+	var sp = StubParams.new(DOUBLE_ME_SCENE_PATH, 'return_hello')
+	sp.to_return('world')
+	gr.stubber.add_stub(sp)
 	var inst = autofree(gr.doubler.double_scene(DOUBLE_ME_SCENE_PATH).instance())
 	assert_eq(inst.return_hello(), 'world')
 
 func test_when_stubbed_to_call_super_then_super_is_called():
-	gr.doubler.set_stubber(gr.stubber)
 	var doubled = gr.doubler.double(DOUBLE_ME_PATH).new()
 	var params = _utils.StubParams.new(doubled, 'set_value').to_call_super()
 	gr.stubber.add_stub(params)
@@ -90,45 +98,39 @@ func test_when_stubbed_to_call_super_then_super_is_called():
 	assert_eq(doubled._value, 99)
 
 func test_can_stub_native_methods():
-	gr.doubler.set_stubber(gr.stubber)
 	var d_node2d = autofree(gr.doubler.double_gdnative(Node2D).new())
 	var params = _utils.StubParams.new(d_node2d, 'get_position').to_return(-1)
 	gr.stubber.add_stub(params)
 	assert_eq(d_node2d.get_position(), -1)
 
 func test_partial_double_of_Node2D_returns_super_values():
-	gr.doubler.set_stubber(gr.stubber)
 	var pd_node_2d  = autofree(gr.doubler.partial_double_gdnative(Node2D).new())
 	#pd_node_2d  = gr.doubler.partial_double_gdnative(Node2D).new()
 	assert_eq(pd_node_2d.is_blocking_signals(), false)
 
 func test_can_stub_all_Node2D_doubles():
-	gr.doubler.set_stubber(gr.stubber)
 	var d_node2d = autofree(gr.doubler.double_gdnative(Node2D).new())
 	var params = _utils.StubParams.new(Node2D, 'get_position').to_return(-1)
 	gr.stubber.add_stub(params)
 	assert_eq(d_node2d.get_position(), -1)
 
 func test_init_is_never_stubbed_to_call_super():
-	gr.doubler.set_stubber(gr.stubber)
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
 	assert_false(gr.stubber.should_call_super(inst, '_init', []))
 
 func test_ready_is_never_stubbed_to_call_super():
-	gr.doubler.set_stubber(gr.stubber)
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
 	assert_false(gr.stubber.should_call_super(inst, '_ready', []))
 
 func test_stubbing_init_to_call_super_generates_error():
 	var err_count = gr.stubber.get_logger().get_errors().size()
-	gr.doubler.set_stubber(gr.stubber)
+
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
 	var params = _utils.StubParams.new(inst, '_init').to_call_super()
 	gr.stubber.add_stub(params)
 	assert_eq(gr.stubber.get_logger().get_errors().size(), err_count + 1)
 
 func test_stubbing_init_to_call_super_does_not_generate_stub():
-	gr.doubler.set_stubber(gr.stubber)
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
 	var params = _utils.StubParams.new(inst, '_init').to_call_super()
 	gr.stubber.add_stub(params)
@@ -136,7 +138,7 @@ func test_stubbing_init_to_call_super_does_not_generate_stub():
 
 func  test_you_cannot_stub_init_to_do_nothing():
 	var err_count = gr.stubber.get_logger().get_errors().size()
-	gr.doubler.set_stubber(gr.stubber)
+
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
 	var params = _utils.StubParams.new(inst, '_init').to_do_nothing()
 	gr.stubber.add_stub(params)

--- a/test/integration/test_gut_and_stubber.gd
+++ b/test/integration/test_gut_and_stubber.gd
@@ -2,6 +2,7 @@ extends "res://addons/gut/test.gd"
 
 var Gut = load('res://addons/gut/gut.gd')
 var Test = load('res://addons/gut/test.gd')
+var StubParams = load('res://addons/gut/stub_params.gd')
 
 const DOUBLE_ME_PATH = 'res://test/resources/doubler_test_objects/double_me.gd'
 const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_me_scene.tscn'
@@ -15,7 +16,8 @@ func test_can_get_stubber():
 # PURE testing but it appears to cover the bases ok.
 # ------
 func test_stubber_cleared_between_tests_setup():
-	gut.get_stubber().set_return('thing', 'method', 5)
+	var sp = StubParams.new('thing', 'method').to_return(5)
+	gut.get_stubber().add_stub(sp)
 	gut.p('this sets up for next test')
 
 func test_stubber_cleared_between_tests():

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -318,7 +318,7 @@ class TestOverridingParameters:
 		var inst =  _test.double(DEFAULT_PARAMS_PATH).new()
 		var ret_val = inst.return_passed()
 		assert_eq(ret_val, '12')
-		# print(gut.get_stubber().to_s())
+		print(_gut.get_stubber().to_s())
 
 
 	func test_issue_246_rpc_id_varargs():
@@ -355,6 +355,7 @@ class TestOverridingParameters:
 		var inst =  _test.partial_double(DEFAULT_PARAMS_PATH).new()
 		var ret_val = inst.return_passed('a', 'b')
 		assert_eq(ret_val, 'ab')
+		print(_gut.get_stubber().to_s())
 
 
 class TestSingletonDoubling:

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -54,6 +54,7 @@ class TestBasics:
 		doubled.is_blocking_signals()
 		gr.test.assert_called(doubled, 'is_blocking_signals')
 		assert_eq(gr.test.get_pass_count(), 1)
+		pause_before_teardown()
 
 	func test_when_strategy_is_partial_then_supers_are_NOT_spied_in_scenes():
 		var doubled = gr.test.double_scene(DOUBLE_ME_SCENE_PATH, DOUBLE_STRATEGY.PARTIAL).instance()
@@ -86,6 +87,12 @@ class TestBasics:
 		var n = autofree(Node.new())
 		gr.test.stub(n, 'something').to_return(3)
 		assert_eq(gr.test.get_logger().get_errors().size(), 1)
+
+	func test_when_stub_passed_singleton_it_generates_error():
+		gr.test.stub(Input, "is_action_just_pressed").to_return(true)
+		assert_eq(gr.test.get_logger().get_errors().size(), 1)
+
+
 
 class TestIgnoreMethodsWhenDoubling:
 	extends "res://test/gut_test.gd"
@@ -126,6 +133,7 @@ class TestIgnoreMethodsWhenDoubling:
 		m_inst.return_hello()
 		# since it is ignored it should not have been caught by the stubber
 		_test.assert_not_called(m_inst, 'return_hello')
+
 
 class TestTestsSmartDoubleMethod:
 	extends "res://test/gut_test.gd"
@@ -348,3 +356,46 @@ class TestOverridingParameters:
 		var ret_val = inst.return_passed('a', 'b')
 		assert_eq(ret_val, 'ab')
 
+
+class TestSingletonDoubling:
+	extends "res://test/gut_test.gd"
+
+	var _test_gut = null
+	var _test = null
+
+	func before_each():
+		_test_gut = Gut.new()
+		_test_gut._should_print_versions = false
+		_test = Test.new()
+		_test.gut = _test_gut
+
+		add_child_autofree(_test_gut)
+		add_child_autofree(_test)
+
+	func test_double_gives_double():
+		var inst = _test.double_singleton("Input").new()
+		assert_eq(inst.__gut_metadata_.from_singleton, "Input")
+
+	func test_partial_gives_partial_double():
+		var inst = _test.partial_double_singleton("Input").new()
+		assert_true(inst.__gut_metadata_.is_partial)
+
+	func test_double_errors_if_not_passed_a_string():
+		var value = _test.double_singleton(Node2D)
+		assert_errored(_test)
+		assert_null(value, "null should be returned")
+
+	func test_double_errors_if_class_name_does_not_exist():
+		var value = _test.double_singleton("asdf")
+		assert_errored(_test)
+		assert_null(value, "null should be returned")
+
+	func test_partial_double_errors_if_not_passed_a_string():
+		var value = _test.partial_double_singleton(Node2D)
+		assert_errored(_test)
+		assert_null(value, "null should be returned")
+
+	func test_partial_double_errors_if_class_name_does_not_exist():
+		var value = _test.partial_double_singleton("asdf")
+		assert_errored(_test)
+		assert_null(value, "null should be returned")

--- a/test/resources/stub_test_objects/has_stub_metadata.gd
+++ b/test/resources/stub_test_objects/has_stub_metadata.gd
@@ -1,4 +1,5 @@
 var __gut_metadata_ = {
     path = '',
-    subpath=''
+    subpath='',
+    from_singleton='',
 }

--- a/test/resources/stub_test_objects/to_stub.gd
+++ b/test/resources/stub_test_objects/to_stub.gd
@@ -5,7 +5,8 @@ var __gut_metadata_ = {
 	path='res://test/resources/stub_test_objects/to_stub.gd',
 	subpath='',
 	stubber=null,
-	spy=null
+	spy=null,
+	from_singleton = "",
 }
 func get_value():
 	return value

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -345,8 +345,8 @@ class TestDefaultParameters:
 		"VisualServer"		# TYPE_REAL_ARRAY, TYPE_INT_ARRAY
 	]
 	func test_various_singletons_that_introduced_new_default_types(singleton = use_parameters(singletons)):
-		pending();return;
-		assert_not_null(doubler.double_singleton(singleton).new())
+		var inst = doubler.double_singleton(singleton).new()
+		assert_not_null(inst)
 
 
 class TestDoubleInnerClasses:
@@ -539,7 +539,6 @@ class TestDoubleSingleton:
 
 	func test_partial_double_gets_implementation():
 		var doubled = _doubler.partial_double_singleton("Input").new()
-		print(get_instance_source(doubled))
 		assert_false(doubled.is_action_just_pressed("foobar"))
 
 	func test_double_gets_constants():
@@ -570,11 +569,11 @@ class TestDoubleSingleton:
 		"Engine", "Geometry", "Input",
 		"InputMap", "IP", "JavaClassWrapper",
 		"JavaScript", "JSON", "Marshalls",
-		"OS", "Performance", #"Physics2DServer",
-		#"PhysicsServer",
+		"OS", "Performance", "Physics2DServer",
+		"PhysicsServer",
 		"ProjectSettings", "ResourceLoader",
 		"ResourceSaver", "TranslationServer", "VisualScriptEditor",
-		#"VisualServer",
+		"VisualServer",
 		# these two were missed by print_instanced_ClassDB_classes but were in
 		# the global scope list.
 		"ClassDB", "EditorNavigationMeshGenerator"

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -454,6 +454,7 @@ class TestPartialDoubles:
 
 		assert_null(double.get_value(), 'double get_value')
 		assert_eq(p_double.get_value(), 0, 'partial get_value')
+		print(doubler.get_stubber().to_s())
 
 
 class TestDoubleGDNaviteClasses:

--- a/test/unit/test_strutils.gd
+++ b/test/unit/test_strutils.gd
@@ -5,6 +5,7 @@ class TestType2Str:
 
 	var strutils = load('res://addons/gut/strutils.gd').new()
 
+
 	class ExtendsControl:
 		extends Control
 
@@ -85,6 +86,18 @@ class TestType2Str:
 		var d = double(InnerClasses, 'InnerA').new()
 		assert_eq(strutils.type2str(d), str(d) + '(double of inner_classes.gd/InnerA)')
 
+	func test_partial_double():
+		var d = partial_double(DOUBLE_ME_PATH).new()
+		assert_string_contains(strutils.type2str(d), "partial-double")
+
+	func test_singleton_double_includes_singleton_name():
+		var d = double_singleton("Input").new()
+		assert_string_contains(strutils.type2str(d), "double of Input")
+
+	func test_singleton_double_includes_word_singleton():
+		var d = double_singleton("Input").new()
+		assert_string_contains(strutils.type2str(d), "Singleton")
+
 	func test_assert_null():
 		assert_eq(strutils.type2str(null), str(null))
 
@@ -104,14 +117,14 @@ class TestType2Str:
 	func test_returns_null_for_just_freed_objects():
 		var n = autofree(Node.new())
 		n.free()
-		assert_eq(strutils.type2str(n), '[Deleted Object]', 'sometimes fails based on timing.')
+		assert_eq(str(n), '[Deleted Object]', 'sometimes fails based on timing.')
 
 	func test_memory_leak():
-		gut.p(str(gut.get_orphan_counter().orphan_count(), ' t-1'))
+		print(gut.get_orphan_counter().orphan_count(), ' t-1')
 		var a = Node
-		gut.p(str(gut.get_orphan_counter().orphan_count(), ' t-2'))
+		print(gut.get_orphan_counter().orphan_count(), ' t-2')
 		var txt = strutils.type2str(a)
-		gut.p(str(gut.get_orphan_counter().orphan_count(), ' t-3'))
+		print(gut.get_orphan_counter().orphan_count(), ' t-3')
 		assert_no_new_orphans()
 
 

--- a/test/unit/test_stub_params.gd
+++ b/test/unit/test_stub_params.gd
@@ -1,4 +1,4 @@
-extends "res://addons/gut/test.gd"
+extends GutTest
 
 # test.gd has a StubParams variable already so this has to have a
 # different name.  I thought it was too vague to just use the one
@@ -61,7 +61,7 @@ func test_to_do_nothing_returns_self():
 	assert_eq(sp.to_do_nothing(), sp)
 
 # --------------
-# Paramter Count and Defaults
+# Parameter Count and Defaults
 # --------------
 func test_param_count_returns_self():
 	var val = gr.stub_params.param_count(3)
@@ -95,3 +95,54 @@ func test_has_param_override_is_false_by_default():
 func test_when_param_count_set_has_param_override_is_true():
 	gr.stub_params.param_count(3)
 	assert_true(gr.stub_params.has_param_override())
+
+# --------------
+# Parameter Override Only
+# --------------
+func test_is_paramter_override_only_false_by_default():
+	var sp = StubParamsClass.new()
+	assert_false(sp.is_param_override_only())
+
+func test_param_count_override_params_sets_flag():
+	var sp = StubParamsClass.new()
+	sp.param_count(10)
+	assert_true(sp.is_param_override_only())
+
+func test_setting_defaults_sets_flag():
+	var sp = StubParamsClass.new()
+	sp.param_defaults([1, 2, 3])
+	assert_true(sp.is_param_override_only())
+
+func test_to_return_sets_override_flag():
+	var sp = StubParamsClass.new()
+	sp.param_count(10)
+	sp.to_return(7)
+	assert_false(sp.is_param_override_only())
+
+func test_order_of_calls_with_to_return_does_not_matter():
+	var sp = StubParamsClass.new()
+	sp.to_return(7)
+	sp.param_count(10)
+	assert_false(sp.is_param_override_only())
+
+func test_to_do_nothing_sets_flag():
+	var sp = StubParamsClass.new()
+	sp.param_count(10)
+	sp.to_do_nothing()
+	assert_false(sp.is_param_override_only())
+
+func test_to_call_super_sets_flag():
+	var sp = StubParamsClass.new()
+	sp.param_count(10)
+	sp.to_call_super()
+	assert_false(sp.is_param_override_only())
+
+# I think this is how it should work.  You may want (if you even can) to
+# stub the paramters of a double when it is passed specific values.  In
+# all other cases that I can think of, you will end up calling one of the
+# other stub methods that flip the flag.
+func test_when_passed_does_not_set_flag():
+	var sp = StubParamsClass.new()
+	sp.param_count(10)
+	sp.when_passed(1, 2, 3)
+	assert_true(sp.is_param_override_only())

--- a/test/unit/test_stubber.gd
+++ b/test/unit/test_stubber.gd
@@ -12,6 +12,20 @@ var ToStub = load(TO_STUB_PATH)
 const HAS_STUB_METADATA_PATH = 'res://test/resources/stub_test_objects/has_stub_metadata.gd'
 var HasStubMetadata = load(HAS_STUB_METADATA_PATH)
 
+
+# The set_return method on Stubber was only used in tests.  I got lazy and
+# made this to circumvent it being removed.
+class HackedStubber:
+	extends 'res://addons/gut/stubber.gd'
+	var StubParams = load('res://addons/gut/stub_params.gd')
+
+	func set_return(obj, method, value):
+		var sp = StubParams.new(obj, method)
+		sp.to_return(value)
+		add_stub(sp)
+		return sp
+
+
 var gr = {
 	stubber = null
 }
@@ -29,13 +43,10 @@ func print_info(c):
 	print('script of inst = ', c.new().get_script().get_path())
 
 func before_each():
-	gr.stubber = Stubber.new()
+	gr.stubber = HackedStubber.new()
 
 func test_has_logger():
 	assert_has_logger(gr.stubber)
-
-func test_can_set_return():
-	gr.stubber.set_return('some_path', 'some_method', 7)
 
 func test_can_get_return_value():
 	gr.stubber.set_return('some_path', 'some_method', 7)
@@ -48,7 +59,7 @@ func test_can_get_return_for_multiple_methods():
 	assert_eq(gr.stubber.get_return('some_path', 'method1'), 1, 'method1 returns 1')
 	assert_eq(gr.stubber.get_return('some_path', 'method2'), 2, 'method1 returns 2')
 
-func test_can_set_return_with_class():
+func test_can_stub_return_with_class():
 	gr.stubber.set_return(ToStub, 'get_value', 0)
 	assert_eq(gr.stubber.get_return(ToStub, 'get_value'), 0)
 
@@ -109,13 +120,15 @@ func test_will_use_instance_instead_of_metadata():
 	assert_eq(gr.stubber.get_return(inst, 'some_method'), 100)
 
 func test_can_stub_with_parameters():
-	gr.stubber.set_return('some_path', 'some_method', 7, [1, 2])
+	var sp = gr.stubber.set_return('some_path', 'some_method', 7)
+	sp.when_passed(1, 2)
 	var val = gr.stubber.get_return('some_path', 'some_method', [1, 2])
 	assert_eq(val, 7)
 
 func test_parameter_stubs_return_different_values():
 	gr.stubber.set_return('some_path', 'some_method', 5)
-	gr.stubber.set_return('some_path', 'some_method', 10, [1, 2])
+	var sp = gr.stubber.set_return('some_path', 'some_method', 10)
+	sp.when_passed(1, 2)
 	var with_params = gr.stubber.get_return('some_path', 'some_method', [1, 2])
 	var wo_params = gr.stubber.get_return('some_path', 'some_method')
 	assert_eq(with_params, 10, 'With params should give correct value')
@@ -123,7 +136,8 @@ func test_parameter_stubs_return_different_values():
 
 func test_stub_with_nothing_works_with_no_parameters():
 	gr.stubber.set_return('some_path', 'has_one_param', 5)
-	gr.stubber.set_return('some_path', 'has_one_param', 10, [1])
+	var sp = gr.stubber.set_return('some_path', 'has_one_param', 10)
+	sp.when_passed(1)
 	assert_eq(gr.stubber.get_return('some_path', 'has_one_param'), 5)
 
 func test_withStubParams_can_set_return():

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1097,7 +1097,7 @@ class TestExtendAsserts:
 class TestAssertTypeOf:
 	extends BaseTestClass
 	func before_all():
-		_print_all_subtests  =  true
+		_print_all_subtests = false
 
 	func test_passes_when_object_is_of_type():
 		var c = Color(1, 1, 1, 1)
@@ -1477,6 +1477,7 @@ class TestReplaceNode:
 		gr.test.replace_node(_arena, old, replacement)
 		assert_errored(gr.test)
 
+
 class TestAssertIsFreed:
 	extends BaseTestClass
 
@@ -1512,6 +1513,7 @@ class TestAssertIsFreed:
 		obj.queue_free()
 		gr.test.assert_not_freed(obj, "Object4")
 		assert_pass(gr.test)
+
 
 class TestConnectionAsserts:
 	extends BaseTestClass
@@ -1600,6 +1602,7 @@ class TestParameterizedTests:
 		var ph = gr.test_with_gut.gut.get_parameter_handler()
 		gr.test_with_gut.use_parameters(['a', 'b', 'c', 'd'])
 		assert_eq(gr.test_with_gut.gut.get_parameter_handler(), ph)
+
 
 class TestMemoryMgmt:
 	extends 'res://addons/gut/test.gd'
@@ -1723,6 +1726,7 @@ class TestTestStateChecking:
 		_run_test('TestUseIsFailingInAfterAll', 'test_nothing')
 		assert_eq(_gut.get_logger().get_errors().size(), 1)
 
+
 class TestPassFailTestMethods:
 	extends BaseTestClass
 
@@ -1790,13 +1794,12 @@ class TestCompareDeepShallow:
 		gr.test.assert_ne_shallow({'a':1}, {'a':1})
 		assert_fail(gr.test)
 
+
 class TestAssertSetgetCalled:
 	extends BaseTestClass
 
-
 	const TestNode = preload("res://test/resources/test_assert_setget_test_objects/test_node.gd")
 	const TestScene = preload("res://test/resources/test_assert_setget_test_objects/TestScene.tscn")
-
 
 	var bad_input = [
 		# Passing instance instead of classe

--- a/test/unit/test_utils.gd
+++ b/test/unit/test_utils.gd
@@ -55,6 +55,12 @@ func test_get_native_class_name_does_not_generate_orphans():
 	utils.free()
 	assert_no_new_orphans()
 
+func test_get_native_class_name_does_not_free_references():
+	var utils = autofree(Utils.new())
+	var n = utils.get_native_class_name(InputEventKey)
+	pass_test("we got here")
+
+
 class TestVersionCheck:
 	extends 'res://addons/gut/test.gd'
 
@@ -99,4 +105,3 @@ func test_latest_version_if_version_is_old_warning_is_on():
 	assert_not_null(p, "should have a child http request")
 	yield(yield_to(p,"request_completed",2),YIELD)
 	assert_true(utils.should_display_latest_version,"this should fail only if you dont have internet connection")
-			


### PR DESCRIPTION
Create doubles and partial doubles of Godot Singletons such as `Input`, `OS`, `JavaScript`.  Any call that results in calling the super method will punch through to the global singleton instance.
```
func test_foo():
  var player = Fighter.new()
  var dbl_input = double_singleton('Input')
  # For doubles of singletons to work, your classes must have a local reference
  # to the singleton that can be overidden with the double.
  player.local_input_ref = dbl_input
  stub(dbl_input, 'is_action_just_pressed').to_return(true).when_passed('jump')
```

```
func test_bar():
  var dbl_os = partial_double_singleton('OS')
  stub(dbl_os, 'name').to_return('iOS')

  var thing = Foo.new()
  thing.local_os_ref = dbl_os

  # assert something happens when the OS name is 'iOS'
```

