### PR TITLE
4.0 Gut Runner Fixes

### DIFF
--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -42,8 +42,8 @@ func run_tests():
 		add_child(_gut)
 
 	if(!_cmdln_mode):
-		_gut.connect('tests_finished', self, '_on_tests_finished',
-			[_gut_config.options.should_exit, _gut_config.options.should_exit_on_success])
+		_gut.connect('tests_finished', _on_tests_finished.bind(
+			_gut_config.options.should_exit, _gut_config.options.should_exit_on_success))
 
 	_gut_config.config_gut(_gut)
 	if(_gut_config.options.gut_on_top):
@@ -62,7 +62,7 @@ func _write_results():
 		f.store_string(content)
 		f.close()
 	else:
-		print('ERROR Could not save bbcode, result = ', result)
+		push_error('Could not save bbcode, result = ', result)
 
 	var exporter = ResultExporter.new()
 	var f_result = exporter.write_json_file(_gut, RESULT_JSON)

--- a/addons/gut/gui/RunResults.gd
+++ b/addons/gut/gui/RunResults.gd
@@ -220,7 +220,7 @@ func _load_result_tree(j):
 			s_item.free()
 		else:
 			var total_text = str(test_keys.size(), ' passed')
-			s_item.set_text_alignment(1, s_item.ALIGN_LEFT)
+			s_item.set_text_alignment(1, HORIZONTAL_ALIGNMENT_LEFT)
 			if(bad_count == 0):
 				s_item.collapsed = true
 			else:
@@ -232,12 +232,10 @@ func _load_result_tree(j):
 
 
 func _free_childless_scripts():
-	var item = _root.get_children()
-	while(item != null):
-		var next_item = item.get_next()
-		if(item.get_children() == null):
-			item.free()
-		item = next_item
+	var children = _root.get_children() # Returns an array in 4.0
+	for i in range(0, children.size()):
+		if(children[i].get_children() == null):
+			children[i].free()
 
 
 func _find_script_item_with_path(path):
@@ -329,9 +327,9 @@ func _get_line_number_for_seq_search(search_strings, te):
 	var string_found = true
 	while(i < search_strings.size() and string_found):
 		result = te.search(search_strings[i], s_flags, start_line, start_col)
-		if(result.size() > 0):
-			start_line = result[TextEdit.SEARCH_RESULT_LINE]
-			start_col = result[TextEdit.SEARCH_RESULT_COLUMN]
+		if(result.length() > 0):
+			start_line = result.y
+			start_col = result.x
 			to_return = start_line
 		else:
 			string_found = false

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -7,7 +7,7 @@ class DirectoryCtrl:
 		get:
 			return _txt_path.text
 		set(val):
-			_txt_path.text = text
+			_txt_path.text = val
 
 	var _txt_path = LineEdit.new()
 	var _btn_dir = Button.new()


### PR DESCRIPTION
### Summary

#### Fixes

- Binding in `GutRunner` for 4.0
- Loading the saved test directory by fixing a left-over bug from `DirectoryCtrl` when setting the `TextEdit` text
- `TreeItem::get_children` now returns an array, so a for loop is used to free children in `RunResults` 
- `Vector2i` refactor for `RunResults::_find_script_item_with_path`  

#### Changes

- `print` error is now `push_error` when bbcode cannot be saved
 