### PR TITLE
Allow specifying an empty FilePrefix and a FileSuffix from in-editor Plugin Controller

### DIFF
--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -272,8 +272,8 @@ func get_config_issues():
 	if(!has_directory):
 		to_return.append('You do not have any directories set.')
 
-	if(_cfg_ctrls['prefix'].text == ''):
-		to_return.append("You must set a Script prefix or GUT won't find any scripts")
+	if not ('.gd' in _cfg_ctrls['suffix'].text):
+		to_return.append("Script suffix must end in '.gd'")
 
 	return to_return
 
@@ -354,6 +354,8 @@ func set_options(options):
 	_add_title('Misc')
 	_add_value('prefix', options.prefix, 'Script Prefix',
 		"The filename prefix for all test scripts.")
+	_add_value('suffix', options.suffix, 'Script Suffix',
+		"The filename suffix for all test scripts.")
 
 
 func get_options(base_opts):
@@ -404,5 +406,6 @@ func get_options(base_opts):
 
 	# Misc
 	to_return.prefix = _cfg_ctrls.prefix.text
+	to_return.suffix = _cfg_ctrls.suffix.text
 
 	return to_return

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -272,7 +272,7 @@ func get_config_issues():
 	if(!has_directory):
 		to_return.append('You do not have any directories set.')
 
-	if not ('.gd' in _cfg_ctrls['suffix'].text):
+	if(!_cfg_ctrls['suffix'].text.ends_with('.gd')):
 		to_return.append("Script suffix must end in '.gd'")
 
 	return to_return
@@ -355,7 +355,7 @@ func set_options(options):
 	_add_value('prefix', options.prefix, 'Script Prefix',
 		"The filename prefix for all test scripts.")
 	_add_value('suffix', options.suffix, 'Script Suffix',
-		"The filename suffix for all test scripts.")
+		"The filename suffix for all test scripts. Must end in '.gc'")
 
 
 func get_options(base_opts):

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -355,7 +355,7 @@ func set_options(options):
 	_add_value('prefix', options.prefix, 'Script Prefix',
 		"The filename prefix for all test scripts.")
 	_add_value('suffix', options.suffix, 'Script Suffix',
-		"The filename suffix for all test scripts. Must end in '.gc'")
+		"The filename suffix for all test scripts. Must end in '.gd'")
 
 
 func get_options(base_opts):

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -355,7 +355,7 @@ func set_options(options):
 	_add_value('prefix', options.prefix, 'Script Prefix',
 		"The filename prefix for all test scripts.")
 	_add_value('suffix', options.suffix, 'Script Suffix',
-		"The filename suffix for all test scripts. Must end in '.gd'")
+		"Script suffix, including .gd extension.  For example '_foo.gd'.")
 
 
 func get_options(base_opts):

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -38,9 +38,6 @@ var _inner_class_name = ''
 var _should_maximize = false setget set_should_maximize, get_should_maximize
 var _log_level = 1 setget set_log_level, get_log_level
 var _disable_strict_datatype_checks = false setget disable_strict_datatype_checks, is_strict_datatype_checks_disabled
-var _test_prefix = 'test_'
-var _file_prefix = 'test_'
-var _file_suffix = '.gd'
 var _inner_class_prefix = 'Test'
 var _temp_directory = 'user://gut_temp_directory'
 var _export_path = '' setget set_export_path, get_export_path
@@ -1083,7 +1080,9 @@ func test_scripts(run_rest=false):
 	if(_script_name != null and _script_name != ''):
 		var indexes = _get_indexes_matching_script_name(_script_name)
 		if(indexes == []):
-			_lgr.error('Could not find script matching ' + _script_name)
+			_lgr.error(str(
+				"Could not find script matching '", _script_name, "'.\n",
+				"Check your directory settings and Script Prefix/Suffix settings."))
 		else:
 			_test_the_scripts(indexes)
 	else:
@@ -1119,7 +1118,7 @@ func add_script(script):
 # with the suffix.  Does not look in sub directories.  Can be called multiple
 # times.
 # ------------------------------------------------------------------------------
-func add_directory(path, prefix=_file_prefix, suffix=_file_suffix):
+func add_directory(path, prefix="test_", suffix=".gd"):
 	# check for '' b/c the calls to addin the exported directories 1-6 will pass
 	# '' if the field has not been populated.  This will cause res:// to be
 	# processed which will include all files if include_subdirectories is true.

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -41,7 +41,6 @@ var _disable_strict_datatype_checks = false setget disable_strict_datatype_check
 var _test_prefix = 'test_'
 var _file_prefix = 'test_'
 var _file_suffix = '.gd'
-var _file_extension = '.gd'
 var _inner_class_prefix = 'Test'
 var _temp_directory = 'user://gut_temp_directory'
 var _export_path = '' setget set_export_path, get_export_path

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -40,6 +40,7 @@ var _log_level = 1 setget set_log_level, get_log_level
 var _disable_strict_datatype_checks = false setget disable_strict_datatype_checks, is_strict_datatype_checks_disabled
 var _test_prefix = 'test_'
 var _file_prefix = 'test_'
+var _file_suffix = '.gd'
 var _file_extension = '.gd'
 var _inner_class_prefix = 'Test'
 var _temp_directory = 'user://gut_temp_directory'
@@ -1119,7 +1120,7 @@ func add_script(script):
 # with the suffix.  Does not look in sub directories.  Can be called multiple
 # times.
 # ------------------------------------------------------------------------------
-func add_directory(path, prefix=_file_prefix, suffix=_file_extension):
+func add_directory(path, prefix=_file_prefix, suffix=_file_suffix):
 	# check for '' b/c the calls to addin the exported directories 1-6 will pass
 	# '' if the field has not been populated.  This will cause res:// to be
 	# processed which will include all files if include_subdirectories is true.

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -133,7 +133,7 @@ func setup_options(options, font_names):
 	opts.add('-gtest', [], 'Comma delimited list of full paths to test scripts to run.')
 	opts.add('-gdir', options.dirs, 'Comma delimited list of directories to add tests from.')
 	opts.add('-gprefix', options.prefix, 'Prefix used to find tests when specifying -gdir.  Default "[default]".')
-	opts.add('-gsuffix', options.suffix, 'Suffix used to find tests when specifying -gdir.  Default "[default]".')
+	opts.add('-gsuffix', options.suffix, 'Test script suffix, including .gd extension.  Default "[default]".')
 	opts.add('-ghide_orphans', false, 'Display orphan counts for tests and scripts.  Default "[default]".')
 	opts.add('-gmaximize', false, 'Maximizes test runner window to fit the viewport.')
 	opts.add('-gcompact_mode', false, 'The runner will be in compact mode.  This overrides -gmaximize.')

--- a/addons/gut/plugin_control.gd
+++ b/addons/gut/plugin_control.gd
@@ -75,9 +75,6 @@ export var _test_prefix = 'test_'
 export var _file_prefix = 'test_'
 # The suffix used to find test scripts.
 export var _file_suffix = '.gd'
-# The file extension for test scripts (I don't think you can change this and
-# everything will work).
-export var _file_extension = '.gd'
 # The prefix used to find Inner Test Classes.
 export var _inner_class_prefix = 'Test'
 # The directory GUT will use to write any temporary files.  This isn't used
@@ -186,7 +183,6 @@ func _setup_gut():
 	_gut._test_prefix = _test_prefix
 	_gut._file_prefix = _file_prefix
 	_gut._file_suffix = _file_suffix
-	_gut._file_extension = _file_extension
 	_gut._inner_class_prefix = _inner_class_prefix
 	_gut._temp_directory = _temp_directory
 

--- a/addons/gut/plugin_control.gd
+++ b/addons/gut/plugin_control.gd
@@ -182,7 +182,6 @@ func _setup_gut():
 
 	_gut._test_prefix = _test_prefix
 	_gut._file_prefix = _file_prefix
-	_gut._file_suffix = _file_suffix
 	_gut._inner_class_prefix = _inner_class_prefix
 	_gut._temp_directory = _temp_directory
 

--- a/addons/gut/plugin_control.gd
+++ b/addons/gut/plugin_control.gd
@@ -73,8 +73,10 @@ export var _disable_strict_datatype_checks = false
 export var _test_prefix = 'test_'
 # The prefix used to find test scripts.
 export var _file_prefix = 'test_'
+# The suffix used to find test scripts.
+export var _file_suffix = '.gd'
 # The file extension for test scripts (I don't think you can change this and
-# everythign work).
+# everything will work).
 export var _file_extension = '.gd'
 # The prefix used to find Inner Test Classes.
 export var _inner_class_prefix = 'Test'
@@ -183,6 +185,7 @@ func _setup_gut():
 
 	_gut._test_prefix = _test_prefix
 	_gut._file_prefix = _file_prefix
+	_gut._file_suffix = _file_suffix
 	_gut._file_extension = _file_extension
 	_gut._inner_class_prefix = _inner_class_prefix
 	_gut._temp_directory = _temp_directory

--- a/scenes/TestPrint.tscn
+++ b/scenes/TestPrint.tscn
@@ -30,7 +30,6 @@ _yield_between_tests = true
 _disable_strict_datatype_checks = false
 _test_prefix = "test_"
 _file_prefix = "test_"
-_file_suffix = ".gd"
 _inner_class_prefix = "Test"
 _temp_directory = "user://gut_temp_directory"
 _export_path = ""

--- a/scenes/TestPrint.tscn
+++ b/scenes/TestPrint.tscn
@@ -30,6 +30,7 @@ _yield_between_tests = true
 _disable_strict_datatype_checks = false
 _test_prefix = "test_"
 _file_prefix = "test_"
+_file_suffix = ".gd"
 _file_extension = ".gd"
 _inner_class_prefix = "Test"
 _temp_directory = "user://gut_temp_directory"

--- a/scenes/TestPrint.tscn
+++ b/scenes/TestPrint.tscn
@@ -31,7 +31,6 @@ _disable_strict_datatype_checks = false
 _test_prefix = "test_"
 _file_prefix = "test_"
 _file_suffix = ".gd"
-_file_extension = ".gd"
 _inner_class_prefix = "Test"
 _temp_directory = "user://gut_temp_directory"
 _export_path = ""

--- a/test/resources/parsing_and_loading_samples/test_with_specific_suffix.gd
+++ b/test/resources/parsing_and_loading_samples/test_with_specific_suffix.gd
@@ -1,0 +1,6 @@
+extends "res://addons/gut/test.gd"
+
+# This test file should only be detected when specifying a 'specific_prefix' and 'suffix.gd'.
+
+func test_empty():
+    assert_true(true, 'All is well.')

--- a/test/unit/test_gut_directory.gd
+++ b/test/unit/test_gut_directory.gd
@@ -46,6 +46,12 @@ class TestUsingResDirs:
 		gr.gut.add_directory(TEST_LOAD_DIR)
 		assert_false(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/bad_prefix.gd'))
 
+	func test_adding_directory_loads_files_for_given_suffix():
+		gr.gut._file_suffix = 'specific_suffix.gd'
+		gr.gut.add_directory(TEST_LOAD_DIR)
+		assert_true(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/test_with_specific_suffix.gd'))
+		assert_eq(gr.gut_test_collector.scripts.size(), 1, 'Should not find more than one test script with \'specific_suffix.gd\'')
+
 	func test_adding_directory_skips_files_with_wrong_extension():
 		gr.gut.add_directory(TEST_LOAD_DIR)
 		assert_false(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/test_bad_extension.txt'))

--- a/test/unit/test_gut_directory.gd
+++ b/test/unit/test_gut_directory.gd
@@ -38,6 +38,7 @@ class TestUsingResDirs:
 	func before_each():
 		gr.gut = get_a_gut()
 
+
 	func test_adding_directory_loads_files():
 		gr.gut.add_directory(TEST_LOAD_DIR)
 		assert_true(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/test_samples.gd'))
@@ -47,10 +48,9 @@ class TestUsingResDirs:
 		assert_false(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/bad_prefix.gd'))
 
 	func test_adding_directory_loads_files_for_given_suffix():
-		gr.gut._file_suffix = 'specific_suffix.gd'
-		gr.gut.add_directory(TEST_LOAD_DIR)
-		assert_true(gr.gut._test_collector.has_script(TEST_LOAD_DIR + '/test_with_specific_suffix.gd'))
-		assert_eq(gr.gut_test_collector.scripts.size(), 1, 'Should not find more than one test script with \'specific_suffix.gd\'')
+		gr.gut.add_directory(TEST_LOAD_DIR, 'test_', 'specific_suffix.gd')
+		assert_true(gr.gut.get_test_collector().has_script(TEST_LOAD_DIR + '/test_with_specific_suffix.gd'))
+		assert_eq(gr.gut.get_test_collector().scripts.size(), 1, 'Should not find more than one test script with \'specific_suffix.gd\'')
 
 	func test_adding_directory_skips_files_with_wrong_extension():
 		gr.gut.add_directory(TEST_LOAD_DIR)


### PR DESCRIPTION
Fixes #375 

Adds a new control field to `gut_config_gui.gd` for `Script Suffix` and propagates its value to the workspace config file.
Reports an error if the user specifies a `suffix` which does not end in `.gd`.
Allows `file_prefix` to be empty (i.e. `''`).
- The previous error message says it must not be empty or GUT cannot find any scripts. However, in reality an empty prefix will match all files, which is actually what the user probably wants.
Both fields retain their default values of `test_` and `.gd` respectively.

Adds a new test and test sample file to express the suffix matching behavior. 
There do not seem to be any tests covering the `gut_config_gui` it self, though I'm not sure how to test such a thing.

Please let me know if you see a gap in coverage.

----

Wiki Text Update:

`wiki/Gut-Settings-And-Methods`

Add after `File Prefix` in the options list:
```
|File Suffix|The suffix used on all test files.  Must end with `.gd`. This is used in conjunction with the Directory settings to find tests.|
```

Remove the row for `File Extension` as it has been removed.

----

I've run the tests locally with this configuration:
```
Platform: OSX 10.15.7
Godot version:  3.4.4
GUT version:  7.3.0
```

My updated test file still passes:

`gut -gexit -gselect=test_gut_directory.gd`

<details>
  <summary>Output</summary>
arguments
0: /Users/brisberg/Library/Application Support/Steam/steamapps/common/Godot Engine/Godot.app/Contents/MacOS/Godot
1: --path
2: /Users/brisberg/DevProjects/forks/Gut
3: -s
4: addons/gut/gut_cmdln.gd
5: -gexit
6: -gselect=test_gut_directory.gd
Current path: /Users/brisberg/DevProjects/forks/Gut
Godot Engine v3.4.4.stable.official.419e713a2 - https://godotengine.org
OpenGL ES 3.0 Renderer: Intel Iris Pro OpenGL Engine
OpenGL ES Batching: ON

Registered camera FaceTime HD Camera with id 1 position 0 at index 0


 ---  Gut  ---
[INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
Godot version:  3.4.4
GUT version:  7.3.0


res://test/unit/test_gut_directory.gd.TestUsingResDirs
* test_adding_directory_loads_files
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
SCRIPT ERROR: Invalid get index 'gut_test_collector' (on base: 'Dictionary').
          at: TestUsingResDirs.test_adding_directory_loads_files_for_given_suffix (res://test/unit/test_gut_directory.gd:54)
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [ERROR]:  The path [res://adsf] does not exist.
    [Passed]:  We should get here
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]:  [135] expected to equal [135]:
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]:  Should have dir1 script
    [Passed]:  Should have dir2 script
    [Passed]:  Should have dir3 script
    [Passed]:  [3] expected to equal [3]:  they should have passed
    [Orphans]:  1 new orphan in test.
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
[Orphans]:  1 new orphan in script.
[WARNING]:  Test script still has children when all tests finisehd.
  @@189:[Control:3263](gut.gd)
  @@283:[Control:3579](gut.gd)
  @@377:[Control:3822](gut.gd)
  @@471:[Control:4134](gut.gd)
  @@565:[Control:4372](gut.gd)
  @@659:[Control:6207](gut.gd)
  @@753:[Control:6443](gut.gd)
  @@847:[Control:8308](gut.gd)
You can use autofree, autoqfree, add_child_autofree, or add_child_autoqfree to automatically free objects.
7/7 passed.


res://test/unit/test_gut_directory.gd.TestUsingDynamicDirs
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]:  @@1130:[Control:9142](gut.gd) should have getter starting with get_ or is_
    [Passed]:  @@1130:[Control:9142](gut.gd) should have method: set_include_subdirectories
    [Passed]:  [False] expected to equal [False]:  It should have the expected default value.
    [Passed]:  [True] expected to equal [True]:  The set value should have been returned.
    [INFO]:  using [/Users/brisberg/Library/Application Support/Godot/app_userdata/Gut] for temporary output.
    Godot version:  3.4.4
    GUT version:  7.3.0
    [Passed]
[WARNING]:  Test script still has children when all tests finisehd.
  @@942:[Control:8630](gut.gd)
  @@1036:[Control:8888](gut.gd)
  @@1130:[Control:9142](gut.gd)
  @@1224:[Control:9396](gut.gd)
You can use autofree, autoqfree, add_child_autofree, or add_child_autoqfree to automatically free objects.
7/7 passed.


*** Run Summary ***
All tests passed

Totals
Scripts:          1
Passing tests     11
Failing tests     0
Risky tests       0
Pending:          0
Asserts:          14 of 14 passed

Warnings/Errors:
* 1 Errors.
* 2 Warnings.


11 passed 0 failed.  Tests finished in 0.0s


[Orphans]:  1921 new orphans in total.
Note:  This count does not include GUT objects that will be freed upon exit.
       It also does not include any orphans created by global scripts
       loaded before tests were ran.
Total orphans = 1924
Ran Scripts matching "test_gut_directory.gd"
Results saved to user://logs/gut_results_1658730950.json
</details>

However, a full test run shows 10-11 tests which still fail and numerous warnings. These appear to be the same tests which fail from a fresh checkout of `master`.

Are these erroneous tests expected? Please advise if I should ignore these failures since they do not appear to be related to this change.