### PR TITLE
Run in viewport

### DIFF
--- a/.gut_editor_config.json
+++ b/.gut_editor_config.json
@@ -22,7 +22,7 @@
  "post_run_script": "",
  "pre_run_script": "",
  "prefix": "test_",
- "selected": "test_totals_testing.gd",
+ "selected": "test_gut.gd",
  "should_exit": false,
  "should_exit_on_success": false,
  "should_maximize": false,
@@ -31,7 +31,16 @@
  "tests": [
 
  ],
- "unit_test_name": null,
+ "unit_test_name": "test_when_test_overrides_strategy_it_is_reset_after_test_finishes",
+ "use_viewport": true,
+ "viewport_size": [
+  0,
+  0
+ ],
+ "resolution": [
+  800,
+  480
+ ],
  "panel_options": {
   "font_name": "CourierPrime",
   "font_size": 30

--- a/.gut_editor_config.json
+++ b/.gut_editor_config.json
@@ -23,7 +23,7 @@
  "pre_run_script": "",
  "prefix": "test_",
  "selected": "test_gut.gd",
- "should_exit": false,
+ "should_exit": true,
  "should_exit_on_success": false,
  "should_maximize": false,
  "show_help": false,
@@ -31,16 +31,18 @@
  "tests": [
 
  ],
- "unit_test_name": "test_when_test_overrides_strategy_it_is_reset_after_test_finishes",
+ "unit_test_name": null,
  "use_viewport": true,
  "viewport_size": [
   0,
   0
  ],
+ "viewport_bg_color": "00ffffff",
  "resolution": [
   800,
-  480
+  500
  ],
+ "gut_on_top": true,
  "panel_options": {
   "font_name": "CourierPrime",
   "font_size": 30

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,8 +1,8 @@
 {
   "dirs":["res://test/unit/", "res://test/integration/"],
-  "should_maximize":true,
+  "should_maximize":false,
   "should_exit":true,
-  "ignore_pause":false,
+  "ignore_pause":true,
   "log_level":2,
   "opacity":100,
   "double_strategy":"partial",

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -4,10 +4,11 @@
   "should_exit":true,
   "ignore_pause":true,
   "log_level":2,
-  "opacity":100,
+  "opacity":50,
   "double_strategy":"partial",
   "include_subdirs":true,
   "inner_class":"",
   "disable_colors":false,
-  "post_run_script":"res://test/post_run_export_json.gd"
+  "post_run_script":"res://test/post_run_export_json.gd",
+
 }

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -2,13 +2,15 @@
   "dirs":["res://test/unit/", "res://test/integration/"],
   "should_maximize":true,
   "should_exit":true,
-  "ignore_pause":true,
+  "ignore_pause":false,
   "log_level":2,
-  "opacity":50,
+  "opacity":100,
   "double_strategy":"partial",
   "include_subdirs":true,
   "inner_class":"",
   "disable_colors":false,
   "post_run_script":"res://test/post_run_export_json.gd",
 
+  "use_viewport":true,
+  "resolution":[1600, 960]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ func test_foo():
   player.local_input_ref = dbl_input
   stub(dbl_input, 'is_action_just_pressed').to_return(true).when_passed('jump')
 ```
+* __Issue 121__ Introduced new settings which make GUT use a viewport to add child objects to instead of itself.  There is a "Use Viewport" setting added to the GUT Panel and some related options.  These options can also be set in a `gutconfig` file but do not have explicit command line options.
 * In-Editor GUT Panel improvements
   * Smart buttons to run tests based on cursor location.
   * Added more settings (hook scripts, font color, background color, panel font settings, directory and file dialog buttons where appropriate, hide orphans, disable colors)
@@ -37,6 +38,7 @@ func test_foo():
   * __Issue 215__ You can now use `extends GutTest` instead of `extends 'res://addons/gut/test.gd'` when creating test scripts.  That's 45% less text!
   * When making a hook script, you can use `extends GutHookScript` instead of using the path.
 * __Issue 310__ The summary output now lists the number of passing/failing tests as well as passing/failing assert counts.
+
 
 ## Bug Fixes
 * __Issue 283__ The Gut Scene now has a theme with a font which prevents higher level font changes from applying to the Gut Scene.

--- a/addons/gut/gui/GutBottomPanel.gd
+++ b/addons/gut/gui/GutBottomPanel.gd
@@ -278,8 +278,8 @@ func set_current_script(script):
 func set_interface(value):
 	_interface = value
 	_interface.get_script_editor().connect("editor_script_changed", self, '_on_editor_script_changed')
-	set_current_script(_interface.get_script_editor().get_current_script())
 	_ctrls.run_at_cursor.set_script_editor(_interface.get_script_editor())
+	set_current_script(_interface.get_script_editor().get_current_script())
 
 
 func set_plugin(value):

--- a/addons/gut/gui/GutBottomPanel.gd
+++ b/addons/gut/gui/GutBottomPanel.gd
@@ -239,19 +239,19 @@ func load_result_output():
 	var summary_json = results.result['test_scripts']['props']
 	_ctrls.results.passing.text = str(summary_json.passing)
 	_ctrls.results.passing.get_parent().visible = true
-	
+
 	_ctrls.results.failing.text = str(summary_json.failures)
 	_ctrls.results.failing.get_parent().visible = true
-	
+
 	_ctrls.results.pending.text = str(summary_json.pending)
 	_ctrls.results.pending.get_parent().visible = _ctrls.results.pending.text != '0'
-	
+
 	_ctrls.results.errors.text = str(summary_json.errors)
 	_ctrls.results.errors.get_parent().visible = _ctrls.results.errors.text != '0'
-	
+
 	_ctrls.results.warnings.text = str(summary_json.warnings)
 	_ctrls.results.warnings.get_parent().visible = _ctrls.results.warnings.text != '0'
-	
+
 	_ctrls.results.orphans.text = str(summary_json.orphans)
 	_ctrls.results.orphans.get_parent().visible = _ctrls.results.orphans.text != '0' and !_gut_config.options.hide_orphans
 

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -15,6 +15,7 @@ var _cmdln_mode = false
 
 var _resolution = null
 var _viewport_size = null
+var _use_viewport = false
 
 
 onready var _test_parent = $ColorRect/ViewportContainer/Viewport
@@ -22,11 +23,30 @@ onready var _color_rect = $ColorRect
 
 
 func _ready():
+	if(_gut_config == null):
+		_gut_config = GutConfig.new()
+		_gut_config.load_options(RUNNER_JSON_PATH)
+
+	if(_gut_config.options.viewport_size != null):
+		_viewport_size = Vector2(
+			_gut_config.options.viewport_size[0],
+			_gut_config.options.viewport_size[1])
+
+	if(_gut_config.options.resolution != null):
+		_resolution = Vector2(
+			_gut_config.options.resolution[0],
+			_gut_config.options.resolution[1])
+
+	_use_viewport = _gut_config.options.use_viewport
 	_setup_screen()
 	call_deferred('_setup_gut')
 
 
 func _setup_screen():
+	if(!_use_viewport):
+		_color_rect.visible = false
+		return
+
 	_test_parent.size = _test_parent.get_parent().rect_size
 	_color_rect.rect_position = Vector2(0, 0)
 
@@ -35,6 +55,7 @@ func _setup_screen():
 
 	if(_resolution != null):
 		get_tree().root.set_size_override(true, _resolution)
+
 	else:
 		_resolution = get_tree().root.get_size_override()
 
@@ -48,21 +69,21 @@ func _setup_screen():
 
 
 func _draw():
-	var drect = _color_rect.get_rect()
-	drect.position -= Vector2(2, 2)
-	drect.size += Vector2(2, 2)
-	draw_rect(drect, Color(1, 0, 0), false, 3)
+	if(_use_viewport):
+		var drect = _color_rect.get_rect()
+		drect.position -= Vector2(2, 2)
+		drect.size += Vector2(2, 2)
+		draw_rect(drect, Color(1, 0, 0), false, 3)
 
 
 func _setup_gut():
 	if(_gut == null):
 		_gut = Gut.new()
-	_gut.set_add_children_to(_test_parent)
-	add_child(_gut)
 
-	if(_gut_config == null):
-		_gut_config = GutConfig.new()
-		_gut_config.load_options(RUNNER_JSON_PATH)
+	if(_use_viewport):
+		_gut.set_add_children_to(_test_parent)
+
+	add_child(_gut)
 
 	if(!_cmdln_mode):
 		_gut.connect('tests_finished', self, '_on_tests_finished',
@@ -122,3 +143,6 @@ func set_viewport_size(s):
 
 func set_resolution(r):
 	_resolution = r
+
+func set_use_viewport(should):
+	_use_viewport = should

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -2,28 +2,71 @@ extends Node2D
 
 var Gut = load('res://addons/gut/gut.gd')
 var ResultExporter = load('res://addons/gut/result_exporter.gd')
+var GutConfig = load('res://addons/gut/gut_config.gd')
 
 const RUNNER_JSON_PATH = 'res://.gut_editor_config.json'
 const RESULT_FILE = 'user://.gut_editor.bbcode'
 const RESULT_JSON = 'user://.gut_editor.json'
 
-var _gut_config = load('res://addons/gut/gut_config.gd').new()
+var _gut_config = null
 var _gut = null;
 var _wrote_results = false
+var _cmdln_mode = false
 
-# Called when the node enters the scene tree for the first time.
+var _resolution = null
+var _viewport_size = null
+
+
+onready var _test_parent = $ColorRect/ViewportContainer/Viewport
+onready var _color_rect = $ColorRect
+
+
 func _ready():
+	_setup_screen()
 	call_deferred('_setup_gut')
 
 
+func _setup_screen():
+	_test_parent.size = _test_parent.get_parent().rect_size
+	_color_rect.rect_position = Vector2(0, 0)
+
+	if(_viewport_size == null):
+		_viewport_size = get_tree().root.get_size_override()
+
+	if(_resolution != null):
+		get_tree().root.set_size_override(true, _resolution)
+	else:
+		_resolution = get_tree().root.get_size_override()
+
+	if(_viewport_size != null):
+		_color_rect.rect_size = _viewport_size
+		_test_parent.size = _viewport_size
+
+	if(_viewport_size.x < _resolution.x):
+		_color_rect.rect_position.x = _resolution.x - _viewport_size.x - 5
+		_color_rect.rect_position.y += 5
+
+
+func _draw():
+	var drect = _color_rect.get_rect()
+	drect.position -= Vector2(2, 2)
+	drect.size += Vector2(2, 2)
+	draw_rect(drect, Color(1, 0, 0), false, 3)
+
+
 func _setup_gut():
-	_gut = Gut.new()
+	if(_gut == null):
+		_gut = Gut.new()
+	_gut.set_add_children_to(_test_parent)
 	add_child(_gut)
 
-	_gut_config.load_options(RUNNER_JSON_PATH)
+	if(_gut_config == null):
+		_gut_config = GutConfig.new()
+		_gut_config.load_options(RUNNER_JSON_PATH)
 
-	_gut.connect('tests_finished', self, '_on_tests_finished',
-		[_gut_config.options.should_exit, _gut_config.options.should_exit_on_success])
+	if(!_cmdln_mode):
+		_gut.connect('tests_finished', self, '_on_tests_finished',
+			[_gut_config.options.should_exit, _gut_config.options.should_exit_on_success])
 
 	_gut_config.config_gut(_gut)
 
@@ -50,7 +93,7 @@ func _write_results():
 
 
 func _exit_tree():
-	if(!_wrote_results):
+	if(!_wrote_results and !_cmdln_mode):
 		_write_results()
 
 
@@ -61,3 +104,21 @@ func _on_tests_finished(should_exit, should_exit_on_success):
 		get_tree().quit()
 	elif(should_exit_on_success and _gut.get_fail_count() == 0):
 		get_tree().quit()
+
+
+func get_gut():
+	if(_gut == null):
+		_gut = Gut.new()
+	return _gut
+
+func set_gut_config(which):
+	_gut_config = which
+
+func set_cmdln_mode(is_it):
+	_cmdln_mode = is_it
+
+func set_viewport_size(s):
+	_viewport_size = s
+
+func set_resolution(r):
+	_resolution = r

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -43,6 +43,7 @@ func _ready():
 	call_deferred('_setup_gut')
 
 
+
 func _setup_screen():
 	if(!_use_viewport):
 		_color_rect.visible = false
@@ -56,6 +57,10 @@ func _setup_screen():
 		_viewport_size = get_tree().root.get_size_override()
 
 	if(_resolution != null):
+		if(_resolution.x < 200):
+			_resolution.x = 200
+		if(_resolution.y < 200):
+			_resolution.y = 200
 		get_tree().root.set_size_override(false, _resolution)
 		OS.window_size = _resolution
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED,  SceneTree.STRETCH_MODE_DISABLED, _resolution)

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -40,7 +40,8 @@ func _ready():
 
 	_color_rect.connect('draw', self, '_on_color_rect_draw')
 	_setup_screen()
-	call_deferred('_setup_gut')
+	if(!_cmdln_mode):
+		call_deferred('run_tests')
 
 
 
@@ -88,7 +89,7 @@ func _on_color_rect_draw():
 		_color_rect.draw_rect(drect, Color(1, 0, 0), false, 3)
 
 
-func _setup_gut():
+func run_tests():
 	if(_gut == null):
 		_gut = Gut.new()
 

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -38,6 +38,7 @@ func _ready():
 
 	_use_viewport = _gut_config.options.use_viewport
 
+	_color_rect.connect('draw', self, '_on_color_rect_draw')
 	_setup_screen()
 	call_deferred('_setup_gut')
 
@@ -49,6 +50,7 @@ func _setup_screen():
 
 	_test_parent.size = _test_parent.get_parent().rect_size
 	_color_rect.rect_position = Vector2(0, 0)
+	_color_rect.color = _gut_config.options.viewport_bg_color
 
 	if(_viewport_size == null):
 		_viewport_size = get_tree().root.get_size_override()
@@ -69,15 +71,16 @@ func _setup_screen():
 		_color_rect.rect_position.x = _resolution.x - _viewport_size.x - 5
 		_color_rect.rect_position.y += 5
 		_should_draw_outline = true
-		update()
+		_color_rect.update()
 
 
-func _draw():
+func _on_color_rect_draw():
 	if(_should_draw_outline):
+
 		var drect = _color_rect.get_rect()
-		drect.position -= Vector2(2, 2)
-		drect.size += Vector2(2, 2)
-		draw_rect(drect, Color(1, 0, 0), false, 3)
+		drect.position = Vector2(-2, -2)
+		drect.size += Vector2(4, 4)
+		_color_rect.draw_rect(drect, Color(1, 0, 0), false, 3)
 
 
 func _setup_gut():
@@ -88,6 +91,8 @@ func _setup_gut():
 		_gut.set_add_children_to(_test_parent)
 
 	add_child(_gut)
+	if(!_gut_config.options.gut_on_top):
+		move_child(_gut, 0)
 
 	if(!_cmdln_mode):
 		_gut.connect('tests_finished', self, '_on_tests_finished',

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -11,6 +11,9 @@ const RESULT_JSON = 'user://.gut_editor.json'
 var _gut_config = null
 var _gut = null;
 var _wrote_results = false
+# Flag for when this is being used at the command line.  Otherwise it is
+# assumed this is being used by the panel and being launched with
+# play_custom_scene
 var _cmdln_mode = false
 
 var _resolution = null
@@ -40,6 +43,10 @@ func _ready():
 
 	_color_rect.connect('draw', self, '_on_color_rect_draw')
 	_setup_screen()
+
+	# The command line will call run_tests on its own.  When used from the panel
+	# we have to kick off the tests ourselves b/c there's no way I know of to
+	# interact with the scene that was run via play_custom_scene.
 	if(!_cmdln_mode):
 		call_deferred('run_tests')
 

--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -16,6 +16,7 @@ var _cmdln_mode = false
 var _resolution = null
 var _viewport_size = null
 var _use_viewport = false
+var _should_draw_outline = false
 
 
 onready var _test_parent = $ColorRect/ViewportContainer/Viewport
@@ -27,17 +28,16 @@ func _ready():
 		_gut_config = GutConfig.new()
 		_gut_config.load_options(RUNNER_JSON_PATH)
 
-	if(_gut_config.options.viewport_size != null):
-		_viewport_size = Vector2(
-			_gut_config.options.viewport_size[0],
-			_gut_config.options.viewport_size[1])
+	var viewport_option = _gut_config.options.viewport_size
+	if(viewport_option != null and viewport_option[0] > 2 and viewport_option[1] > 2):
+		_viewport_size = Vector2(viewport_option[0], viewport_option[1])
 
-	if(_gut_config.options.resolution != null):
-		_resolution = Vector2(
-			_gut_config.options.resolution[0],
-			_gut_config.options.resolution[1])
+	var res_option = _gut_config.options.resolution
+	if(res_option != null and res_option[0] > 2 and res_option[1] > 2):
+		_resolution = Vector2(res_option[0], res_option[1])
 
 	_use_viewport = _gut_config.options.use_viewport
+
 	_setup_screen()
 	call_deferred('_setup_gut')
 
@@ -54,8 +54,9 @@ func _setup_screen():
 		_viewport_size = get_tree().root.get_size_override()
 
 	if(_resolution != null):
-		get_tree().root.set_size_override(true, _resolution)
-
+		get_tree().root.set_size_override(false, _resolution)
+		OS.window_size = _resolution
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED,  SceneTree.STRETCH_MODE_DISABLED, _resolution)
 	else:
 		_resolution = get_tree().root.get_size_override()
 
@@ -63,13 +64,16 @@ func _setup_screen():
 		_color_rect.rect_size = _viewport_size
 		_test_parent.size = _viewport_size
 
+
 	if(_viewport_size.x < _resolution.x):
 		_color_rect.rect_position.x = _resolution.x - _viewport_size.x - 5
 		_color_rect.rect_position.y += 5
+		_should_draw_outline = true
+		update()
 
 
 func _draw():
-	if(_use_viewport):
+	if(_should_draw_outline):
 		var drect = _color_rect.get_rect()
 		drect.position -= Vector2(2, 2)
 		drect.size += Vector2(2, 2)

--- a/addons/gut/gui/GutRunner.tscn
+++ b/addons/gut/gui/GutRunner.tscn
@@ -10,7 +10,7 @@ margin_left = 417.0
 margin_top = 48.0
 margin_right = 1071.0
 margin_bottom = 473.0
-color = Color( 0, 0, 0, 1 )
+color = Color( 0.376471, 0.00784314, 0.4, 1 )
 __meta__ = {
 "_edit_group_": true,
 "_edit_use_anchors_": false

--- a/addons/gut/gui/GutRunner.tscn
+++ b/addons/gut/gui/GutRunner.tscn
@@ -4,3 +4,27 @@
 
 [node name="GutRunner" type="Node2D"]
 script = ExtResource( 1 )
+
+[node name="ColorRect" type="ColorRect" parent="."]
+margin_left = 417.0
+margin_top = 48.0
+margin_right = 1071.0
+margin_bottom = 473.0
+color = Color( 0, 0, 0, 1 )
+__meta__ = {
+"_edit_group_": true,
+"_edit_use_anchors_": false
+}
+
+[node name="ViewportContainer" type="ViewportContainer" parent="ColorRect"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="ColorRect/ViewportContainer"]
+size = Vector2( 400, 400 )
+transparent_bg = true
+handle_input_locally = false
+render_target_update_mode = 3

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -23,6 +23,7 @@ class DirectoryCtrl:
 	func _on_selected(path):
 		set_text(path)
 
+
 	func _on_dir_button_pressed():
 		_dialog.current_dir = _txt_path.text
 		_dialog.popup_centered()
@@ -194,6 +195,7 @@ func _add_boolean(key, value, disp_text, hint=''):
 
 	var ctrl = _new_row(key, disp_text, value_ctrl, hint)
 
+
 func _add_directory(key, value, disp_text, hint=''):
 	var value_ctrl = DirectoryCtrl.new()
 	value_ctrl.size_flags_horizontal = value_ctrl.SIZE_EXPAND_FILL
@@ -211,12 +213,14 @@ func _add_file(key, value, disp_text, hint=''):
 
 	var ctrl = _new_row(key, disp_text, value_ctrl, hint)
 
+
 func _add_color(key, value, disp_text, hint=''):
 	var value_ctrl = ColorPickerButton.new()
 	value_ctrl.size_flags_horizontal = value_ctrl.SIZE_EXPAND_FILL
 	value_ctrl.color = value
 
 	var ctrl = _new_row(key, disp_text, value_ctrl, hint)
+
 
 func _add_vector2(key, value, disp_text, hint=''):
 	var value_ctrl = Vector2Ctrl.new()
@@ -313,13 +317,6 @@ func set_options(options):
 		"Exit if there are no failures.  Does nothing if 'Exit on Finish' is enabled.")
 
 
-	_add_title("XML Output")
-	_add_value("junit_xml_file", options.junit_xml_file, "Output Path",
-		"Path and filename where GUT should create the JUnit XML file.")
-	_add_boolean("junit_xml_timestamp", options.junit_xml_timestamp, "Include timestamp",
-		"Include a timestamp in the filename so that each run gets its own xml file.")
-
-
 	_add_title("Panel Output")
 	_add_select('output_font_name', options.panel_options.font_name, _avail_fonts, 'Font',
 		"The name of the font to use when running tests and in the output panel to the left.")
@@ -329,15 +326,17 @@ func set_options(options):
 
 	_add_title('Runner Appearance')
 	_add_select('font_name', options.font_name, _avail_fonts, 'Font',
-		"The name of the font to use when running tests and in the output panel to the left.")
+		"The font to use for text output in the Gut Runner.")
 	_add_number('font_size', options.font_size, 'Font Size', 5, 100,
-		"The font size to use when running tests and in the output panel to the left.")
+		"The font size for text output in the Gut Runner.")
+	_add_color('font_color', options.font_color, 'Font Color',
+		"The font color for text output in the Gut Runner.")
+	_add_color('background_color', options.background_color, 'Background Color',
+		"The background color for text output in the Gut Runner.")
 	_add_boolean('should_maximize', options.should_maximize, 'Maximize',
 		"Maximize GUT when tests are being run.")
 	_add_number('opacity', options.opacity, 'Opacity', 0, 100,
 		"The opacity of GUT when tests are running.")
-	_add_color('background_color', options.background_color, 'Background Color')
-	_add_color('font_color', options.font_color, 'Font Color')
 	_add_boolean('disable_colors', options.disable_colors, 'Disable Formatting',
 		'Disable formatting and colors used in the Runner.  Does not affect panel output.')
 
@@ -346,13 +345,22 @@ func set_options(options):
 	_add_boolean("use_viewport", options.use_viewport, "Use Viewport",
 		"Tests are added to the tree in a viewport instead of to the GUT " + \
 		"instance.  This can help with layout while tests are running")
-	_add_boolean("gut_on_top", options.gut_on_top, "GUT on Top")
-	_add_vector2('resolution', options.resolution, 'Resolution')
-	_add_vector2('viewport_size', options.viewport_size, 'Viewport Size')
-	_add_color('viewport_bg_color', options.viewport_bg_color, 'Viewport Bg Color')
+	_add_boolean("gut_on_top", options.gut_on_top, "GUT on Top",
+		"The GUT Runner appears above the viewport.")
+	_add_vector2('resolution', options.resolution, 'Resolution',
+		"The size and resolution of the window when tests are run.  Set both " +
+		"the x and y to non-zero values to override the project setting size.  " +
+		"The viewport retains the size of the project settings window size " +
+		"unless Viewport Size is set.")
+	_add_vector2('viewport_size', options.viewport_size, 'Viewport Size',
+		"Change the size of the viewport.  The viewport defaults to the project settings " +
+		"window size.")
+	_add_color('viewport_bg_color', options.viewport_bg_color, 'Viewport Bg Color',
+		"The color shown behind the viewport.  This color will bleed through " +
+		"transparencies of objects when you use add_child in a test.")
 
 
-	_add_title('Directories')
+	_add_title('Test Directories')
 	_add_boolean('include_subdirs', options.include_subdirs, 'Include Subdirs',
 		"Include subdirectories of the directories configured below.")
 	for i in range(DIRS_TO_LIST):
@@ -362,10 +370,20 @@ func set_options(options):
 
 		_add_directory(str('directory_', i), value, str('Directory ', i))
 
+	_add_title("XML Output")
+	_add_value("junit_xml_file", options.junit_xml_file, "Output Path",
+		"Path and filename where GUT should create a JUnit compliant XML file.  " +
+		"This file will contain the results of the last test run.  To avoid " +
+		"overriding the file use Include Timestamp.")
+	_add_boolean("junit_xml_timestamp", options.junit_xml_timestamp, "Include Timestamp",
+		"Include a timestamp in the filename so that each run gets its own xml file.")
+
 
 	_add_title('Hooks')
-	_add_file('pre_run_script', options.pre_run_script, 'Pre-Run Hook', 'This script will be run by GUT before any tests are run.')
-	_add_file('post_run_script', options.post_run_script, 'Post-Run Hook', 'This script will be run by GUT after all tests are run.')
+	_add_file('pre_run_script', options.pre_run_script, 'Pre-Run Hook',
+		'This script will be run by GUT before any tests are run.')
+	_add_file('post_run_script', options.post_run_script, 'Post-Run Hook',
+		'This script will be run by GUT after all tests are run.')
 
 
 	_add_title('Misc')
@@ -386,10 +404,6 @@ func get_options(base_opts):
 	to_return.should_exit = _cfg_ctrls.should_exit.pressed
 	to_return.should_exit_on_success = _cfg_ctrls.should_exit_on_success.pressed
 
-	# XML Output
-	to_return.junit_xml_file = _cfg_ctrls.junit_xml_file.text
-	to_return.junit_xml_timestamp = _cfg_ctrls.junit_xml_timestamp.pressed
-
 	#Output
 	to_return.panel_options.font_name = _cfg_ctrls.output_font_name.get_item_text(
 		_cfg_ctrls.output_font_name.selected)
@@ -404,7 +418,6 @@ func get_options(base_opts):
 	to_return.background_color = _cfg_ctrls.background_color.color.to_html()
 	to_return.font_color = _cfg_ctrls.font_color.color.to_html()
 	to_return.disable_colors = _cfg_ctrls.disable_colors.pressed
-
 
 	# Test Window
 	to_return.use_viewport = _cfg_ctrls.use_viewport.pressed
@@ -422,6 +435,10 @@ func get_options(base_opts):
 		if(val != '' and val != null):
 			dirs.append(val)
 	to_return.dirs = dirs
+
+	# XML Output
+	to_return.junit_xml_file = _cfg_ctrls.junit_xml_file.text
+	to_return.junit_xml_timestamp = _cfg_ctrls.junit_xml_timestamp.pressed
 
 	# Hooks
 	to_return.pre_run_script = _cfg_ctrls.pre_run_script.text

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -51,6 +51,7 @@ var _post_run_script = '' setget set_post_run_script, get_post_run_script
 var _color_output = false setget set_color_output, get_color_output
 var _junit_xml_file = '' setget set_junit_xml_file, get_junit_xml_file
 var _junit_xml_timestamp = false setget set_junit_xml_timestamp, get_junit_xml_timestamp
+var _add_children_to = self setget set_add_children_to, get_add_children_to
 # -- End Settings --
 
 
@@ -590,7 +591,7 @@ func _does_class_name_match(the_class_name, script_class_name):
 func _setup_script(test_script):
 	test_script.gut = self
 	test_script.set_logger(_lgr)
-	add_child(test_script)
+	_add_children_to.add_child(test_script)
 	_test_script_objects.append(test_script)
 
 
@@ -916,7 +917,7 @@ func _test_the_scripts(indexes=[]):
 		# don't clean up after themselves.  Might have to consolidate output
 		# into some other structure and kill the script objects with
 		# test_script.free() instead of remove child.
-		remove_child(test_script)
+		_add_children_to.remove_child(test_script)
 
 		_lgr.set_indent_level(0)
 		if(test_script.get_assert_count() > 0):
@@ -1662,3 +1663,13 @@ func get_junit_xml_timestamp():
 # ------------------------------------------------------------------------------
 func set_junit_xml_timestamp(junit_xml_timestamp):
 	_junit_xml_timestamp = junit_xml_timestamp
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func get_add_children_to():
+	return _add_children_to
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+func set_add_children_to(add_children_to):
+	_add_children_to = add_children_to

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -266,14 +266,11 @@ func _run_gut():
 			runner.set_gut_config(_gut_config)
 
 			_tester = runner.get_gut()
-			# get_root().add_child(_tester)
 			_tester.connect('tests_finished', self, '_on_tests_finished',
 				[_final_opts.should_exit, _final_opts.should_exit_on_success])
-			# _gut_config.apply_options(_tester)
 
+			# The runner will kick off tests after _ready
 			get_root().add_child(runner)
-			# var run_others = _final_opts.selected == null
-			# _tester.test_scripts(run_others)
 
 
 # exit if option is set.

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -41,6 +41,7 @@ extends SceneTree
 
 var Optparse = load('res://addons/gut/optparse.gd')
 var Gut = load('res://addons/gut/gut.gd')
+var GutRunner = load('res://addons/gut/gui/GutRunner.tscn')
 
 # ------------------------------------------------------------------------------
 # Helper class to resolve the various different places where an option can
@@ -260,14 +261,19 @@ func _run_gut():
 			_final_opts = opt_resolver.get_resolved_values();
 			_gut_config.options = _final_opts
 
-			_tester = Gut.new()
-			get_root().add_child(_tester)
+			var runner = GutRunner.instance()
+			runner.set_cmdln_mode(true)
+			runner.set_gut_config(_gut_config)
+
+			_tester = runner.get_gut()
+			# get_root().add_child(_tester)
 			_tester.connect('tests_finished', self, '_on_tests_finished',
 				[_final_opts.should_exit, _final_opts.should_exit_on_success])
-			_gut_config.apply_options(_tester)
+			# _gut_config.apply_options(_tester)
 
-			var run_others = _final_opts.selected == null
-			_tester.test_scripts(run_others)
+			get_root().add_child(runner)
+			# var run_others = _final_opts.selected == null
+			# _tester.test_scripts(run_others)
 
 
 # exit if option is set.

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -269,7 +269,6 @@ func _run_gut():
 			_tester.connect('tests_finished', self, '_on_tests_finished',
 				[_final_opts.should_exit, _final_opts.should_exit_on_success])
 
-			# The runner will kick off tests after _ready
 			get_root().add_child(runner)
 			runner.run_tests()
 

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -271,6 +271,7 @@ func _run_gut():
 
 			# The runner will kick off tests after _ready
 			get_root().add_child(runner)
+			runner.run_tests()
 
 
 # exit if option is set.

--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -41,7 +41,10 @@ var default_options = {
 
 	use_viewport = false,
 	viewport_size = null,
-	resolution = null
+	viewport_bg_color = Color(1, 1, 1, 0).to_html(),
+	resolution = null,
+	gut_on_top = true,
+
 }
 
 var default_panel_options = {

--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -44,7 +44,6 @@ var default_options = {
 	viewport_bg_color = Color(1, 1, 1, 0).to_html(),
 	resolution = null,
 	gut_on_top = true,
-
 }
 
 var default_panel_options = {

--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -38,6 +38,10 @@ var default_options = {
 	suffix = '.gd',
 	tests = [],
 	unit_test_name = '',
+
+	use_viewport = false,
+	viewport_size = null,
+	resolution = null
 }
 
 var default_panel_options = {

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -42,7 +42,7 @@ extends Node
 # Helper class to hold info for objects to double.  This extracts info and has
 # some convenience methods.  This is key in being able to make the "smart double"
 # method which makes doubling much easier for the user.
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 class DoubleInfo:
 	var path
 	var subpath

--- a/test/panel_demo_scripts/test_totals_testing.gd
+++ b/test/panel_demo_scripts/test_totals_testing.gd
@@ -2,31 +2,31 @@ extends GutTest
 
 func test_passing_test():
 	pass_test('did it!')
-	
+
 func test_failing_test():
 	fail_test('did not do it!')
 
 func test_generates_error():
 	gut.get_logger().error('This is a manual error')
 	pass_test('passing')
-	
+
 func test_generates_warning():
 	gut.get_logger().warn("This is a manual warning")
-	
+
 func test_multiple_passing_asserts():
 	assert_eq(1, 1)
 	assert_eq(2, 2)
 	assert_eq('a', 'a')
-	
+
 func test_makes_orphan():
 	var orphan = Node2D.new()
 	assert_true(true)
-	
+
 func test_makes_an_info():
 	gut.get_logger().info("here is some info")
 	pass_test('info pass!')
-	
+
 func test_pending():
 	pending("this is pending")
-	
+
 

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -146,6 +146,9 @@ func test_get_set_junit_xml_file():
 
 func test_get_set_junit_xml_timestamp():
 	assert_accessors(gr.test_gut, 'junit_xml_timestamp', false, true)
+
+func test_get_set_add_children_to():
+	assert_accessors(gr.test_gut, 'add_children_to', gr.test_gut, autofree(Node.new()))
 # ------------------------------
 # Doubler
 # ------------------------------

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -168,6 +168,7 @@ func test_clears_ignored_methods_between_tests():
 	gr.test_gut._tests_like = 'test_assert_eq_number_not_equal'
 	gr.test_gut.test_scripts()
 	assert_eq(gr.test_gut.get_doubler().get_ignored_methods().size(), 0)
+	pause_before_teardown()
 
 
 # ------------------------------


### PR DESCRIPTION
Add "Use Viewport" option which causes GUT to add `GutTest` instances to the viewport instead of itself.  This means all calls to `add_child` in a test will be added in the viewport instead of on top of GUT.  This fixes issue #121.

Adds additional options related to "Use Viewport"
* resolution:  The resolution and window size that the GUT window uses.  This defaults to the project settings.  This does not affect the viewport size.  The viewport size will use the project settings unless it is set.  When the viewport is smaller than the resolution it will be right justified.
* viewport size:  The size of the viewport.  This defaults to the project settings.  When this is smaller than the resolution it will be right justified.
* Gut on Top:  Toggles whether the GUT Runner will be above or behind the viewport.
* Viewport Background Color:  You can set a background color for the viewport.  The default is transparent.