### PR TITLE
4.0 Run Result Line Select Fixes

### DIFF
--- a/addons/gut/gui/RunResults.gd
+++ b/addons/gut/gui/RunResults.gd
@@ -154,7 +154,7 @@ func _add_test_tree_item(test_name, test_json, script_item):
 
 	item.set_text(0, test_name)
 	item.set_text(1, status)
-	item.set_text_alignment(1, TreeItem.ALIGN_RIGHT)
+	item.set_text_alignment(1, HORIZONTAL_ALIGNMENT_RIGHT)
 	item.set_custom_bg_color(1, _col_1_bg_color)
 
 	item.set_metadata(0, meta)
@@ -256,7 +256,7 @@ func _find_script_item_with_path(path):
 func _get_line_number_from_assert_msg(msg):
 	var line = -1
 	if(msg.find('at line') > 0):
-		line = int(msg.split("at line")[-1].split(" ")[-1])
+		line = msg.split("at line")[-1].split(" ")[-1].to_int()
 	return line
 
 

--- a/addons/gut/gui/script_text_editor_controls.gd
+++ b/addons/gut/gui/script_text_editor_controls.gd
@@ -17,7 +17,7 @@ class ScriptEditorControlRef:
 		# type of control we care about.  Chances are there won't be more than
 		# one of these in the future, but their position in the tree may change.
 		_code_editor = weakref(_get_first_child_named('CodeTextEditor', _script_editor.get_ref()))
-		_text_edit = weakref(_get_first_child_named("TextEdit", _code_editor.get_ref()))
+		_text_edit = weakref(_get_first_child_named("CodeEdit", _code_editor.get_ref()))
 
 
 	func _get_first_child_named(obj_name, parent_obj):
@@ -187,7 +187,7 @@ func get_line_info():
 	var done_func = false
 	var done_inner = false
 	while(line > 0 and (!done_func or !done_inner)):
-		if(editor.can_fold(line)):
+		if(editor.can_fold_line(line)):
 			var text = editor.get_line(line)
 			var strip_text = text.strip_edges(true, false) # only left
 


### PR DESCRIPTION
### Summary

Applies some name & class changes for 4.0 so clicking on the `RunResult` lines opens the proper file at the specified line (when applicable and if used with #404).