### PR TITLE
4.0 Button Pressed in GutBottomPanel & OutputText

### DIFF
--- a/addons/gut/gui/GutBottomPanel.gd
+++ b/addons/gut/gui/GutBottomPanel.gd
@@ -52,8 +52,8 @@ func _init():
 
 
 func _ready():
-	_ctrls.results.bar.connect('draw',Callable(self,'_on_results_bar_draw'),[_ctrls.results.bar])
-	hide_settings(!_ctrls.settings_button.pressed)
+	_ctrls.results.bar.connect('draw', _on_results_bar_draw.bind(_ctrls.results.bar))
+	hide_settings(!_ctrls.settings_button.button_pressed)
 	_gut_config_gui = GutConfigGui.new(_ctrls.settings)
 	_gut_config_gui.set_options(_gut_config.options)
 
@@ -130,9 +130,9 @@ func _show_errors(errs):
 
 func _save_config():
 	_gut_config.options = _gut_config_gui.get_options(_gut_config.options)
-	_gut_config.options.panel_options.hide_settings = !_ctrls.settings_button.pressed
-	_gut_config.options.panel_options.hide_result_tree = !_ctrls.run_results_button.pressed
-	_gut_config.options.panel_options.hide_output_text = !_ctrls.output_button.pressed
+	_gut_config.options.panel_options.hide_settings = !_ctrls.settings_button.button_pressed
+	_gut_config.options.panel_options.hide_result_tree = !_ctrls.run_results_button.button_pressed
+	_gut_config.options.panel_options.hide_output_text = !_ctrls.output_button.button_pressed
 	_gut_config.options.panel_options.use_colors = _ctrls.output_ctrl.get_use_colors()
 
 	var w_result = _gut_config.write_options(RUNNER_JSON_PATH)
@@ -218,17 +218,17 @@ func _on_RunAtCursor_run_tests(what):
 
 
 func _on_Settings_pressed():
-	hide_settings(!_ctrls.settings_button.pressed)
+	hide_settings(!_ctrls.settings_button.button_pressed)
 	_save_config()
 
 
 func _on_OutputBtn_pressed():
-	hide_output_text(!_ctrls.output_button.pressed)
+	hide_output_text(!_ctrls.output_button.button_pressed)
 	_save_config()
 
 
 func _on_RunResultsBtn_pressed():
-	hide_result_tree(! _ctrls.run_results_button.pressed)
+	hide_result_tree(! _ctrls.run_results_button.button_pressed)
 	_save_config()
 
 
@@ -242,7 +242,7 @@ func _on_UseColors_pressed():
 # ---------------
 func hide_result_tree(should):
 	_ctrls.run_results.visible = !should
-	_ctrls.run_results_button.pressed = !should
+	_ctrls.run_results_button.button_pressed = !should
 
 
 func hide_settings(should):
@@ -257,12 +257,12 @@ func hide_settings(should):
 		s_scroll.get_parent().move_child(s_scroll, 1)
 
 	$layout/RSplit.collapsed = should
-	_ctrls.settings_button.pressed = !should
+	_ctrls.settings_button.button_pressed = !should
 
 
 func hide_output_text(should):
 	$layout/RSplit/CResults/TabBar/OutputText.visible = !should
-	_ctrls.output_button.pressed = !should
+	_ctrls.output_button.button_pressed = !should
 
 
 func load_result_output():

--- a/addons/gut/gui/OutputText.gd
+++ b/addons/gut/gui/OutputText.gd
@@ -164,7 +164,7 @@ func _on_CopyButton_pressed():
 
 
 func _on_UseColors_pressed():
-	_ctrls.output.syntax_highlighter = _ctrls.use_colors.pressed
+	_ctrls.output.syntax_highlighter = _ctrls.use_colors.button_pressed
 
 
 func _on_ClearButton_pressed():
@@ -172,7 +172,7 @@ func _on_ClearButton_pressed():
 
 
 func _on_ShowSearch_pressed():
-	show_search(_ctrls.show_search.pressed)
+	show_search(_ctrls.show_search.button_pressed)
 
 
 func _on_SearchTerm_focus_entered():
@@ -216,7 +216,7 @@ func show_search(should):
 	if(should):
 		_ctrls.search_bar.search_term.grab_focus()
 		_ctrls.search_bar.search_term.select_all()
-	_ctrls.show_search.pressed = should
+	_ctrls.show_search.button_pressed = should
 
 
 func search(text, start_pos, highlight=true):


### PR DESCRIPTION
### Summary

- Addresses a part of #384 regarding the conversion of `button.pressed` to `button.button_pressed` in 4.0 for `GutBottomPanel` and `OutputText`
- Fixes a  `_on_results_bar_draw` binding in `GutBottomPanel` according to #383