### PR TITLE
Allow simulate to check whether a Node has disabled its process methods

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -1340,19 +1340,58 @@ func get_yield_between_tests():
 	return _yield_between.should
 
 # ------------------------------------------------------------------------------
-# Call _process or _fixed_process, if they exist, on obj and all it's children
-# and their children and so and so forth.  Delta will be passed through to all
-# the _process or _fixed_process methods.
+# Simulate a number of frames by calling '_process' and '_physics_process' on an
+# object and all of its descendents. The specified frame time, 'delta', will be
+# passed to each simulated call. Calls to '_process' or '_physics_process' on an
+# object will be skipped if its 'is_processing()' or 'is_physics_processing()'
+# methods return 'false', respectively.
+# 
+# NOTE: To call processing methods on objects outside of the scene tree,
+# regardless of whether the objects have them toggled on, call 'simulate' with
+# 'force_simulate_if_outside_tree' as 'true' (the default). When an object is
+# inside of the scene tree, 'force_simulate_if_outside_tree' has no effect.
 # ------------------------------------------------------------------------------
-func simulate(obj, times, delta):
+func simulate(obj, times, delta, force_simulate_if_outside_tree: bool = true):
 	for _i in range(times):
-		if(obj.has_method("_process")):
+		if (
+			# As long as the object has 'is_processing() == true', then call the
+			# '_process' method.
+			obj.is_processing()
+			or (
+				# If the object is outside the scene tree, the user should
+				# specify whether 'simulate' can call '_process' based solely on
+				# whether the method is overridden.
+				#
+				# NOTE: To test objects which utilize 'set_process(false)', set
+				# 'force_simulate_if_outside_tree' to 'false' so that 'simulate'
+				# relies solely on the 'is_processing' method.
+				force_simulate_if_outside_tree
+				and not obj.is_inside_tree()
+				and obj.has_method("_process")
+			)
+		):
 			obj._process(delta)
-		if(obj.has_method("_physics_process")):
+		if(
+			# As long as the object has 'is_physics_processing() == true', then
+			# call the '_physics_process' method.
+			obj.is_physics_processing()
+			or (
+				# If the object is outside the scene tree, the user should
+				# specify whether 'simulate' can call '_physics_process' based
+				# solely on whether the method is overridden.
+				#
+				# NOTE: To test objects which utilize 'set_physics_process(false)',
+				# set 'force_simulate_if_outside_tree' to 'false' so that 'simulate'
+				# relies solely on the 'is_physics_processing' method.
+				force_simulate_if_outside_tree
+				and not obj.is_inside_tree()
+				and obj.has_method("_physics_process")
+			)
+		):
 			obj._physics_process(delta)
 
 		for kid in obj.get_children():
-			simulate(kid, 1, delta)
+			simulate(kid, 1, delta, force_simulate_if_outside_tree)
 
 # ------------------------------------------------------------------------------
 # Starts an internal timer with a timeout of the passed in time.  A 'timeout'

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1457,8 +1457,8 @@ func stub(thing, p2, p3=null):
 # ------------------------------------------------------------------------------
 # convenience wrapper.
 # ------------------------------------------------------------------------------
-func simulate(obj, times, delta):
-	gut.simulate(obj, times, delta)
+func simulate(obj, times, delta, force_simulate_if_outside_tree: bool = true):
+	gut.simulate(obj, times, delta, force_simulate_if_outside_tree)
 
 # ------------------------------------------------------------------------------
 # Replace the node at base_node.get_node(path) with with_this.  All references

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1457,8 +1457,8 @@ func stub(thing, p2, p3=null):
 # ------------------------------------------------------------------------------
 # convenience wrapper.
 # ------------------------------------------------------------------------------
-func simulate(obj, times, delta, force_simulate_if_outside_tree: bool = true):
-	gut.simulate(obj, times, delta, force_simulate_if_outside_tree)
+func simulate(obj, times, delta, check_is_processing: bool = false):
+	gut.simulate(obj, times, delta, check_is_processing)
 
 # ------------------------------------------------------------------------------
 # Replace the node at base_node.get_node(path) with with_this.  All references


### PR DESCRIPTION
Right now, Gut's `simulate` function will call `_physics_process` and `_process` on a `Node` [as long as the methods are overridden](https://github.com/bitwes/Gut/blob/fe292bcdcf9baca6022944ecdb0f973083ff3ed4/addons/gut/gut.gd#L1349-L1352). However, it's possible for a `Node` to disable its `_physics_process` method using `set_physics_process(false)` and `_process` method using `set_process(false)`. The `simulate` function should respect when a `Node` toggles the status of its  `_physics_process` and `_process` methods.

Regarding the implementation here, I think it would be correct to simply replace the `if(obj.has_method("_process")):` check with `if (obj.is_in_group("idle_process")):`. This is because these groups are [set by Godot](https://docs.godotengine.org/en/stable/classes/class_node.html?highlight=set_process#class-node-method-set-process) when the method is defined and updated when the `set_[physics_]process` methods are called. However, in an effort to provide backwards-compatibility, I've used a parameter on `simulate` to allow opting in to this behavior. This should preserve existing behavior in the event that a current user manually modifies the membership of simulated `Node`s in these Godot-added groups.

NOTE: With Godot 4.0+, the name of these groups is changing. I've added a comment to point this out, but perhaps an additional bug can be created (or this can be added to #384 perhaps?).