### PR TITLE
I387 accumulate input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # 7.X.X
 
 ## Features
-* __Issue 354__ Doubles and partial doubles can now be instanced with parameters
+* __Issue #354__ Doubles and partial doubles can now be instanced with parameters
   * You can now specify parameters when instancing a double/partial double:<br/>
   `var dbl = double(MyClass).new(1, 2, 'c')`
   * You can now spy on `_init` to verify parameter values:<br/>
   `assert_called(my_inst, '_init', [1, 2, 'c'])`
   * You can now stub default parameter values for `_init`:<br/>
   `stub(MyClass, '_init').param_defaults([1, 2, 'c'])`
-* __Issue 363__ GUT In-Editor Panel Improvements
+* __Issue #363__ GUT In-Editor Panel Improvements
   * New, super fancy, Tree Panel that shows your failing/pending/risky tests.  Click an element in the tree, go to that line in the file AND that line in the output.
   * You can toggle the visibility of Settings, Output, and Tree panels.
   * You can search the output.
@@ -25,8 +25,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Test totals in various places have been adjusted to display a passing count and total count.
 
 ## Bug Fixes
-* __Issue 288__ First `yield` in a test does not cause a .4 second delay.
-* __Issue 368__ Doubling `WebSocketClient` and anything with a `PoolStringArray` default value.
+* __Issue #288__ First `yield` in a test does not cause a .4 second delay.
+* __Issue #368__ Doubling `WebSocketClient` and anything with a `PoolStringArray` default value.
+* __Issue #387__ Introduced `auto_flush_input` to `InputSender` to address that `Input.use_accumulate_input` is enabled by default in Godot 3.5.0.
 
 # 7.3.0
 

--- a/addons/gut/UserFileViewer.tscn
+++ b/addons/gut/UserFileViewer.tscn
@@ -26,8 +26,6 @@ resizable = true
 mode = 0
 access = 1
 show_hidden_files = true
-current_dir = "user://"
-current_path = "user://"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/addons/gut/input_sender.gd
+++ b/addons/gut/input_sender.gd
@@ -92,6 +92,7 @@ class InputQueueItem:
 			var t = _delay_timer(time_delay)
 			t.connect("timeout", self, "_on_time_timeout")
 
+
 # ##############################################################################
 #
 # ##############################################################################
@@ -115,6 +116,8 @@ var _last_event = null
 var _pressed_keys = {}
 var _pressed_actions = {}
 var _pressed_mouse_buttons = {}
+
+var _auto_flush_input = false
 
 signal idle
 
@@ -141,6 +144,8 @@ func _send_event(event):
 	for r in _receivers:
 		if(r == Input):
 			Input.parse_input_event(event)
+			if(_auto_flush_input):
+				Input.flush_buffered_events()
 		else:
 			if(r.has_method("_input")):
 				r._input(event)
@@ -363,3 +368,11 @@ func is_action_pressed(which):
 
 func is_mouse_button_pressed(which):
 	return _pressed_mouse_buttons.has(which) and _pressed_mouse_buttons[which]
+
+
+func get_auto_flush_input():
+	return _auto_flush_input
+
+
+func set_auto_flush_input(val):
+	_auto_flush_input = val

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1651,3 +1651,37 @@ func assert_ne_shallow(v1, v2):
 		_pass(result.get_short_summary())
 	else:
 		_fail(result.get_short_summary())
+
+
+# ------------------------------------------------------------------------------
+# Checks the passed in version string (x.x.x) against the engine version to see
+# if the engine version is less than the expected version.  If it is then the
+# test is mareked as passed (for a lack of anything better to do).  The result
+# of the check is returned.
+#
+# Example:
+# if(skip_if_godot_version_lt('3.5.0')):
+# 	return
+# ------------------------------------------------------------------------------
+func skip_if_godot_version_lt(expected):
+	var should_skip = !_utils.is_godot_version_gte(expected)
+	if(should_skip):
+		_pass(str('Skipping ', _utils.godot_version(), ' is less than ', expected))
+	return should_skip
+
+
+# ------------------------------------------------------------------------------
+# Checks if the passed in version matches the engine version.  The passed in
+# version can contain just the major, major.minor or major.minor.path.  If
+# the version is not the same then the test is marked as passed.  The result of
+# the check is returned.
+#
+# Example:
+# if(skip_if_godot_version_ne('3.4')):
+# 	return
+# ------------------------------------------------------------------------------
+func skip_if_godot_version_ne(expected):
+	var should_skip = !_utils.is_godot_version(expected)
+	if(should_skip):
+		_pass(str('Skipping ', _utils.godot_version(), ' is not ', expected))
+	return should_skip

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -202,6 +202,32 @@ func is_version_ok(engine_info=Engine.get_version_info(),required=req_godot):
 	return nvl(is_ok, true)
 
 
+func godot_version(engine_info=Engine.get_version_info()):
+	return str(engine_info.major, '.', engine_info.minor, '.', engine_info.patch)
+
+
+func is_godot_version(expected, engine_info=Engine.get_version_info()):
+	var engine_array = [engine_info.major, engine_info.minor, engine_info.patch]
+	var expected_array = expected.split('.')
+
+	if(expected_array.size() > engine_array.size()):
+		return false
+
+	var is_version = true
+	var i = 0
+	while(i < expected_array.size() and i < engine_array.size() and is_version):
+		if(expected_array[i] == str(engine_array[i])):
+			i += 1
+		else:
+			is_version = false
+
+	return is_version
+
+
+func is_godot_version_gte(expected, engine_info=Engine.get_version_info()):
+	return is_version_ok(engine_info, expected.split('.'))
+
+
 # ------------------------------------------------------------------------------
 # Everything should get a logger through this.
 #

--- a/scratch/test_35_input_sender.gd
+++ b/scratch/test_35_input_sender.gd
@@ -7,7 +7,7 @@ extends SceneTree
 #
 # For all checks other than is_action_just_pressed and is_action_just_released,
 # yeilding before checking will also work.  The *just* methods require that you
-# either disable accumu0lated input or flush the buffer so that checks fire
+# either disable accumulated input or flush the buffer so that checks fire
 # on the same frame.
 
 var InputSender = load('res://addons/gut/input_sender.gd')

--- a/scratch/test_35_input_sender.gd
+++ b/scratch/test_35_input_sender.gd
@@ -1,0 +1,54 @@
+extends SceneTree
+# In 3.5 Input.use_accumulated_input has been enabled by default.  In 3.4 it was
+# disabled even though the documentation indicated it was enabled.  In order for
+# Input to fire all events as they are sent through an InputSender you must either
+# disable use_accumulated_input or call Input.flush_buffered_events() before
+# you check that an input was handled correctly.
+#
+# For all checks other than is_action_just_pressed and is_action_just_released,
+# yeilding before checking will also work.  The *just* methods require that you
+# either disable accumu0lated input or flush the buffer so that checks fire
+# on the same frame.
+
+var InputSender = load('res://addons/gut/input_sender.gd')
+
+func test_input_vanilla():
+    # -- Action checks --
+    var action_event = InputEventAction.new()
+    action_event.action = 'jump'
+    action_event.pressed = true
+
+    Input.parse_input_event(action_event)
+    Input.flush_buffered_events()
+    print("jump pressed = ", Input.is_action_pressed('jump'))
+    print("jump just pressed = ", Input.is_action_just_pressed('jump'))
+
+    # -- Key checks --
+    var key_event = InputEventKey.new()
+    key_event.pressed = true
+    key_event.scancode = KEY_Y
+
+    Input.parse_input_event(key_event)
+    Input.flush_buffered_events()
+    print('Y pressed = ', Input.is_key_pressed(KEY_Y))
+
+
+func test_auto_flush():
+    var sender = InputSender.new(Input)
+    sender._auto_flush_input = false
+
+    var action_event = InputEventAction.new()
+    action_event.action = 'jump'
+    action_event.pressed = true
+
+    sender.send_event(action_event)
+    print("jump pressed = ", Input.is_action_pressed('jump'))
+    print("jump just pressed = ", Input.is_action_just_pressed('jump'))
+
+
+func _init():
+    # Input.use_accumulated_input = false
+    InputMap.add_action("jump")
+    test_auto_flush()
+
+    quit()

--- a/test/unit/test_orphan_counter.gd
+++ b/test/unit/test_orphan_counter.gd
@@ -11,7 +11,6 @@ func test_can_add_get_counter():
 	assert_eq(oc.get_counter('one'), 4)
 
 func test_print_singular_orphan():
-	stub(_utils.Logger, '_init').to_do_nothing()
 	var oc = partial_double(_utils.OrphanCounter).new()
 	var d_logger = double(_utils.Logger).new()
 
@@ -23,7 +22,6 @@ func test_print_singular_orphan():
 	assert_string_contains(msg, 'orphan(')
 
 func test_print_plural_orphans():
-	stub(_utils.Logger, '_init').to_do_nothing()
 	var oc = partial_double(_utils.OrphanCounter).new()
 	var d_logger = double(_utils.Logger).new()
 

--- a/test/unit/test_utils.gd
+++ b/test/unit/test_utils.gd
@@ -24,6 +24,15 @@ func test_is_double_returns_false_for_primitives():
 	assert_false(utils.is_double({}), 'dictionary')
 	# that's probably enough spot checking
 
+func test_latest_version_if_version_is_old_warning_is_on():
+	var utils = autofree(Utils.new())
+	utils.version = "1.0.0"
+	add_child(utils)
+	utils._http_request_latest_version()
+	var p = utils.get_node("http_request")
+	assert_not_null(p, "should have a child http request")
+	yield(yield_to(p,"request_completed",2),YIELD)
+	assert_true(utils.should_display_latest_version,"this should fail only if you dont have internet connection")
 
 class OverloadsGet:
 	var a = []
@@ -61,6 +70,7 @@ func test_get_native_class_name_does_not_free_references():
 	pass_test("we got here")
 
 
+
 class TestVersionCheck:
 	extends 'res://addons/gut/test.gd'
 
@@ -70,7 +80,7 @@ class TestVersionCheck:
 		var parsed = version.split('.')
 		return{'major':parsed[0], 'minor':parsed[1], 'patch':parsed[2]}
 
-	var test_versions = ParameterFactory.named_parameters(
+	var test_ok_versions = ParameterFactory.named_parameters(
 		['engine_version', 'req_version', 'expected_result'],
 		[
 			['1.2.3', '1.2.3', true],
@@ -88,20 +98,31 @@ class TestVersionCheck:
 			['1.2.3', '1.3.0', false],
 
 		])
-	func test_is_version_ok(p=use_parameters(test_versions)):
+	func test_is_version_ok(p=use_parameters(test_ok_versions)):
 		var utils = autofree(Utils.new())
 		var engine_info = _fake_engine_version(p.engine_version)
 		var req_version = p.req_version.split('.')
 		assert_eq(utils.is_version_ok(engine_info, req_version), p.expected_result,
 			str(p.engine_version, ' >= ', p.req_version))
 
+	var test_is_versions = ParameterFactory.named_parameters(
+		['engine_version', 'expected_version', 'expected_result'],
+		[
+			['1.2.3', '1.2.3', true],
+			['1.2.3', '1.2', true],
+			['1.2.3', '1', true],
 
-func test_latest_version_if_version_is_old_warning_is_on():
-	var utils = autofree(Utils.new())
-	utils.version = "1.0.0"
-	add_child(utils)
-	utils._http_request_latest_version()
-	var p = utils.get_node("http_request")
-	assert_not_null(p, "should have a child http request")
-	yield(yield_to(p,"request_completed",2),YIELD)
-	assert_true(utils.should_display_latest_version,"this should fail only if you dont have internet connection")
+			['1.2.4', '1.2.3', false],
+			['1.3.3', '1.2.3', false],
+			['2.2.3', '1.2.3', false],
+
+			['1.2.3', '1.2.3.4', false]
+		])
+
+	func test_is_godot_version(p=use_parameters(test_is_versions)):
+		var utils = autofree(Utils.new())
+		var engine_info = _fake_engine_version(p.engine_version)
+		assert_eq(utils.is_godot_version(p.expected_version, engine_info), p.expected_result,
+			str(p.engine_version, ' is ', p.expected_version))
+
+


### PR DESCRIPTION
Adds `auto_flush_input` to `InputSender`.  This will make the `InputSender` behave as if `Input.use_accumulate_input` was disabled (enabled by default in Godot 3.5).  This gives you the option to set this on `InputSender` without having to worry about setting and resetting `use_accumulate_input` in your tests (at the cost of having to set it on every `InputSender` you create).

When `use_accumulate_input` is enabled and `auto_flush_input` is disabled (it is by default), then any input sent through `Input` via `InputSender` or anywhere else will not be processed until the end of a frame.  