### PR TITLE
Fix for comparison of incompatible types when the first type is Array

### DIFF
--- a/addons/gut/comparator.gd
+++ b/addons/gut/comparator.gd
@@ -65,8 +65,7 @@ func simple(v1, v2, missing_string=''):
 		extra = str('.  ', _cannot_comapre_text(v1, v2))
 
 	cmp_str = get_compare_symbol(result.are_equal)
-	if(typeof(v1) != TYPE_ARRAY):
-		result.summary = str(format_value(v1), ' ', cmp_str, ' ', format_value(v2), extra)
+	result.summary = str(format_value(v1), ' ', cmp_str, ' ', format_value(v2), extra)
 
 	return result
 

--- a/test/unit/test_comparator.gd
+++ b/test/unit/test_comparator.gd
@@ -72,7 +72,7 @@ class TestSimpleCompare:
 		assert_string_contains(result.summary, str(p[0]), 'zero value')
 		assert_string_contains(result.summary, str(p[1]), 'one value')
 
-	var incompatible_types = [[1, 'a'], ['text', Node], [false, []], [{}, []]]
+	var incompatible_types = [[1, 'a'], ['text', Node], [false, []], [{}, []], [[], 12]]
 	func test_incompatible_types(p=use_parameters(incompatible_types)):
 		var result = _comparator.simple(p[0], p[1])
 		assert_not_null(result.are_equal,  result.summary)


### PR DESCRIPTION
It made some asserts cause a script error, e.g. here:

```
func test_assert_eq_shallow_array_to_pool_array():
	var pool_array = PoolByteArray()
	assert_eq_shallow([], pool_array)
```

`result.summary `was left as null and later there was an attempt to concatenate a string with that null.