### PR TITLE
Godot 4 Inst to Dict

### DIFF
--- a/addons/gut/strutils.gd
+++ b/addons/gut/strutils.gd
@@ -74,11 +74,10 @@ func _get_obj_filename(thing):
 			# we do nothing.  This just read better.
 			pass
 	elif(!_utils.is_native_class(thing)):
-		filename = 'inst2dict is missing'
-		# var dict = inst2dict(thing)
-		# filename = _get_filename(dict['@path'])
-		# if(str(dict['@subpath']) != ''):
-		# 	filename += str('/', dict['@subpath'])
+		var dict = inst_to_dict(thing)
+		filename = _get_filename(dict['@path'])
+		if(str(dict['@subpath']) != ''):
+			filename += str('/', dict['@subpath'])
 
 	return filename
 


### PR DESCRIPTION
### Summary

Fixes the name change `inst2dict` to `inst_to_dict` in `strutils` for Godot 4, and restores the commented out logic