### PR TITLE
Fix #368.  Add PoolStringArray as a supported default.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Bug Fixes
 * __Issue 288__ First `yield` in a test does not cause a .4 second delay.
+* __Issue 368__ Doubling `WebSocketClient` and anything with a `PoolStringArray` default value.
 
 # 7.3.0
 

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -58,6 +58,7 @@ const PARAM_PREFIX = 'p_'
 	# TYPE_RID = 16 — Variable is of type RID.
 	# TYPE_INT_ARRAY = 21 — Variable is of type PoolIntArray.
 	# TYPE_REAL_ARRAY = 22 — Variable is of type PoolRealArray.
+	# TYPE_STRING_ARRAY = 23 — Variable is of type PoolStringArray.
 
 
 # TYPE_PLANE = 9 — Variable is of type Plane.
@@ -66,7 +67,6 @@ const PARAM_PREFIX = 'p_'
 # TYPE_BASIS = 12 — Variable is of type Basis.
 # TYPE_NODE_PATH = 15 — Variable is of type NodePath.
 # TYPE_RAW_ARRAY = 20 — Variable is of type PoolByteArray.
-# TYPE_STRING_ARRAY = 23 — Variable is of type PoolStringArray.
 # TYPE_VECTOR3_ARRAY = 25 — Variable is of type PoolVector3Array.
 # TYPE_COLOR_ARRAY = 26 — Variable is of type PoolColorArray.
 # TYPE_MAX = 27 — Marker for end of type constants.
@@ -98,6 +98,7 @@ func _init():
 	_supported_defaults[TYPE_TRANSFORM] = 'Transform'
 	_supported_defaults[TYPE_INT_ARRAY] = 'PoolIntArray'
 	_supported_defaults[TYPE_REAL_ARRAY] = 'PoolRealArray'
+	_supported_defaults[TYPE_STRING_ARRAY] = 'PoolStringArray'
 
 # ###############
 # Private
@@ -106,7 +107,7 @@ var _func_text = _utils.get_file_as_text('res://addons/gut/double_templates/func
 var _init_text = _utils.get_file_as_text('res://addons/gut/double_templates/init_template.txt')
 
 func _is_supported_default(type_flag):
-	return type_flag >= 0 and type_flag < _supported_defaults.size() and [type_flag] != null
+	return type_flag >= 0 and type_flag < _supported_defaults.size() and _supported_defaults[type_flag] != null
 
 
 func _make_stub_default(method, index):
@@ -140,7 +141,7 @@ func _make_arg_array(method_meta, override_size):
 					else:
 						dflt_text = str(_supported_defaults[t], str(method_meta.default_args[dflt_idx]).to_lower())
 				elif(t == TYPE_TRANSFORM):
-					#value will be 4 Vector3 and look like: 1, 0, 0, 0, 1, 0, 0, 0, 1 - 0, 0, 0
+					# value will be 4 Vector3 and look like: 1, 0, 0, 0, 1, 0, 0, 0, 1 - 0, 0, 0
 					var sections = str(method_meta.default_args[dflt_idx]).split("-")
 					var vecs = sections[0].split(",")
 					vecs.append_array(sections[1].split(","))
@@ -158,10 +159,9 @@ func _make_arg_array(method_meta, override_size):
 					dflt_text = str(_supported_defaults[t], "(", vectors, ")")
 				elif(t == TYPE_RID):
 					dflt_text = str(_supported_defaults[t], 'null')
-				elif(t in [TYPE_REAL_ARRAY, TYPE_INT_ARRAY]):
+				elif(t in [TYPE_REAL_ARRAY, TYPE_INT_ARRAY, TYPE_STRING_ARRAY]):
 					dflt_text = str(_supported_defaults[t], "()")
-
-				# Everything else puts the prefix (if one is there) form _supported_defaults
+				# Everything else puts the prefix (if one is there) from _supported_defaults
 				# in front.  The to_lower is used b/c for some reason the defaults for
 				# null, true, false are all "Null", "True", "False".
 				else:

--- a/test/unit/test_bugs/test_i368_WebSocketClient_double.gd
+++ b/test/unit/test_bugs/test_i368_WebSocketClient_double.gd
@@ -1,0 +1,40 @@
+extends GutTest
+
+func test_make_double_of_WebSocketClient():
+	var WebSocketClientPD = partial_double(WebSocketClient)
+	assert_not_null(WebSocketClientPD)
+
+func test_make_instance_of_WebSocketClient_double():
+	var pd = double(WebSocketClient).new()
+	assert_not_null(pd)
+
+func test_can_spy_on_connect_to_url():
+	var pd = double(WebSocketClient).new()
+	pd.connect_to_url('somewhere.biz')
+	assert_called(pd, 'connect_to_url')
+
+func test_can_spy_on_partial_connect_to_url():
+	var pd = partial_double(WebSocketClient).new()
+	pd.connect_to_url('somewhere.biz')
+	assert_called(pd, 'connect_to_url')
+
+func test_can_spy_on_defaulted_params():
+	var pd = double(WebSocketClient).new()
+	pd.connect_to_url('somewhere.biz')
+	assert_called(pd, 'connect_to_url',
+		['somewhere.biz', PoolStringArray(), false, PoolStringArray()])
+
+func test_can_stub_default_of_connect_to_url_first_param():
+	stub(WebSocketClient, 'connect_to_url').param_defaults(['asdf'])
+	var pd = double(WebSocketClient).new()
+	pd.connect_to_url()
+	assert_called(pd, 'connect_to_url',
+		['asdf', PoolStringArray(), false, PoolStringArray()])
+
+func test_can_spy_on_all_params():
+	var pd = double(WebSocketClient).new()
+	var psa_1 = PoolStringArray([1, 2, 3])
+	var psa_2 = PoolStringArray(['a', 'b', 'c'])
+	pd.connect_to_url('somewhere.biz', psa_1, true, psa_2)
+	assert_called(pd, 'connect_to_url',
+		['somewhere.biz', psa_1, true, psa_2])

--- a/test/unit/test_method_maker.gd
+++ b/test/unit/test_method_maker.gd
@@ -39,6 +39,18 @@ class TestGetDecleration:
 		var _txt = _mm.get_function_text(meta)
 		assert_true(true, 'we got here')
 
+	func test_unsupported_type_within_range_generates_error():
+		var err_count = gut.get_logger().get_errors().size()
+
+		# Force an unsupported on a known supported
+		_mm._supported_defaults[TYPE_INT] = null
+		var params = [make_param('value1', TYPE_INT)]
+
+		var meta = make_meta('dummy', params)
+		meta.default_args.append(1)
+		var _txt = _mm.get_function_text(meta)
+		assert_eq(gut.get_logger().get_errors().size(), err_count + 1)
+
 	func test_if_unknonw_param_type_function_text_is_null():
 		var params = [make_param('value1', 999)]
 		var meta = make_meta('dummy', params)
@@ -100,6 +112,8 @@ class TestGetDecleration:
 		meta.default_args.append('1,1,1,1')
 		var txt = _mm.get_function_text(meta)
 		assert_string_contains(txt, 'func dummy(p_value1=Color(1,1,1,1)):')
+
+
 
 class TestSuperCall:
 	extends BaseTest


### PR DESCRIPTION
Adds `PoolStringArray` as a supported default value type.  Also fixes a bug that prevented an error message from appearing when an unsupported datatype was encountered.