### PR TITLE
4.0 Name Change Errors

### DIFF
--- a/addons/gut/gui/OutputText.gd
+++ b/addons/gut/gui/OutputText.gd
@@ -123,7 +123,7 @@ func _ready():
 # Private
 # ------------------
 func _setup_colors():
-	_ctrls.output.clear_colors()
+	_ctrls.output.clear()
 	var keywords = [
 		['Failed', Color.RED],
 		['Passed', Color.GREEN],

--- a/addons/gut/gui/RunResults.gd
+++ b/addons/gut/gui/RunResults.gd
@@ -52,7 +52,7 @@ func _test_running_setup():
 
 
 func _set_toolbutton_icon(btn, icon_name, text):
-	if(Engine.editor_hint):
+	if(Engine.is_editor_hint()):
 		btn.icon = get_theme_icon(icon_name, 'EditorIcons')
 	else:
 		btn.text = str('[', text, ']')
@@ -84,7 +84,7 @@ func _ready():
 	call_deferred('_update_min_width')
 
 func _update_min_width():
-	custom_minimum_size.x = _ctrls.toolbar.toolbar.rect_size.x
+	custom_minimum_size.x = _ctrls.toolbar.toolbar.size.x
 
 func _open_file(path, line_number):
 	if(_interface == null):


### PR DESCRIPTION
### Summary

Fixes a few errors relating to 4.0 name changes that appear after enabling the plugin within a 4.0 project.

#### Additional Comments

I noticed there are two 4.0 related branches.  Not sure if this is the main one, but seeing as it was updated recently I decided to use it as a base.  