### PR TITLE
I354 init parameters

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -3,7 +3,7 @@
   "should_maximize":false,
   "should_exit":true,
   "ignore_pause":true,
-  "log_level":3,
+  "log_level":0,
   "opacity":100,
   "double_strategy":"partial",
   "include_subdirs":true,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+# 7.X.X
+
+## Features
+* __Issue 354__ Doubles and partial doubles can now be instanced with parameters
+  * You can now specify parameters when instancing a double/partial double:<br/>
+  `var dbl = double(MyClass).new(1, 2, 'c')`
+  * You can now spy on `_init` to verify parameter values:<br/>
+  `assert_called(my_inst, '_init', [1, 2, 'c'])`
+  * You can now stub default parameter values for `_init`:<br/>
+  `stub(MyClass, '_init').param_defaults([1, 2, 'c'])`
+*
+#### Misc
+* Yield messages are now disabled on log level 0.
+*
+
 # 7.3.0
 
 ## Features

--- a/addons/gut/double_templates/init_template.txt
+++ b/addons/gut/double_templates/init_template.txt
@@ -1,0 +1,2 @@
+{func_decleration}{super_params}:
+    __gut_init()

--- a/addons/gut/double_templates/init_template.txt
+++ b/addons/gut/double_templates/init_template.txt
@@ -1,2 +1,3 @@
 {func_decleration}{super_params}:
     __gut_init()
+    __gut_spy('{method_name}', {param_array})

--- a/addons/gut/double_templates/script_template.txt
+++ b/addons/gut/double_templates/script_template.txt
@@ -49,8 +49,8 @@ func __gut_default_val(method_name, p_index):
 	else:
 		return null
 
-
-func  _init():
+func __gut_init():
+	print('!! __gut_init called')
 	if(__gut_metadata_.gut != null):
 		__gut_metadata_.gut.get_autofree().add_free(self)
 

--- a/addons/gut/double_templates/script_template.txt
+++ b/addons/gut/double_templates/script_template.txt
@@ -50,7 +50,6 @@ func __gut_default_val(method_name, p_index):
 		return null
 
 func __gut_init():
-	print('!! __gut_init called')
 	if(__gut_metadata_.gut != null):
 		__gut_metadata_.gut.get_autofree().add_free(self)
 

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -66,7 +66,7 @@ class ScriptMethods:
 		# There is an init in the template.  There is also no real reason
 		# to include this method since it will always be called, it has no
 		# return value, and you cannot prevent super from being called.
-		'_init'
+
 	]
 
 	var built_ins = []
@@ -394,7 +394,7 @@ func _stub_to_call_super(obj_info, method_name):
 	_stubber.add_stub(params)
 
 
-func _get_base_script_text(obj_info, override_path):
+func _get_base_script_text(obj_info, override_path, script_methods):
 	var path = obj_info.get_path()
 	if(override_path != null):
 		path = override_path
@@ -431,8 +431,8 @@ func _get_base_script_text(obj_info, override_path):
 
 
 func _write_file(obj_info, dest_path, override_path=null):
-	var base_script = _get_base_script_text(obj_info, override_path)
 	var script_methods = _get_methods(obj_info)
+	var base_script = _get_base_script_text(obj_info, override_path, script_methods)
 	var super_name = ""
 	var path = ""
 

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -61,13 +61,6 @@ class ScriptMethods:
 		'_get_minimum_size', # Nonexistent function _get_minimum_size
 	]
 
-	# These methods should not be included in the double.
-	var _skip = [
-		# There is an init in the template.  There is also no real reason
-		# to include this method since it will always be called, it has no
-		# return value, and you cannot prevent super from being called.
-
-	]
 
 	var built_ins = []
 	var local_methods = []
@@ -77,8 +70,6 @@ class ScriptMethods:
 		return _blacklist.find(method_meta.name) != -1
 
 	func _add_name_if_does_not_have(method_name):
-		if(_skip.has(method_name)):
-			return false
 		var should_add = _method_names.find(method_name) == -1
 		if(should_add):
 			_method_names.append(method_name)

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -231,7 +231,7 @@ func _get_spy_call_parameters_text(args):
 # Public
 # ###############
 
-func _get_init_text(meta, args, method_params):
+func _get_init_text(meta, args, method_params, param_array):
 	var text = null
 
 	var decleration = str('func ', meta.name, '(', method_params, ')')
@@ -246,7 +246,9 @@ func _get_init_text(meta, args, method_params):
 
 	text = _init_text.format({
 		"func_decleration":decleration,
-		"super_params":super_params
+		"super_params":super_params,
+		"param_array":param_array,
+		"method_name":meta.name
 	})
 
 	return text
@@ -280,7 +282,7 @@ func get_function_text(meta, path=null, override_size=null, super_name=""):
 
 	if(method_params != null):
 		if(meta.name == '_init'):
-			text =  _get_init_text(meta, args, method_params)
+			text =  _get_init_text(meta, args, method_params, param_array)
 		else:
 			var decleration = str('func ', meta.name, '(', method_params, '):')
 			text = _func_text.format({

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -103,6 +103,7 @@ func _init():
 # Private
 # ###############
 var _func_text = _utils.get_file_as_text('res://addons/gut/double_templates/function_template.txt')
+var _init_text = _utils.get_file_as_text('res://addons/gut/double_templates/init_template.txt')
 
 func _is_supported_default(type_flag):
 	return type_flag >= 0 and type_flag < _supported_defaults.size() and [type_flag] != null
@@ -229,12 +230,55 @@ func _get_spy_call_parameters_text(args):
 # ###############
 # Public
 # ###############
+func _get_init_text(meta, override_size=null):
+	var method_params = ''
+	var text = null
+
+	var result = _make_arg_array(meta, override_size)
+	var has_unsupported = result[0]
+	var args = result[1]
+
+	var param_array = _get_spy_call_parameters_text(args)
+
+	if(has_unsupported):
+		# This will cause a runtime error.  This is the most convenient way to
+		# to stop running before the error gets more obscure.  _make_arg_array
+		# generates a gut error when unsupported defaults are found.
+		method_params = null
+	else:
+		method_params = _get_arg_text(args);
+
+	if(param_array == 'null'):
+		param_array = '[]'
+
+	if(method_params != null):
+		var decleration = str('func ', meta.name, '(', method_params, ')')
+		var super_params = ''
+		if(args.size() > 0):
+			super_params = '.('
+			for i in range(args.size()):
+				super_params += args[i].p_name
+				if(i != args.size() -1):
+					super_params += ', '
+			super_params += ')'
+
+		text = _init_text.format({
+			"func_decleration":decleration,
+			"super_params":super_params
+		})
+
+	return text
 
 # Creates a delceration for a function based off of function metadata.  All
 # types whose defaults are supported will have their values.  If a datatype
 # is not supported and the parameter has a default, a warning message will be
 # printed and the declaration will return null.
+#
+# path is no longer used
 func get_function_text(meta, path=null, override_size=null, super_name=""):
+	if(meta.name == '_init'):
+		return _get_init_text(meta, override_size)
+
 	var method_params = ''
 	var text = null
 	var result = _make_arg_array(meta, override_size)

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -230,44 +230,27 @@ func _get_spy_call_parameters_text(args):
 # ###############
 # Public
 # ###############
-func _get_init_text(meta, override_size=null):
-	var method_params = ''
+
+func _get_init_text(meta, args, method_params):
 	var text = null
 
-	var result = _make_arg_array(meta, override_size)
-	var has_unsupported = result[0]
-	var args = result[1]
+	var decleration = str('func ', meta.name, '(', method_params, ')')
+	var super_params = ''
+	if(args.size() > 0):
+		super_params = '.('
+		for i in range(args.size()):
+			super_params += args[i].p_name
+			if(i != args.size() -1):
+				super_params += ', '
+		super_params += ')'
 
-	var param_array = _get_spy_call_parameters_text(args)
-
-	if(has_unsupported):
-		# This will cause a runtime error.  This is the most convenient way to
-		# to stop running before the error gets more obscure.  _make_arg_array
-		# generates a gut error when unsupported defaults are found.
-		method_params = null
-	else:
-		method_params = _get_arg_text(args);
-
-	if(param_array == 'null'):
-		param_array = '[]'
-
-	if(method_params != null):
-		var decleration = str('func ', meta.name, '(', method_params, ')')
-		var super_params = ''
-		if(args.size() > 0):
-			super_params = '.('
-			for i in range(args.size()):
-				super_params += args[i].p_name
-				if(i != args.size() -1):
-					super_params += ', '
-			super_params += ')'
-
-		text = _init_text.format({
-			"func_decleration":decleration,
-			"super_params":super_params
-		})
+	text = _init_text.format({
+		"func_decleration":decleration,
+		"super_params":super_params
+	})
 
 	return text
+
 
 # Creates a delceration for a function based off of function metadata.  All
 # types whose defaults are supported will have their values.  If a datatype
@@ -276,9 +259,6 @@ func _get_init_text(meta, override_size=null):
 #
 # path is no longer used
 func get_function_text(meta, path=null, override_size=null, super_name=""):
-	if(meta.name == '_init'):
-		return _get_init_text(meta, override_size)
-
 	var method_params = ''
 	var text = null
 	var result = _make_arg_array(meta, override_size)
@@ -299,13 +279,16 @@ func get_function_text(meta, path=null, override_size=null, super_name=""):
 		param_array = '[]'
 
 	if(method_params != null):
-		var decleration = str('func ', meta.name, '(', method_params, '):')
-		text = _func_text.format({
-			"func_decleration":decleration,
-			"method_name":meta.name,
-			"param_array":param_array,
-			"super_call":_get_super_call_text(meta.name, args, super_name)
-		})
+		if(meta.name == '_init'):
+			text =  _get_init_text(meta, args, method_params)
+		else:
+			var decleration = str('func ', meta.name, '(', method_params, '):')
+			text = _func_text.format({
+				"func_decleration":decleration,
+				"method_name":meta.name,
+				"param_array":param_array,
+				"super_call":_get_super_call_text(meta.name, args, super_name)
+			})
 
 	return text
 

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -1,3 +1,6 @@
+var _utils = load('res://addons/gut/utils.gd').get_instance()
+var _lgr = _utils.get_logger()
+
 var return_val = null
 var stub_target = null
 var target_subpath = null
@@ -29,19 +32,30 @@ func _init(target=null, method=null, subpath=null):
 	stub_method = method
 	target_subpath = subpath
 
+
 func to_return(val):
-	return_val = val
-	call_super = false
-	_parameter_override_only = false
+	if(stub_method == '_init'):
+		_lgr.error("You cannot stub _init to do nothing.  Super's _init is always called.")
+	else:
+		return_val = val
+		call_super = false
+		_parameter_override_only = false
 	return self
+
 
 func to_do_nothing():
-	return to_return(null)
+	to_return(null)
+	return self
+
 
 func to_call_super():
-	call_super = true
-	_parameter_override_only = false
+	if(stub_method == '_init'):
+		_lgr.error("You cannot stub _init to call super.  Super's _init is always called.")
+	else:
+		call_super = true
+		_parameter_override_only = false
 	return self
+
 
 func when_passed(p1=NOT_SET,p2=NOT_SET,p3=NOT_SET,p4=NOT_SET,p5=NOT_SET,p6=NOT_SET,p7=NOT_SET,p8=NOT_SET,p9=NOT_SET,p10=NOT_SET):
 	parameters = [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10]
@@ -53,23 +67,28 @@ func when_passed(p1=NOT_SET,p2=NOT_SET,p3=NOT_SET,p4=NOT_SET,p5=NOT_SET,p6=NOT_S
 			idx += 1
 	return self
 
+
 func param_count(x):
 	parameter_count = x
 	return self
+
 
 func param_defaults(values):
 	parameter_count = values.size()
 	parameter_defaults = values
 	return self
 
+
 func has_param_override():
 	return parameter_count != -1
+
 
 func is_param_override_only():
 	var to_return = false
 	if(has_param_override()):
 		to_return = _parameter_override_only
 	return to_return
+
 
 func to_s():
 	var base_string = str(stub_target)

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -113,11 +113,11 @@ func _find_stub(obj, method, parameters=null, find_overloads=false):
 
 
 func add_stub(stub_params):
-	if(stub_params.stub_method == '_init'):
-		_lgr.error("You cannot stub _init.  Super's _init is ALWAYS called.")
-	else:
-		var key = _add_obj_method(stub_params.stub_target, stub_params.stub_method, stub_params.target_subpath)
-		returns[key][stub_params.stub_method].append(stub_params)
+	# if(stub_params.stub_method == '_init'):
+	# 	_lgr.error("You cannot stub _init.  Super's _init is ALWAYS called.")
+	# else:
+	var key = _add_obj_method(stub_params.stub_target, stub_params.stub_method, stub_params.target_subpath)
+	returns[key][stub_params.stub_method].append(stub_params)
 
 
 # Gets a stubbed return value for the object and method passed in.  If the

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -180,6 +180,7 @@ func get_parameter_count(obj, method):
 func get_default_value(obj, method, p_index):
 	var to_return = null
 	var stub_info = _find_stub(obj, method, null, true)
+
 	if(stub_info != null and
 		stub_info.parameter_defaults != null and
 		stub_info.parameter_defaults.size() > p_index):

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -113,9 +113,7 @@ func _find_stub(obj, method, parameters=null, find_overloads=false):
 
 
 func add_stub(stub_params):
-	# if(stub_params.stub_method == '_init'):
-	# 	_lgr.error("You cannot stub _init.  Super's _init is ALWAYS called.")
-	# else:
+	stub_params._lgr = _lgr
 	var key = _add_obj_method(stub_params.stub_target, stub_params.stub_method, stub_params.target_subpath)
 	returns[key][stub_params.stub_method].append(stub_params)
 

--- a/test/integration/test_doubler_and_spy.gd
+++ b/test/integration/test_doubler_and_spy.gd
@@ -1,6 +1,7 @@
 extends 'res://test/gut_test.gd'
 
 const TEMP_FILES = 'user://test_doubler_and_spy'
+const INIT_PARAMETERS = 'res://test/resources/stub_test_objects/init_parameters.gd'
 
 class TestBoth:
 	extends 'res://test/gut_test.gd'
@@ -60,3 +61,11 @@ class TestBoth:
 		inst.is_action_just_pressed("foobar")
 		assert_true(_spy.was_called(inst, "is_action_just_pressed"))
 
+
+	func test_can_spy_on_init():
+		var inst = _doubler.double(INIT_PARAMETERS).new('test_value')
+		assert_true(_spy.was_called(inst, '_init'))
+
+	func test_can_spy_on_init_parameters():
+		var inst = _doubler.double(INIT_PARAMETERS).new('test_value')
+		assert_true(_spy.was_called(inst, '_init', ['test_value']))

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -9,6 +9,7 @@ const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_m
 const DOUBLE_EXTENDS_NODE2D = 'res://test/resources/doubler_test_objects/double_extends_node2d.gd'
 const TEMP_FILES = 'user://test_doubler_temp_file'
 const TO_STUB_PATH = 'res://test/resources/stub_test_objects/to_stub.gd'
+const INIT_PARAMETERS = 'res://test/resources/stub_test_objects/init_parameters.gd'
 
 
 var gr = {
@@ -126,8 +127,9 @@ func test_stubbing_init_to_call_super_generates_error():
 	var err_count = gr.stubber.get_logger().get_errors().size()
 
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
-	var params = _utils.StubParams.new(inst, '_init').to_call_super()
+	var params = _utils.StubParams.new(inst, '_init')
 	gr.stubber.add_stub(params)
+	params.to_call_super()
 	assert_eq(gr.stubber.get_logger().get_errors().size(), err_count + 1)
 
 func test_stubbing_init_to_call_super_does_not_generate_stub():
@@ -138,11 +140,26 @@ func test_stubbing_init_to_call_super_does_not_generate_stub():
 
 func  test_you_cannot_stub_init_to_do_nothing():
 	var err_count = gr.stubber.get_logger().get_errors().size()
-
 	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
-	var params = _utils.StubParams.new(inst, '_init').to_do_nothing()
+	var params = _utils.StubParams.new(inst, '_init')
 	gr.stubber.add_stub(params)
+	params.to_do_nothing()
 	assert_false(gr.stubber.should_call_super(inst, '_init'), 'stub not created')
 	assert_eq(gr.stubber.get_logger().get_errors().size(), err_count + 1, 'error generated')
 
+func test_stubbing_return_value_of_init_results_in_error():
+	var err_count = gr.stubber.get_logger().get_errors().size()
+	var inst =  gr.doubler.partial_double(DOUBLE_ME_PATH).new()
+	var params = _utils.StubParams.new(inst, '_init')
+	gr.stubber.add_stub(params)
+	params.to_return('abc')
+	assert_eq(gr.stubber.get_return(inst, '_init'), null, 'return value')
+	assert_eq(gr.stubber.get_logger().get_errors().size(), err_count + 1, 'error generated')
+
+func test_double_can_have_default_param_values_stubbed():
+	var params = _utils.StubParams.new(INIT_PARAMETERS, '_init')
+	params.param_defaults(["override_default"])
+	gr.stubber.add_stub(params)
+	var inst = gr.doubler.double(INIT_PARAMETERS).new()
+	assert_eq(inst.value, 'override_default')
 

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -356,9 +356,8 @@ class TestOverridingParameters:
 		var inst =  _test.partial_double(DEFAULT_PARAMS_PATH).new()
 		var ret_val = inst.return_passed('a', 'b')
 		assert_eq(ret_val, 'ab')
-		print(_gut.get_stubber().to_s())
 
-	func test_double___can_have_default_param_values_stubbed_using_class():
+	func test_double_can_have_default_param_values_stubbed_using_class():
 		var InitParams = load(INIT_PARAMETERS)
 		_test.stub(InitParams, '_init').param_defaults(["override_default"])
 		var inst = _test.double(InitParams).new()

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -94,6 +94,7 @@ class TestBasics:
 
 
 
+
 class TestIgnoreMethodsWhenDoubling:
 	extends "res://test/gut_test.gd"
 
@@ -306,7 +307,7 @@ class TestOverridingParameters:
 		_gut.free()
 		_test.free()
 
-
+	const INIT_PARAMETERS = 'res://test/resources/stub_test_objects/init_parameters.gd'
 	const DEFAULT_PARAMS_PATH = 'res://test/resources/doubler_test_objects/double_default_parameters.gd'
 	# -------------------
 	# Default parameters and override parameter count
@@ -356,6 +357,13 @@ class TestOverridingParameters:
 		var ret_val = inst.return_passed('a', 'b')
 		assert_eq(ret_val, 'ab')
 		print(_gut.get_stubber().to_s())
+
+	func test_double___can_have_default_param_values_stubbed_using_class():
+		var InitParams = load(INIT_PARAMETERS)
+		_test.stub(InitParams, '_init').param_defaults(["override_default"])
+		var inst = _test.double(InitParams).new()
+		assert_eq(inst.value, 'override_default')
+
 
 
 # class TestSingletonDoubling:

--- a/test/resources/stub_test_objects/init_parameters.gd
+++ b/test/resources/stub_test_objects/init_parameters.gd
@@ -1,0 +1,4 @@
+var value = 'start_value'
+
+func _init(new_value='default_value'):
+    value = new_value

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -502,13 +502,7 @@ class TestAutofree:
 		gut.get_autofree().free_all()
 		assert_no_new_orphans()
 
-	func test_double_default_init_params():
-		var doubled = double('res://test/unit/test_doubler.gd', 'TestAutofree/InitHasDefaultParams').new()
-		assert_eq(doubled.a, 'asdf')
 
-	func test_partial_double_default_init_params():
-		var doubled = partial_double('res://test/unit/test_doubler.gd', 'TestAutofree/InitHasDefaultParams').new()
-		assert_eq(doubled.a, 'asdf')
 
 class TestInitParameters:
 	extends BaseTest
@@ -543,15 +537,14 @@ class TestInitParameters:
 		var doubled = DoubledClass.new('test')
 		assert_eq(doubled.value, 'test')
 
-	func test_double_can_have_default_param_values_stubbed():
-		stub('res://test/unit/test_doubler.gd',
-		'TestInitParameters/InitDefaultParameters', '_init').param_defaults(["override_default"])
-		var doubled = DoubledClass.new()
-		assert_eq(doubled.value, 'override_default')
-
 	func test_partial_double_gets_passed_value():
 		var doubled = PartialDoubledClass.new('test')
 		assert_eq(doubled.value, 'test')
+
+	func test_partial_double_gets_null_for_default_value():
+		var doubled = PartialDoubledClass.new()
+		assert_null(doubled.value)
+
 
 
 # class TestDoubleSingleton:

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -519,38 +519,38 @@ class TestInitParameters:
 		func _init(p_arg0='default_value'):
 			value = p_arg0
 
-	func _double_InitDefaultParameters():
-		return double(
-			'res://test/unit/test_doubler.gd',
-			'TestInitParameters/InitDefaultParameters')
+	var DoubledClass = null
+	var PartialDoubledClass = null
 
 	func before_all():
-		gut.get_doubler()._print_source = true
-
-	func after_all():
 		gut.get_doubler()._print_source = false
+
+	func before_each():
+		DoubledClass = double(
+			'res://test/unit/test_doubler.gd',
+			'TestInitParameters/InitDefaultParameters')
+		PartialDoubledClass = partial_double(
+			'res://test/unit/test_doubler.gd',
+			'TestInitParameters/InitDefaultParameters')
 
 	# This is due to the gut defaulting mechanism since the
 	# default value cannot be known
 	func test_double_gets_null_for_default_value():
-		var DoubledClass = _double_InitDefaultParameters()
 		var doubled = DoubledClass.new()
 		assert_null(doubled.value)
 
 	func test_double_gets_passed_value():
-		var DoubledClass = _double_InitDefaultParameters()
 		var doubled = DoubledClass.new('test')
 		assert_eq(doubled.value, 'test')
 
-	func test_double_can_have_default_stubbed():
-		var DoubledClass = _double_InitDefaultParameters()
-		stub(DoubledClass, '_init').param_defaults(["override_default"])
+	func test_double_can_have_default_param_values_stubbed():
+		stub('res://test/unit/test_doubler.gd',
+		'TestInitParameters/InitDefaultParameters', '_init').param_defaults(["override_default"])
 		var doubled = DoubledClass.new()
 		assert_eq(doubled.value, 'override_default')
 
 	func test_partial_double_gets_passed_value():
-		var DoubledClass = _double_InitDefaultParameters()
-		var doubled = DoubledClass.new('test')
+		var doubled = PartialDoubledClass.new('test')
 		assert_eq(doubled.value, 'test')
 
 

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -510,6 +510,49 @@ class TestAutofree:
 		var doubled = partial_double('res://test/unit/test_doubler.gd', 'TestAutofree/InitHasDefaultParams').new()
 		assert_eq(doubled.a, 'asdf')
 
+class TestInitParameters:
+	extends BaseTest
+
+	class InitDefaultParameters:
+		var value = 'start_value'
+
+		func _init(p_arg0='default_value'):
+			value = p_arg0
+
+	func _double_InitDefaultParameters():
+		return double(
+			'res://test/unit/test_doubler.gd',
+			'TestInitParameters/InitDefaultParameters')
+
+	func before_all():
+		gut.get_doubler()._print_source = true
+
+	func after_all():
+		gut.get_doubler()._print_source = false
+
+	# This is due to the gut defaulting mechanism since the
+	# default value cannot be known
+	func test_double_gets_null_for_default_value():
+		var DoubledClass = _double_InitDefaultParameters()
+		var doubled = DoubledClass.new()
+		assert_null(doubled.value)
+
+	func test_double_gets_passed_value():
+		var DoubledClass = _double_InitDefaultParameters()
+		var doubled = DoubledClass.new('test')
+		assert_eq(doubled.value, 'test')
+
+	func test_double_can_have_default_stubbed():
+		var DoubledClass = _double_InitDefaultParameters()
+		stub(DoubledClass, '_init').param_defaults(["override_default"])
+		var doubled = DoubledClass.new()
+		assert_eq(doubled.value, 'override_default')
+
+	func test_partial_double_gets_passed_value():
+		var DoubledClass = _double_InitDefaultParameters()
+		var doubled = DoubledClass.new('test')
+		assert_eq(doubled.value, 'test')
+
 
 # class TestDoubleSingleton:
 # 	extends BaseTest


### PR DESCRIPTION
This PR adds:
* The ability to pass parameters to `new` when instancing doubles and partial doubles.
* The ability to stub default parameter values for `_init`.
* The ability to spy on parameters passed to `_init`.

See CHANGES.md for examples.