### PR TITLE
4.0 DirectoryCtrl::set_text Infinite Loop Fix

### DIFF
--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -7,7 +7,9 @@ class DirectoryCtrl:
 		get:
 			return get_text()
 		set(val):
-			set_text(val)
+			text = val
+			_txt_path.text = text
+
 	var _txt_path = LineEdit.new()
 	var _btn_dir = Button.new()
 	var _dialog = FileDialog.new()
@@ -25,7 +27,7 @@ class DirectoryCtrl:
 		_dialog.size = Vector2(1000, 700)
 
 	func _on_selected(path):
-		set_text(path)
+		text = path
 
 
 	func _on_dir_button_pressed():
@@ -34,16 +36,12 @@ class DirectoryCtrl:
 
 
 	func _ready():
-		add_child(_txt_path)
-		add_child(_btn_dir)
-		add_child(_dialog)
+		call_deferred('add_child', _txt_path)
+		call_deferred('add_child', _btn_dir)
+		call_deferred('add_child', _dialog)
 
 	func get_text():
 		return _txt_path.text
-
-	func set_text(t):
-		text = t
-		_txt_path.text = text
 
 	func get_line_edit():
 		return _txt_path

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -5,9 +5,8 @@ class DirectoryCtrl:
 
 	var text = '':
 		get:
-			return get_text()
+			return _txt_path.text
 		set(val):
-			text = val
 			_txt_path.text = text
 
 	var _txt_path = LineEdit.new()
@@ -36,12 +35,10 @@ class DirectoryCtrl:
 
 
 	func _ready():
-		call_deferred('add_child', _txt_path)
-		call_deferred('add_child', _btn_dir)
-		call_deferred('add_child', _dialog)
+		add_child(_txt_path)
+		add_child(_btn_dir)
+		add_child(_dialog)
 
-	func get_text():
-		return _txt_path.text
 
 	func get_line_edit():
 		return _txt_path


### PR DESCRIPTION
### Summary

#### Bug

An infinite loop occurs while attempting to initialize `gut_config_gui` due to `set_text` calling into itself via `text = t`, resulting in an editor crash while opening a project with the plugin enabled.  In case it's relevant, I'm running the editor and plugin on Windows 10.

Interestingly, I received no error messages (such as an out of memory error / exception) from the engine while trying to nail down the source, even when running the editor in verbose mode.  

#### Fix 

I removed the `set_text` function in `DirectoryCtrl`, migrating the logic into the setter. 

~~#### Extras~~

~~I changed the `add_child` calls to `call_deferred` in `DirectoryCtrl::_ready` as I believe this is the preferred method for adding children in `_ready`.~~