### PR TITLE
Fix "instantiate" being used as a noun or adjective

### DIFF
--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -115,7 +115,7 @@ class ObjectInfo:
 		if(subpath != null):
 			_subpaths = Array(subpath.split('/'))
 
-	# Returns an instantiate of the class/inner class
+	# Returns an instance of the class/inner class
 	func instantiate():
 		var to_return = null
 

--- a/addons/gut/gui/script_text_editor_controls.gd
+++ b/addons/gut/gui/script_text_editor_controls.gd
@@ -13,7 +13,7 @@ class ScriptEditorControlRef:
 
 
 	func _populate_controls():
-		# who knows if the tree will change so get the first instantiate of each
+		# who knows if the tree will change so get the first instance of each
 		# type of control we care about.  Chances are there won't be more than
 		# one of these in the future, but their position in the tree may change.
 		_code_editor = weakref(_get_first_child_named('CodeTextEditor', _script_editor.get_ref()))
@@ -68,7 +68,7 @@ class ScriptEditorControlRef:
 
 # Used to make searching for the controls easier and faster.
 var _script_editors_parent = null
-# reference the ScriptEditor instantiate
+# reference the ScriptEditor instance
 var _script_editor = null
 # Array of ScriptEditorControlRef containing all the opened ScriptTextEditors
 # and related controls at the time of the last refresh.

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -251,7 +251,7 @@ var _select_script = ''
 var _last_paint_time = 0.0
 var _strutils = _utils.Strutils.new()
 
-# The instantiate that is created from _pre_run_script.  Accessible from
+# The instance that is created from _pre_run_script.  Accessible from
 # get_pre_run_script_instance.
 var _pre_run_script_instance = null
 var _post_run_script_instance = null # This is not used except in tests.
@@ -307,7 +307,7 @@ func _init():
 	_before_all_test_obj.name = 'before_all'
 	_after_all_test_obj.name = 'after_all'
 	# When running tests for GUT itself, _utils has been setup to always return
-	# a new logger so this does not set the gut instantiate on the base logger
+	# a new logger so this does not set the gut instance on the base logger
 	# when creating test instances of GUT.
 	_lgr.set_gut(self)
 
@@ -527,10 +527,10 @@ func _print_summary():
 func _validate_hook_script(path):
 	var result = {
 		valid = true,
-		instantiate = null
+		instance = null
 	}
 
-	# empty path is valid but will have a null instantiate
+	# empty path is valid but will have a null instance
 	if(path == ''):
 		return result
 
@@ -538,7 +538,7 @@ func _validate_hook_script(path):
 	if(f.file_exists(path)):
 		var inst = load(path).new()
 		if(inst and inst is _utils.HookScript):
-			result.instantiate = inst
+			result.instance = inst
 			result.valid = true
 		else:
 			result.valid = false
@@ -572,9 +572,9 @@ func _init_run():
 	_is_running = true
 
 	var pre_hook_result = _validate_hook_script(_pre_run_script)
-	_pre_run_script_instance = pre_hook_result.instantiate
+	_pre_run_script_instance = pre_hook_result.instance
 	var post_hook_result = _validate_hook_script(_post_run_script)
-	_post_run_script_instance  = post_hook_result.instantiate
+	_post_run_script_instance  = post_hook_result.instance
 
 	valid = pre_hook_result.valid and  post_hook_result.valid
 
@@ -768,7 +768,7 @@ func _run_parameterized_test(test_script, test_name):
 
 
 # ------------------------------------------------------------------------------
-# Runs a single test given a test.gd instantiate and the name of the test to run.
+# Runs a single test given a test.gd instance and the name of the test to run.
 # ------------------------------------------------------------------------------
 func _run_test(script_inst, test_name):
 	_lgr.log_test_name()
@@ -1389,7 +1389,7 @@ func set_yield_signal_or_time(obj, signal_name, max_wait, text=''):
 
 
 # ------------------------------------------------------------------------------
-# Returns the instantiated script object that is currently being run.
+# Returns the script object instance that is currently being run.
 # ------------------------------------------------------------------------------
 func get_current_script_object():
 	var to_return = null

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -118,7 +118,7 @@ class OptionResolver:
 # ------------------------------------------------------------------------------
 var _utils = load('res://addons/gut/utils.gd').get_instance()
 var _gut_config = load('res://addons/gut/gut_config.gd').new()
-# instantiate of gut
+# instance of gut
 var _tester = null
 # array of command line options specified
 var _final_opts = []

--- a/addons/gut/hook_script.gd
+++ b/addons/gut/hook_script.gd
@@ -7,7 +7,7 @@ class_name GutHookScript
 # ------------------------------------------------------------------------------
 var JunitXmlExport = load('res://addons/gut/junit_xml_export.gd')
 
-# This is the instantiate of GUT that is running the tests.  You can get
+# This is the instance of GUT that is running the tests.  You can get
 # information about the run from this object.  This is set by GUT when the
 # script is instantiated.
 var gut  = null

--- a/addons/gut/spy.gd
+++ b/addons/gut/spy.gd
@@ -78,27 +78,27 @@ func get_call_parameters(variant, method_name, index=-1):
 
 	return to_return
 
-func call_count(instantiate, method_name, parameters=null):
+func call_count(instance, method_name, parameters=null):
 	var to_return = 0
 
-	if(was_called(instantiate, method_name)):
+	if(was_called(instance, method_name)):
 		if(parameters):
-			for i in range(_calls[instantiate][method_name].size()):
-				if(_calls[instantiate][method_name][i] == parameters):
+			for i in range(_calls[instance][method_name].size()):
+				if(_calls[instance][method_name][i] == parameters):
 					to_return += 1
 		else:
-			to_return = _calls[instantiate][method_name].size()
+			to_return = _calls[instance][method_name].size()
 	return to_return
 
 func clear():
 	_calls = {}
 
-func get_call_list_as_string(instantiate):
+func get_call_list_as_string(instance):
 	var to_return = ''
-	if(_calls.has(instantiate)):
-		for method in _calls[instantiate]:
-			for i in range(_calls[instantiate][method].size()):
-				to_return += str(method, '(', _get_params_as_string(_calls[instantiate][method][i]), ")\n")
+	if(_calls.has(instance)):
+		for method in _calls[instance]:
+			for i in range(_calls[instance][method].size()):
+				to_return += str(method, '(', _get_params_as_string(_calls[instance][method][i]), ")\n")
 	return to_return
 
 func get_logger():

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -13,7 +13,7 @@ var call_super = false
 # Parmater overrides are stored in here along with all the other stub info
 # so that you can chain stubbing parameter overrides along with all the
 # other stubbing.  This adds some complexity to the logic that tries to
-# find the correct stub for a call by a double.  Since an instantiate of this
+# find the correct stub for a call by a double.  Since an instance of this
 # class could be just a parameter override, or it could have been chained
 # we have to have _paramter_override_only so that we know when to tell the
 # difference.

--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -30,7 +30,7 @@ func _make_key_from_metadata(doubled):
 
 # Creates they key for the returns hash based on the type of object passed in
 # obj could be a string of a path to a script with an optional subpath or
-# it could be an instantiate of a doubled object.
+# it could be an instance of a doubled object.
 func _make_key_from_variant(obj, subpath=null):
 	var to_return = null
 
@@ -67,10 +67,10 @@ func _add_obj_method(obj, method, subpath=null):
 # Public
 # ##############
 
-# Searches returns for an entry that matches the instantiate or the class that
+# Searches returns for an entry that matches the instance or the class that
 # passed in obj is.
 #
-# obj can be an instantiate, class, or a path.
+# obj can be an instance, class, or a path.
 func _find_stub(obj, method, parameters=null, find_overloads=false):
 	var key = _make_key_from_variant(obj)
 	var to_return = null
@@ -119,7 +119,7 @@ func add_stub(stub_params):
 
 
 # Gets a stubbed return value for the object and method passed in.  If the
-# instantiate was stubbed it will use that, otherwise it will use the path and
+# instance was stubbed it will use that, otherwise it will use the path and
 # subpath of the object to try to find a value.
 #
 # It will also use the optional list of parameter values to find a value.  If
@@ -130,7 +130,7 @@ func add_stub(stub_params):
 # If it cannot find anything that matches then null is returned.for
 #
 # Parameters
-# obj:  this should be an instantiate of a doubled object.
+# obj:  this should be an instance of a doubled object.
 # method:  the method called
 # parameters:  optional array of parameter vales to find a return value for.
 func get_return(obj, method, parameters=null):

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -117,7 +117,7 @@ var _compare = _utils.Comparator.new()
 const YIELD = 'timeout'
 signal timeout
 
-# Need a reference to the instantiate that is running the tests.  This
+# Need a reference to the instance that is running the tests.  This
 # is set by the gut class when it runs the tests.  This gets you
 # access to the asserts in the tests you write.
 var gut = null
@@ -209,7 +209,7 @@ func _do_datatypes_match__fail_if_not(got, expected, text):
 
 # ------------------------------------------------------------------------------
 # Create a string that lists all the methods that were called on an spied
-# instantiate.
+# instance.
 # ------------------------------------------------------------------------------
 func _get_desc_of_calls_to_instance(inst):
 	var BULLET = '  * '
@@ -796,7 +796,7 @@ func get_call_count(object, method_name, parameters=null):
 
 
 # ------------------------------------------------------------------------------
-# Assert that object is an instantiate of a_class
+# Assert that object is an instance of a_class
 # ------------------------------------------------------------------------------
 func assert_is(object, a_class, text=''):
 	var disp  = ''#var disp = str('Expected [', _str(object), '] to be type of [', a_class, ']: ', text)
@@ -805,7 +805,7 @@ func assert_is(object, a_class, text=''):
 	var bad_param_2 = 'Parameter 2 must be a Class (like Node2D or Label).  You passed '
 
 	if(typeof(object) != TYPE_OBJECT):
-		_fail(str('Parameter 1 must be an instantiate of an object.  You passed:  ', _str(object)))
+		_fail(str('Parameter 1 must be an instance of an object.  You passed:  ', _str(object)))
 	elif(typeof(a_class) != TYPE_OBJECT):
 		_fail(str(bad_param_2, _str(a_class)))
 	else:
@@ -916,7 +916,7 @@ func assert_string_ends_with(text, search, match_case=true):
 			_fail(disp)
 
 # ------------------------------------------------------------------------------
-# Assert that a method was called on an instantiate of a doubled class.  If
+# Assert that a method was called on an instance of a doubled class.  If
 # parameters are supplied then the params passed in when called must match.
 # TODO make 3rd parameter "param_or_text" and add fourth parameter of "text" and
 #      then work some magic so this can have a "text" parameter without being
@@ -929,7 +929,7 @@ func assert_called(inst, method_name, parameters=null):
 		return
 
 	if(!_utils.is_double(inst)):
-		_fail('You must pass a doubled instantiate to assert_called.  Check the wiki for info on using double.')
+		_fail('You must pass a doubled instance to assert_called.  Check the wiki for info on using double.')
 	else:
 		if(gut.get_spy().was_called(inst, method_name, parameters)):
 			_pass(disp)
@@ -939,7 +939,7 @@ func assert_called(inst, method_name, parameters=null):
 			_fail(str(disp, "\n", _get_desc_of_calls_to_instance(inst)))
 
 # ------------------------------------------------------------------------------
-# Assert that a method was not called on an instantiate of a doubled class.  If
+# Assert that a method was not called on an instance of a doubled class.  If
 # parameters are specified then this will only fail if it finds a call that was
 # sent matching parameters.
 # ------------------------------------------------------------------------------
@@ -950,7 +950,7 @@ func assert_not_called(inst, method_name, parameters=null):
 		return
 
 	if(!_utils.is_double(inst)):
-		_fail('You must pass a doubled instantiate to assert_not_called.  Check the wiki for info on using double.')
+		_fail('You must pass a doubled instance to assert_not_called.  Check the wiki for info on using double.')
 	else:
 		if(gut.get_spy().was_called(inst, method_name, parameters)):
 			if(parameters != null):
@@ -960,7 +960,7 @@ func assert_not_called(inst, method_name, parameters=null):
 			_pass(disp)
 
 # ------------------------------------------------------------------------------
-# Assert that a method on an instantiate of a doubled class was called a number
+# Assert that a method on an instance of a doubled class was called a number
 # of times.  If parameters are specified then only calls with matching
 # parameter values will be counted.
 # ------------------------------------------------------------------------------
@@ -977,7 +977,7 @@ func assert_call_count(inst, method_name, expected_count, parameters=null):
 	disp = disp % [method_name, _str(inst), expected_count, param_text, count]
 
 	if(!_utils.is_double(inst)):
-		_fail('You must pass a doubled instantiate to assert_call_count.  Check the wiki for info on using double.')
+		_fail('You must pass a doubled instance to assert_call_count.  Check the wiki for info on using double.')
 	else:
 		if(count == expected_count):
 			_pass(disp)
@@ -1065,7 +1065,7 @@ func _validate_singleton_name(singleton_name):
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 func assert_setget(
-	instantiate, name_property,
+	instance, name_property,
 	const_or_setter = null, getter="__not_set__"):
 	_lgr.deprecated('assert_setget')
 	_fail('assert_setget has been removed.  Use assert_property, assert_set_property, assert_readonly_property instead.')
@@ -1297,7 +1297,7 @@ func double(thing, p2=null, p3=null):
 	var double_info = DoubleInfo.new(thing, p2, p3)
 	print(double_info.to_s())
 	if(!double_info.is_valid):
-		_lgr.error('double requires a class or path, you passed an instantiate:  ' + _str(thing))
+		_lgr.error('double requires a class or path, you passed an instance:  ' + _str(thing))
 		return null
 
 	double_info.make_partial = false
@@ -1309,7 +1309,7 @@ func double(thing, p2=null, p3=null):
 func partial_double(thing, p2=null, p3=null):
 	var double_info = DoubleInfo.new(thing, p2, p3)
 	if(!double_info.is_valid):
-		_lgr.error('partial_double requires a class or path, you passed an instantiate:  ' + _str(thing))
+		_lgr.error('partial_double requires a class or path, you passed an instance:  ' + _str(thing))
 		return null
 
 	double_info.make_partial = true
@@ -1378,7 +1378,7 @@ func ignore_method_when_doubling(thing, method_name):
 # Stub something.
 #
 # Parameters
-# 1: the thing to stub, a file path or a instantiate or a class
+# 1: the thing to stub, a file path or an instance or a class
 # 2: either an inner class subpath or the method name
 # 3: the method name if an inner class subpath was specified
 # NOTE:  right now we cannot stub inner classes at the path level so this should

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -34,7 +34,7 @@
 extends Node
 
 # ------------------------------------------------------------------------------
-# The instantiate name as a function since you can't have static variables.
+# The instance name as a function since you can't have static variables.
 # ------------------------------------------------------------------------------
 static func INSTANCE_NAME():
 	return '__GutUtilsInstName__'
@@ -52,7 +52,7 @@ static func get_root_node():
 		return null
 
 # ------------------------------------------------------------------------------
-# Get the ONE instantiate of utils
+# Get the ONE instance of utils
 # Since we can't have static variables we have to store the instance in the
 # tree.  This means you have to wait a bit for the main loop to be up and
 # running.
@@ -290,7 +290,7 @@ func is_double(obj):
 
 
 # ------------------------------------------------------------------------------
-# Checks if the passed in is an instantiate of a class
+# Checks if the passed in is an instance of a class
 # ------------------------------------------------------------------------------
 func is_instance(obj):
 	return typeof(obj) == TYPE_OBJECT and !obj.has_method('new') and !obj.has_method('instantiate')

--- a/scratch/find_bad_methods.gd
+++ b/scratch/find_bad_methods.gd
@@ -77,7 +77,7 @@ func remove_methods_from_blacklist_one_by_one(obj, path):
 
 	doubler.clear_output_directory()
 
-# given a path it will create a double of it and then create an instantiate of the
+# given a path it will create a double of it and then create an instance of the
 # doubled object checking for nulls along the way.  Thi is what I used to test
 # the black lists for various objects.
 func double_and_instance_it(path):

--- a/scratch/make_class_from_string.gd
+++ b/scratch/make_class_from_string.gd
@@ -61,7 +61,7 @@ func create_instance():
 	obj.set_script(get_script_for_text(make_class()))
 
 	var inner_class = obj.MadeIt.new()
-	print('create instantiate  = ', inner_class.do_something())
+	print('create instance  = ', inner_class.do_something())
 
 func create_scene():
 	var s2 = SuperPack.new()

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -73,8 +73,8 @@ func _on_tests_finished():
 
 #------------------------------------
 # Example:
-# This creates an instantiate of Gut and runs a single script.  The output will
-# be visible in the console, not the Gut instantiate on the screen.
+# This creates an instance of Gut and runs a single script.  The output will
+# be visible in the console, not the Gut instance on the screen.
 #------------------------------------
 func _run_test_one_line():
 	load('res://addons/gut/gut.gd').new().test_script('res://test/samples/test_sample_all_passed.gd')
@@ -85,7 +85,7 @@ func _run_test_one_line():
 # with a reference to the class.
 #------------------------------------
 func _run_all_tests():
-	# get an instantiate of gut
+	# get an instance of gut
 	tester = get_node("Gut")
 
 	tester.connect('tests_finished',Callable(self,'_on_tests_finished'))

--- a/test/integration/test_doubler_and_stubber.gd
+++ b/test/integration/test_doubler_and_stubber.gd
@@ -63,8 +63,8 @@ func test_can_stub_doubled_instance_values():
 	var sp2 = StubParams.new(d1, 'get_value').to_return(10)
 	gr.stubber.add_stub(sp2)
 
-	assert_eq(d1.get_value(), 10, 'instantiate gets right value')
-	assert_eq(d2.get_value(), 5, 'other instantiate gets class value')
+	assert_eq(d1.get_value(), 10, 'Instance gets right value')
+	assert_eq(d2.get_value(), 5, 'other instance gets class value')
 
 func test_stubbed_methods_send_parameters_in_callback():
 	var sp = StubParams.new(DOUBLE_ME_PATH, 'has_one_param')

--- a/test/integration/test_everything_together.gd
+++ b/test/integration/test_everything_together.gd
@@ -21,7 +21,7 @@ class TestLogging:
 	func test_gut_sets_stubber_logger():
 		assert_eq(_gut.get_stubber().get_logger(), _gut.logger)
 
-	# This test makes assertion using THIS test script instantiate since it would
+	# This test makes assertion using THIS test script instance since it would
 	# be super hard to get a test object that was being run.
 	func test_gut_sets_logger_on_tests():
 		assert_eq(gut.logger, get_logger())

--- a/test/integration/test_gut_and_spy.gd
+++ b/test/integration/test_gut_and_spy.gd
@@ -14,7 +14,7 @@ func test_spy_for_doubler_is_guts_spy():
 
 
 # ---------------------------------
-# these two tests use the gut instantiate that is passed to THIS test.  This isn't
+# these two tests use the gut instance that is passed to THIS test.  This isn't
 # PURE testing but it appears to cover the bases ok.
 class TestGutClearsSpyBetweenTests:
 	extends 'res://addons/gut/test.gd'

--- a/test/integration/test_gut_and_stubber.gd
+++ b/test/integration/test_gut_and_stubber.gd
@@ -12,7 +12,7 @@ func test_can_get_stubber():
 	assert_ne(g.get_stubber(), null)
 
 # ---------------------------------
-# these two tests use the gut instantiate that is passed to THIS test.  This isn't
+# these two tests use the gut instance that is passed to THIS test.  This isn't
 # PURE testing but it appears to cover the bases ok.
 # ------
 func test_stubber_cleared_between_tests_setup():

--- a/test/resources/parsing_and_loading_samples/test_samples.gd
+++ b/test/resources/parsing_and_loading_samples/test_samples.gd
@@ -2,7 +2,7 @@
 #All the magic happens with the extends.  This gets you access to all the gut
 #asserts and the overridable setup and teardown methods.
 #
-#The path to this script is passed to an instantiate of the gut script when calling
+#The path to this script is passed to an instance of the gut script when calling
 #test_script
 #
 #WARNING

--- a/test/resources/parsing_and_loading_samples/test_samples2.gd
+++ b/test/resources/parsing_and_loading_samples/test_samples2.gd
@@ -2,7 +2,7 @@
 #All the magic happens with the extends.  This gets you access to all the gut
 #asserts and the overridable setup and teardown methods.
 #
-#The path to this script is passed to an instantiate of the gut script when calling
+#The path to this script is passed to an instance of the gut script when calling
 #test_script
 #
 #WARNING

--- a/test/resources/parsing_and_loading_samples/test_samples3.gd
+++ b/test/resources/parsing_and_loading_samples/test_samples3.gd
@@ -2,7 +2,7 @@
 #All the magic happens with the extends.  This gets you access to all the gut
 #asserts and the overridable setup and teardown methods.
 #
-#The path to this script is passed to an instantiate of the gut script when calling
+#The path to this script is passed to an instance of the gut script when calling
 #test_script
 #
 #WARNING

--- a/test/samples/test_readme_examples.gd
+++ b/test/samples/test_readme_examples.gd
@@ -574,7 +574,7 @@ func test_assert_called():
 	# ast least not yet.
 	assert_called(doubled, 'has_two_params_one_default', ['a'])
 	# This fails with a specific message indicating that you have to pass an
-	# instantiate of a doubled class.
+	# instance of a doubled class.
 	assert_called(GDScript.new(), 'some_method')
 
 func test_assert_call_count():
@@ -598,7 +598,7 @@ func test_assert_call_count():
 	assert_call_count(doubled, 'set_value', 2, [4])
 	assert_call_count(doubled, 'get_value', 1)
 	# This fails with a specific message indicating that you have to pass an
-	# instantiate of a doubled class even though technically the method was called.
+	# instance of a doubled class even though technically the method was called.
 	assert_call_count(GDScript.new(), 'some_method', 0)
 	# This fails b/c double_extends_node2d does not have it's own implementation
 	# of set_position.  The function is supplied by the parent class and these

--- a/test/samples/test_sample_one.gd
+++ b/test/samples/test_sample_one.gd
@@ -2,7 +2,7 @@
 #All the magic happens with the extends.  This gets you access to all the gut
 #asserts and the overridable setup and teardown methods.
 #
-#The path to this script is passed to an instantiate of the gut script when calling
+#The path to this script is passed to an instance of the gut script when calling
 #test_script
 #
 #WARNING

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -267,8 +267,8 @@ class TestBuiltInOverloading:
 	func test_when_everything_included_you_can_still_double_a_scene():
 		var inst = autofree(doubler.double_scene(DOUBLE_ME_SCENE_PATH).instantiate())
 		add_child(inst)
-		assert_ne(inst, null, "instantiate is not null")
-		assert_ne(inst.label, null, "Can get to a label on the instantiate")
+		assert_ne(inst, null, "Instance is not null")
+		assert_ne(inst.label, null, "Can get to a label on the instance")
 		# pause so _process gets called
 		await yield_for(3).YIELD
 

--- a/test/unit/test_stubber.gd
+++ b/test/unit/test_stubber.gd
@@ -100,8 +100,8 @@ func test_returns_can_be_layered():
 	gr.stubber.set_return(TO_STUB_PATH, 'get_value', 0)
 	var inst = ToStub.new()
 	gr.stubber.set_return(inst, 'get_other', 100)
-	assert_eq(gr.stubber.get_return(inst, 'get_value'), 0, 'unstubbed instantiate method should get class value')
-	assert_eq(gr.stubber.get_return(inst, 'get_other'), 100, 'stubbed instantiate method should get inst value')
+	assert_eq(gr.stubber.get_return(inst, 'get_value'), 0, 'unstubbed instance method should get class value')
+	assert_eq(gr.stubber.get_return(inst, 'get_other'), 100, 'stubbed instance method should get inst value')
 	assert_eq(gr.stubber.get_return(TO_STUB_PATH, 'get_value'), 0, 'stubbed path method should get path value')
 	assert_eq(gr.stubber.get_return(TO_STUB_PATH ,'get_other'), null, 'unstubbed path method should get null')
 

--- a/tests_4_0/test_gut.gd
+++ b/tests_4_0/test_gut.gd
@@ -437,16 +437,16 @@ class TestEverythingElse:
 	func test_after_running_script_everything_checks_out():
 		gr.test_gut.add_script('res://test/samples/test_before_after.gd')
 		gr.test_gut.test_scripts()
-		var instantiate = gr.test_gut.get_current_script_object()
-		assert_eq(instantiate.counts.before_all, 1, 'before_all')
-		assert_eq(instantiate.counts.before_each, 3, 'before_each')
-		assert_eq(instantiate.counts.after_all, 1, 'after_all')
-		assert_eq(instantiate.counts.after_each, 3, 'after_each')
+		var instance = gr.test_gut.get_current_script_object()
+		assert_eq(instance.counts.before_all, 1, 'before_all')
+		assert_eq(instance.counts.before_each, 3, 'before_each')
+		assert_eq(instance.counts.after_all, 1, 'after_all')
+		assert_eq(instance.counts.after_each, 3, 'after_each')
 
-		assert_eq(instantiate.counts.prerun_setup, 1, 'prerun_setup')
-		assert_eq(instantiate.counts.setup, 3, 'setup')
-		assert_eq(instantiate.counts.postrun_teardown, 1, 'postrun_teardown')
-		assert_eq(instantiate.counts.teardown, 3, 'teardown')
+		assert_eq(instance.counts.prerun_setup, 1, 'prerun_setup')
+		assert_eq(instance.counts.setup, 3, 'setup')
+		assert_eq(instance.counts.postrun_teardown, 1, 'postrun_teardown')
+		assert_eq(instance.counts.teardown, 3, 'teardown')
 
 	func test_when_inner_class_skipped_none_of_the_before_after_are_called():
 		pending('pending in 4.0')


### PR DESCRIPTION
It looks like at some point there was a bulk find/replace of instance -> instantiate, which made some comments incorrect.