### PR TITLE
Godot 4 fix array dictionary compare

### DIFF
--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -57,6 +57,10 @@ These are changes to Godot that affect how GUT is used/implemented.
 * Arrays are pass by reference now.
 * `File` and `Directory` have been replaced with `FileAccess` and `DirAccess`.
 
+
+
+
+
 ## Working Features
 * The command line seems to be working fine.
 * Basic asserts (assert_eq, ne, between etc) with anything except arrays and dictionaries.
@@ -101,6 +105,12 @@ await wait_frames(30, 'optional message')
 ```
 * Doubling no longer supports paths to a script or scene.  Load the script or scene first and pass that to `double`.  See the "Doubling Changes" section for more details.
 * Doubling Inner Classes now requires you to call `register_inner_classes` first.  See the "Doubling Changes" sedtion for more details.
+
+### Comparing Dictionaries and Arrays
+In Godot 3.x dictionaries were compared by reference and arrays were compared by value.  In 4.0 both are compared by value.  In Godot 4.0 you can compare dictionaries and arrays by reference using `is_same`.
+
+GUT honored the default comparing logic in 3.x, so it does the same in 4.0.  This means that `assert_eq` will use Godot's `==` logic for dictionaries and arrays (comparing by value).  If you want to compare by reference you can use the new `assert_same`.  `assert_same`
+
 
 ### Doubling Changes
 #### Doubling scripts and scenes

--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -109,7 +109,13 @@ await wait_frames(30, 'optional message')
 ### Comparing Dictionaries and Arrays
 In Godot 3.x dictionaries were compared by reference and arrays were compared by value.  In 4.0 both are compared by value.  In Godot 4.0 you can compare dictionaries and arrays by reference using `is_same`.
 
-GUT honored the default comparing logic in 3.x, so it does the same in 4.0.  This means that `assert_eq` will use Godot's `==` logic for dictionaries and arrays (comparing by value).  If you want to compare by reference you can use the new `assert_same`.  `assert_same`
+GUT honored the default comparing logic in 3.x, so it does the same in 4.0.  This means that `assert_eq` will use Godot's `==` logic for dictionaries and arrays (comparing by value).  If you want to compare by reference you can use the new `assert_same` or `assert_not_same`.
+
+The shallow compare functionanlity has been removed since it no longer applies.  Shallow compares would compare the elements of an array or dictionary by value.  In Godot 3.x this meant that dictionaries inside of arrays or dictionaries would be compared by reference.  Since everything is compared by value now, shallow compares do not apply.  The following methods have been removed.  Calling these methods will generate a failure and a warning.
+* `compare_shallow`
+* `assert_eq_shallow`
+* `assert_ne_shallow`
+
 
 
 ### Doubling Changes

--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -55,10 +55,8 @@ These are changes to Godot that affect how GUT is used/implemented.
 * `connect` has been significantly altered.  The signal related asserts will likely change to use `Callable` parameters instead of strings.  It is possible to use strings, so this may remain in some form.  More info in [#383](/../../issues/383).
 * `yield` has been replaced with `await`.  `yield_to`, `yield_for`, and `yield_frames` have been deprecated, the new methods are `wait_seconds`, `wait_frams` and `wait_for_signal`.  There are exampels below and more info at [#382](/../../issues/382).
 * Arrays are pass by reference now.
+* Dictionaries are compared by value now.
 * `File` and `Directory` have been replaced with `FileAccess` and `DirAccess`.
-
-
-
 
 
 ## Working Features
@@ -72,11 +70,12 @@ These are changes to Godot that affect how GUT is used/implemented.
 * Using `await` (the new `yield`) in tests, and all the GUT supplied `yield_` methods.  See notes in Changes section.
 * Input mocking.
 * Doubling Inner Classes has been fixed and all the tests have been restored.
+* Comparing Dictionary/Arrys with `assert_eq`, `assert_eq_deep`, and the new `assert_same` and `assert_not_same` for comparing references.  See Godot's new `is_same` function for details on how `assert_same` works (it's just an assertion wrapper around `is_same`).  See the section "Comparing Dictionaries and Arrays" below for more details.
+
 
 ## Broken Features
 * Gut Panel.  The in-editor panel is not working, you must use the CLI or the VSCode plugin (which uses the cli) for now.
-* Dictionary/array asserts are broke in some cases.  Godot 4 passes all arrays and dictionaries by reference now (arrays were by value, dictionaries were by reference).  This has broken a lot of the logic for comparing dictionaris, arrays, arrays in dictionaries, dictionaries in arrays.
-* Probably somewhat more.
+* Other misc items.
 
 
 
@@ -107,15 +106,16 @@ await wait_frames(30, 'optional message')
 * Doubling Inner Classes now requires you to call `register_inner_classes` first.  See the "Doubling Changes" sedtion for more details.
 
 ### Comparing Dictionaries and Arrays
-In Godot 3.x dictionaries were compared by reference and arrays were compared by value.  In 4.0 both are compared by value.  In Godot 4.0 you can compare dictionaries and arrays by reference using `is_same`.
+In Godot 3.x dictionaries were compared by reference and arrays were compared by value.  In 4.0 both are compared by value.  Godot 4.0 introduces the `is_same` method which (amongst other things) will compare dictionaries and arrays by reference.
 
-GUT honored the default comparing logic in 3.x, so it does the same in 4.0.  This means that `assert_eq` will use Godot's `==` logic for dictionaries and arrays (comparing by value).  If you want to compare by reference you can use the new `assert_same` or `assert_not_same`.
+GUT's `assert_eq` and `asssert_ne` changed to match Godot's behavior.  To compare by reference you can use the new `assert_same` or `assert_not_same`.  This works with arrays and dictionaries.  Review Godot's documentation for `is_same`.  When comparing dictionaries and arrays it is recommended that you use `assert_eq_deep` since it provides more detailed output than `assert_eq`.
 
-The shallow compare functionanlity has been removed since it no longer applies.  Shallow compares would compare the elements of an array or dictionary by value.  In Godot 3.x this meant that dictionaries inside of arrays or dictionaries would be compared by reference.  Since everything is compared by value now, shallow compares do not apply.  The following methods have been removed.  Calling these methods will generate a failure and a warning.
-* `compare_shallow`
+The shallow compare functionanlity has been removed since it no longer applies.  Shallow compares would compare the elements of an array or dictionary by value.  In Godot 3.x this meant that dictionaries inside of arrays or dictionaries would be compared by reference and everything else would be compared by value.  Since arrays and dictionaries are both cmpared by value now, shallow compares are no different (functionally) than deep compares.  The following methods have been removed.  Calling these methods will generate a failure and an error.
+* `compare_shallow` (causes failure and returns `null` which will likely result in a runtime error)
 * `assert_eq_shallow`
 * `assert_ne_shallow`
 
+Final note: `assert_eq` does not use `assert_eq_deep` since `assert_eq_deep` compares each element of both arrays/dictionaries and provides detailed info about what is different.  This can be slow for large arrays/dictionaries.  Godot's `==` operator uses a hashing function which is much faster but does not provide information about what is different in each array/dictionary.  With `assert_eq`, `assert_eq_deep`, and `assert_same` (and their inverses) you have fine grained control over the type of comparision that is performed.
 
 
 ### Doubling Changes

--- a/Godot_4_latest_run.md
+++ b/Godot_4_latest_run.md
@@ -1,30 +1,12 @@
 # The results of testing GUT as of now in Godot 4 RC 2
 
 ```
+==============================================
+= Run Summary
+==============================================
+
 res://test/unit/test_bugs/test_i368_WebSocketClient_double.gd
     [Risky] Script was skipped:  WebSocket changed in beta 3, not sure if these are valid anymore.
-
-res://test/unit/test_comparator.gd.TestSimpleCompare
-- test_comparing_different_dictionaries_includes_disclaimer
-    [Pending]:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_comparator.gd.TestShallowCompare
-- test_comparing_dictionaries_does_not_include_sub_dictionaries
-    [Pending]:  4.0 Dictionary and array compare broke
-- test_comparing_arrays_does_not_include_sub_dictionaries
-    [Pending]:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_diff_tool.gd.TestArrayDiff
-    [Risky] Script was skipped:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_diff_tool.gd.TestArrayDeepDiff
-    [Risky] Script was skipped:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_diff_tool.gd.TestDictionaryCompareResultInterace
-    [Risky] Script was skipped:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_diff_tool.gd.TestDictionaryDiff
-    [Risky] Script was skipped:  4.0 Dictionary and array compare broke
 
 res://test/unit/test_gut.gd.TestMisc
 - test_gut_does_not_make_orphans_when_freed_before_in_tree
@@ -37,10 +19,10 @@ res://test/unit/test_gut.gd.TestEverythingElse
 
 res://test/unit/test_gut_yielding.gd.TestWaitSeconds
 - test_failing_assert_ends_yield
-    [Failed]:  [0.5163724949495] expected to be > than [999.0]:  Testing that GUT continues after failing assert; ignore failing unless value not ~.5.
+    [Failed]:  [0.516293] expected to be > than [999.0]:  Testing that GUT continues after failing assert; ignore failing unless value not ~.5.
           at line 183
 - test_pending_ends_yield
-    [Pending]:  Testing Gut continues after yield.  0.5125 should be ~.5.
+    [Pending]:  Testing Gut continues after yield.  0.516739 should be ~.5.
 
 res://test/unit/test_logger.gd
 - test_get_set_gut
@@ -97,25 +79,6 @@ res://test/unit/test_stub_params.gd
     [Pending]:  defaults for draw_primitive have changed, need a better fit.
 - test_draw_parameter_method_meta4
     [Pending]:  Parameters for draw_pimitive have changed. Need a different method to test with
-- test_not_freeing_children_generates_warning
-    [Risky] Did not assert
-
-res://test/unit/test_test.gd.TestAssertEq
-- test_with_array
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-    [Pending]:  4.0 Dictionary and array compare broke
-- test_dictionary_not_compared_by_value
-    [Pending]:  4.0 Dictionary and array compare broke
-
-res://test/unit/test_test.gd.TestAssertNe
-- test_dictionary_not_compared_by_value
-    [Pending]:  4.0 Dictionary and array compare broke
 
 res://test/unit/test_test.gd.TestPending
 - test_pending_accepts_text
@@ -127,10 +90,7 @@ res://test/unit/test_test.gd.TestAssertExports
 res://test/unit/test_test.gd.TestMemoryMgmt
 - test_failing_orphan_assert_marks_test_as_failing
     [Failed]:  Expected no orphans, but found 1:  this should fail
-          at line 1701
-
-res://test/unit/test_test.gd.TestCompareDeepShallow
-    [Risky] Script was skipped:  Not implemented in 4.0
+          at line 1684
 
 res://test/unit/test_test_collector.gd.TestTestCollector
 - test_has_logger
@@ -157,9 +117,6 @@ res://test/integration/test_gut_import_export.gd
     [Failed]:  Does not have get_logger method
           at line 58
 
-res://test/integration/test_test_stubber_doubler.gd.TestIgnoreMethodsWhenDoubling
-    [Risky] Script was skipped:  skip for now, array compares are broke.
-
 res://test/integration/test_test_stubber_doubler.gd.TestPartialDoubleMethod
 - test_can_double_file_skip__
     [Pending]:  SKIPPED because it ends with _skip__
@@ -176,21 +133,19 @@ res://test/integration/test_this_script_has_a_really_long_name_to_test_display.g
 - test_nothing
     [Pending]:  do not need a test, but felt weird to not have one.
 
-
-
 Totals
 Scripts:          48
-Passing tests     1062
+Passing tests     1118
 Failing tests     8
-Risky tests       16
-Pending:          29
-Asserts:          1671 of 1686 passed
+Risky tests       9
+Pending:          16
+Asserts:          1766 of 1781 passed
 
 Warnings/Errors:
 * 15 Errors.
-* 35 Warnings.
+* 31 Warnings.
 * 4 Deprecated calls.
 
 
-1062 passed 8 failed.  Tests finished in 118.332s
+1118 passed 8 failed.  Tests finished in 115.214s
 ```

--- a/addons/gut/comparator.gd
+++ b/addons/gut/comparator.gd
@@ -4,7 +4,6 @@ var _max_length = 100
 var _should_compare_int_to_float = true
 
 const MISSING = '|__missing__gut__compare__value__|'
-const DICTIONARY_DISCLAIMER = 'Dictionaries are compared-by-ref.  See assert_eq in wiki.'
 
 func _cannot_compare_text(v1, v2):
 	return str('Cannot compare ', _strutils.types[typeof(v1)], ' with ',
@@ -51,19 +50,12 @@ func simple(v1, v2, missing_string=''):
 		result.are_equal = v1 == v2
 	elif(_utils.are_datatypes_same(v1, v2)):
 		result.are_equal = v1 == v2
-		if(typeof(v1) == TYPE_DICTIONARY):
-			if(result.are_equal):
-				extra = '.  Same dictionary ref.  '
-			else:
-				extra = '.  Different dictionary refs.  '
-			extra += DICTIONARY_DISCLAIMER
 
-		if(typeof(v1) == TYPE_ARRAY):
-			var array_result = _utils.DiffTool.new(v1, v2, _utils.DIFF.SHALLOW)
-			result.summary = array_result.get_short_summary()
-			if(!array_result.are_equal):
-				extra = ".\n" + array_result.get_short_summary()
-
+		if(typeof(v1) == TYPE_DICTIONARY or typeof(v1) == TYPE_ARRAY):
+			var sub_result = _utils.DiffTool.new(v1, v2, _utils.DIFF.DEEP)
+			result.summary = sub_result.get_short_summary()
+			if(!sub_result.are_equal):
+				extra = ".\n" + sub_result.get_short_summary()
 	else:
 		cmp_str = '!='
 		result.are_equal = false
@@ -77,10 +69,9 @@ func simple(v1, v2, missing_string=''):
 
 func shallow(v1, v2):
 	var result =  null
-
 	if(_utils.are_datatypes_same(v1, v2)):
 		if(typeof(v1) in [TYPE_ARRAY, TYPE_DICTIONARY]):
-			result = _utils.DiffTool.new(v1, v2, _utils.DIFF.SHALLOW)
+			result = _utils.DiffTool.new(v1, v2, _utils.DIFF.DEEP)
 		else:
 			result = simple(v1, v2)
 	else:
@@ -111,8 +102,6 @@ func compare(v1, v2, diff_type=_utils.DIFF.SIMPLE):
 	var result = null
 	if(diff_type == _utils.DIFF.SIMPLE):
 		result = simple(v1, v2)
-	elif(diff_type == _utils.DIFF.SHALLOW):
-		result = shallow(v1, v2)
 	elif(diff_type ==  _utils.DIFF.DEEP):
 		result = deep(v1, v2)
 

--- a/addons/gut/comparator.gd
+++ b/addons/gut/comparator.gd
@@ -50,7 +50,7 @@ func simple(v1, v2, missing_string=''):
 	elif([TYPE_STRING, TYPE_STRING_NAME].has(tv1) and [TYPE_STRING, TYPE_STRING_NAME].has(tv2)):
 		result.are_equal = v1 == v2
 	elif(_utils.are_datatypes_same(v1, v2)):
-		result.are_equal = is_same(v1, v2)
+		result.are_equal = v1 == v2
 		if(typeof(v1) == TYPE_DICTIONARY):
 			if(result.are_equal):
 				extra = '.  Same dictionary ref.  '

--- a/addons/gut/comparator.gd
+++ b/addons/gut/comparator.gd
@@ -50,7 +50,7 @@ func simple(v1, v2, missing_string=''):
 	elif([TYPE_STRING, TYPE_STRING_NAME].has(tv1) and [TYPE_STRING, TYPE_STRING_NAME].has(tv2)):
 		result.are_equal = v1 == v2
 	elif(_utils.are_datatypes_same(v1, v2)):
-		result.are_equal = v1 == v2
+		result.are_equal = is_same(v1, v2)
 		if(typeof(v1) == TYPE_DICTIONARY):
 			if(result.are_equal):
 				extra = '.  Same dictionary ref.  '

--- a/addons/gut/diff_tool.gd
+++ b/addons/gut/diff_tool.gd
@@ -2,7 +2,6 @@ extends 'res://addons/gut/compare_result.gd'
 const INDENT = '    '
 enum {
 	DEEP,
-	SHALLOW,
 	SIMPLE
 }
 

--- a/addons/gut/summary.gd
+++ b/addons/gut/summary.gd
@@ -217,8 +217,9 @@ func log_summary_text(lgr):
 
 	for s in range(_scripts.size()):
 		lgr.set_indent_level(0)
+
 		if(_scripts[s].was_skipped or _scripts[s].get_fail_count() > 0 or _scripts[s].get_pending_count() > 0):
-			lgr.log(_scripts[s].name, lgr.fmts.underline)
+			lgr.log("\n" + _scripts[s].name, lgr.fmts.underline)
 
 		if(_scripts[s].was_skipped):
 			lgr.inc_indent()

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1558,6 +1558,23 @@ func assert_ne_shallow(v1, v2):
 
 
 # ------------------------------------------------------------------------------
+# Assert wrapper for is_same
+# ------------------------------------------------------------------------------
+func assert_same(v1, v2, text=''):
+	var disp = "[" + _str(v1) + "] expected to be same as  [" + _str(v2) + "]:  " + text
+	if(is_same(v1, v2)):
+		_pass(disp)
+	else:
+		_fail(disp)
+
+func assert_not_same(v1, v2, text=''):
+	var disp = "[" + _str(v1) + "] expected to not be same as  [" + _str(v2) + "]:  " + text
+	if(is_same(v1, v2)):
+		_fail(disp)
+	else:
+		_pass(disp)
+
+# ------------------------------------------------------------------------------
 # Checks the passed in version string (x.x.x) against the engine version to see
 # if the engine version is less than the expected version.  If it is then the
 # test is mareked as passed (for a lack of anything better to do).  The result
@@ -1589,6 +1606,7 @@ func skip_if_godot_version_ne(expected):
 	if(should_skip):
 		_pass(str('Skipping ', _utils.godot_version(), ' is not ', expected))
 	return should_skip
+
 
 # ------------------------------------------------------------------------------
 # Registers all the inner classes in a script with the doubler.  This is required

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -242,13 +242,11 @@ func assert_eq(got, expected, text=""):
 		var disp = "[" + _str(got) + "] expected to equal [" + _str(expected) + "]:  " + text
 		var result = null
 
-		if(typeof(got) == TYPE_ARRAY):
-			result = _compare.shallow(got, expected)
-		else:
-			result = _compare.simple(got, expected)
+		result = _compare.simple(got, expected)
 
 		if(typeof(got) in [TYPE_ARRAY, TYPE_DICTIONARY]):
 			disp = str(result.summary, '  ', text)
+			_lgr.info('Array/Dictionary compared by value.  Use assert_same to compare references.  Use assert_eq_deep to see diff when failing.')
 
 		if(result.are_equal):
 			_pass(disp)
@@ -264,13 +262,11 @@ func assert_ne(got, not_expected, text=""):
 		var disp = "[" + _str(got) + "] expected to not equal [" + _str(not_expected) + "]:  " + text
 		var result = null
 
-		if(typeof(got) == TYPE_ARRAY):
-			result = _compare.shallow(got, not_expected)
-		else:
-			result = _compare.simple(got, not_expected)
+		result = _compare.simple(got, not_expected)
 
 		if(typeof(got) in [TYPE_ARRAY, TYPE_DICTIONARY]):
 			disp = str(result.summary, '  ', text)
+			_lgr.info('Array/Dictionary compared by value.  Use assert_not_same to compare references.  Use assert_ne_deep to see diff.')
 
 		if(result.are_equal):
 			_fail(disp)
@@ -1507,14 +1503,13 @@ func compare_deep(v1, v2, max_differences=null):
 	return result
 
 # ------------------------------------------------------------------------------
-# Peforms a shallow compare on both values, a CompareResult instnace is returned.
-# The optional max_differences paramter sets the max_differences to be displayed.
+# REMOVED
 # ------------------------------------------------------------------------------
 func compare_shallow(v1, v2, max_differences=null):
-	var result = _compare.shallow(v1, v2)
-	if(max_differences != null):
-		result.max_differences = max_differences
-	return result
+	_fail('compare_shallow has been removed.  Use compare_deep or just compare using == instead.')
+	_lgr.error('compare_shallow has been removed.  Use compare_deep or just compare using == instead.')
+	return null
+
 
 # ------------------------------------------------------------------------------
 # Performs a deep compare and asserts the  values are equal
@@ -1537,24 +1532,16 @@ func assert_ne_deep(v1, v2):
 		_fail(result.get_short_summary())
 
 # ------------------------------------------------------------------------------
-# Performs a shallow compare and asserts the values are equal
+# REMOVED
 # ------------------------------------------------------------------------------
 func assert_eq_shallow(v1, v2):
-	var result = compare_shallow(v1, v2)
-	if(result.are_equal):
-		_pass(result.get_short_summary())
-	else:
-		_fail(result.summary)
+	_fail('assert_eq_shallow has been removed.  Use assert_eq/assert_same/assert_eq_deep')
 
 # ------------------------------------------------------------------------------
-# Performs a shallow compare and asserts the values are not equal
+# REMOVED
 # ------------------------------------------------------------------------------
 func assert_ne_shallow(v1, v2):
-	var result = compare_shallow(v1, v2)
-	if(!result.are_equal):
-		_pass(result.get_short_summary())
-	else:
-		_fail(result.get_short_summary())
+	_fail('assert_eq_shallow has been removed.  Use assert_eq/assert_same/assert_eq_deep')
 
 
 # ------------------------------------------------------------------------------

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1327,11 +1327,8 @@ func ignore_method_when_doubling(thing, method_name):
 		return
 
 	var r = thing
-
 	if(thing is PackedScene):
-		var inst = thing.instantiate()
-		if(inst.get_script()):
-			r = inst.get_script()
+		r = _utils.get_scene_script_object(thing)
 
 	gut.get_doubler().add_ignored_method(r, method_name)
 

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -167,7 +167,6 @@ enum DOUBLE_STRATEGY{
 
 enum DIFF {
 	DEEP,
-	SHALLOW,
 	SIMPLE
 }
 

--- a/test/gut_test.gd
+++ b/test/gut_test.gd
@@ -1,3 +1,5 @@
+class_name GutInternalTester
+
 extends GutTest
 
 const DOUBLE_ME_PATH = 'res://test/resources/doubler_test_objects/double_me.gd'
@@ -38,6 +40,14 @@ func assert_errored(obj, times=1):
 	else:
 		_fail('Does not have get_logger method')
 
+func assert_deprecated(obj, times=1):
+	if(obj.has_method('get_logger')):
+		var msg = str('Should have ', times, ' deprecations.')
+		assert_eq(obj.get_logger().get_deprecated().size(), times, msg)
+	else:
+		_fail('Does not have get_logger method')
+
+
 func assert_has_logger(obj):
 	assert_has_method(obj, 'get_logger')
 	assert_has_method(obj, 'set_logger')
@@ -58,3 +68,22 @@ func new_gut():
 	g._should_print_summary = false
 	g.log_level = g.LOG_LEVEL_FAIL_ONLY
 	return g
+
+# ----------------------------
+# Not used yet, but will be used eventually
+
+# func new_test():
+# 	var t = GutTest.new()
+# 	var logger = _utils.Logger.new()
+# 	t.set_logger(logger)
+# 	return t
+
+
+# func new_test_double():
+# 	var t = double(GutTest).new()
+# 	var logger = double(_utils.Logger).new()
+# 	stub(t, 'set_logger').to_call_super()
+# 	stub(t, 'get_logger').to_call_super()
+# 	t.set_logger(logger)
+# 	return t
+# ----------------------------

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -105,7 +105,6 @@ class TestBasics:
 
 class TestIgnoreMethodsWhenDoubling:
 	extends "res://test/gut_test.gd"
-	var skip_script = 'skip for now, array compares are broke.'
 
 	var _test_gut = null
 	var _test = null
@@ -118,23 +117,18 @@ class TestIgnoreMethodsWhenDoubling:
 		add_child_autofree(_test_gut)
 		add_child_autofree(_test)
 
-	func test_when_calling_with_path_it_sends_path_to_doubler():
-		var m_doubler = double(_utils.Doubler).new()
-		_test_gut._doubler = m_doubler
-		_test.ignore_method_when_doubling('one', 'two')
-		assert_called(m_doubler, 'add_ignored_method', ['one', 'two'])
-
-	func test_when_calling_with_loaded_script_the_path_is_sent_to_doubler():
+	func test_sends_loaded_script_to_the_doubler():
 		var m_doubler = double(_utils.Doubler).new()
 		_test_gut._doubler = m_doubler
 		_test.ignore_method_when_doubling(DoubleMe, 'two')
-		assert_called(m_doubler, 'add_ignored_method', [DOUBLE_ME_PATH, 'two'])
+		assert_called(m_doubler, 'add_ignored_method', [DoubleMe, 'two'])
 
-	func test_when_calling_with_scene_the_script_path_is_sent_to_doubler():
+	func test_sends_loaded_scene_to_the_doubler():
 		var m_doubler = double(_utils.Doubler).new()
 		_test_gut._doubler = m_doubler
 		_test.ignore_method_when_doubling(DoubleMeScene, 'two')
-		assert_called(m_doubler, 'add_ignored_method', ['res://test/resources/doubler_test_objects/double_me_scene.gd', 'two'])
+		assert_called(m_doubler, 'add_ignored_method',
+			[_utils.get_scene_script_object(DoubleMeScene), 'two'])
 
 	func test_when_ignoring_scene_methods_they_are_not_doubled():
 		_test.ignore_method_when_doubling(DoubleMeScene, 'return_hello')

--- a/test/samples/test_readme_examples.gd
+++ b/test/samples/test_readme_examples.gd
@@ -685,38 +685,6 @@ func test_assert_connected():
 	assert_connected(signaler, foo, 'the_signal')
 
 
-func test_shallow_array_compare_1():
-	var a1 = [
-		'a', 'b', 'c',
-		[1, 2, 3, 4],
-		{'a':1, 'b':2, 'c':3},
-		[{'a':1}, {'b':2}]
-	]
-	var a2 = [
-		'a', 2, 'c',
-		['a', 2, 3, 'd'],
-		{'a':11, 'b':12, 'c':13},
-		[{'a':'diff'}, {'b':2}]
-	]
-	var result = compare_shallow(a1, a2)
-	assert_true(result.are_equal, result.summary)
-
-
-func test_shallow_array_compare_2():
-	var a1 = [
-		[1, 2, 3, 4],
-		[[4, 5, 6], ['same'], [7, 8, 9]]
-	]
-	var a2 = [
-		["1", 2.0, 13],
-		[[14, 15, 16], ['same'], [17, 18, 19]]
-	]
-	var result = compare_deep(a1, a2)
-	gut.p(result.summary)
-
-	gut.p('Traversing differences:')
-	gut.p(result.differences[1].differences[2].differences[0])
-
 func test_nested_difference():
 	var v1 = {'a':{'b':{'c':{'d':1}}}}
 	var v2 = {'a':{'b':{'c':{'d':2}}}}
@@ -747,35 +715,6 @@ func test_mix_of_array_and_dictionaries_deep():
 	gut.p(result.differences[5].differences[0].differences['a'])
 
 
-func test_assert_eq_shallow():
-	var complex_example = [
-		'a', 'b', 'c',
-		[1, 2, 3, 4],
-		{'a':1, 'b':2, 'c':3},
-		[{'a':1}, {'b':2}]
-	]
-
-	# Passing
-	assert_eq_shallow([1, 2, 3], [1, 2, 3])
-	assert_eq_shallow([1, [2, 3], 4], [1, [2, 3], 4])
-	var d1 = {'foo':'bar'}
-	assert_eq_shallow([1, 2, d1], [1, 2, d1])
-	assert_eq_shallow({'a':1}, {'a':1})
-	assert_eq_shallow({'a':[1, 2, 3, d1]}, {'a':[1, 2, 3, d1]})
-
-	var shallow_copy = complex_example.duplicate(false)
-	assert_eq_shallow(complex_example, shallow_copy)
-
-	# Failing
-	assert_eq_shallow([1, 2], [1, 2 ,3]) # missing index
-	assert_eq_shallow({'a':1}, {'a':1, 'b':2}) # missing key
-	assert_eq_shallow([1, 2], [1.0, 2.0]) # floats != ints
-	assert_eq_shallow([1, 2, {'a':1}], [1, 2, {'a':1}]) # compare [2] by ref
-	assert_eq_shallow({'a':1}, {'a':1.0}) # floats != ints
-	assert_eq_shallow({'a':1, 'b':{'c':1}}, {'a':1, 'b':{'c':1}}) # compare 'b' by ref
-
-	var deep_copy = complex_example.duplicate(true)
-	assert_eq_shallow(complex_example, deep_copy)
 
 
 
@@ -798,8 +737,6 @@ func test_assert_eq_deep():
 	assert_eq_deep(shallow_copy, deep_copy)
 
 	# Failing
-	assert_eq_shallow([1, 2], [1, 2 ,3]) # missing index
-	assert_eq_shallow({'a':1}, {'a':1, 'b':2}) # missing key
 	assert_eq_deep([1, 2, {'a':1}], [1, 2, {'a':1.0}]) # floats != ints
 
 

--- a/test/unit/test_comparator.gd
+++ b/test/unit/test_comparator.gd
@@ -91,9 +91,6 @@ class TestSimpleCompare:
 		assert_string_contains(result.summary, _comparator.DICTIONARY_DISCLAIMER)
 
 	func test_comparing_different_dictionaries_includes_disclaimer():
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		var result = _comparator.simple({}, {})
 		assert_false(result.are_equal, result.summary)
 		assert_string_contains(result.summary, _comparator.DICTIONARY_DISCLAIMER)
@@ -161,16 +158,10 @@ class TestShallowCompare:
 		assert_not_null(result.summary)
 
 	func test_comparing_dictionaries_does_not_include_sub_dictionaries():
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		var result = _comparator.shallow({'a':{}}, {'a':{}})
 		assert_false(result.are_equal)
 
 	func test_comparing_arrays_does_not_include_sub_dictionaries():
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		var result = _comparator.shallow([{'a':1}], [{'a':1}])
 		assert_false(result.are_equal)
 

--- a/test/unit/test_comparator.gd
+++ b/test/unit/test_comparator.gd
@@ -1,8 +1,8 @@
-extends 'res://addons/gut/test.gd'
+extends GutTest
 
 
 class TestTheBasics:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	func test_can_make_one():
 		var c = _utils.Comparator.new()
@@ -14,7 +14,7 @@ class TestTheBasics:
 
 
 class TestMissing:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	func test_when_first_value_is_missing_it_uses_missing_string_in_summary():
 		var c = _utils.Comparator.new()
@@ -44,7 +44,7 @@ class TestMissing:
 
 
 class TestSimpleCompare:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	var _comparator  = null
 
@@ -101,7 +101,7 @@ class TestSimpleCompare:
 
 
 class TestShouldCompareIntToFloat:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	var _comparator  = null
 
@@ -130,7 +130,7 @@ class TestShouldCompareIntToFloat:
 
 
 class TestShallowCompare:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	var _comparator  = null
 
@@ -175,7 +175,7 @@ class TestShallowCompare:
 
 
 class TestDeepCompare:
-	extends 'res://addons/gut/test.gd'
+	extends GutTest
 
 	var _comparator  = null
 
@@ -217,3 +217,31 @@ class TestDeepCompare:
 	func test_works_with_primitives():
 		var result =  _comparator.deep(1, 1)
 		assert_true(result.are_equal)
+
+
+class TestGodot4ArrayDictionary:
+	extends GutTest
+
+	var _comparator  = null
+
+	func before_each():
+		_comparator = _utils.Comparator.new()
+
+	var _same_arrays = [
+		[[1, 2, 3], [1, 2, 3]],
+		[['a', 2, 'c'], ['a', 2, 'c']],
+		[['one', [1, 2], 'three'], ['one', [1, 2], 'three']]
+	]
+
+	var _same_dicts = [
+		[{'a':1, 'b':2}, {'a':1, 'b':2}],
+		[{'one':'one', 'two':[1, 2]},  {'one':'one', 'two':[1, 2]}]
+	]
+	func test_simple_compares_arrays_by_value(p = use_parameters(_same_arrays)):
+		var result = _comparator.simple(p[0], p[1])
+		assert_true(result.are_equal, result.summary)
+
+	func test_simple_compares_dictionaries_by_value(p = use_parameters(_same_dicts)):
+		var result = _comparator.simple(p[0], p[1])
+		assert_true(result.are_equal, result.summary)
+

--- a/test/unit/test_comparator.gd
+++ b/test/unit/test_comparator.gd
@@ -83,21 +83,11 @@ class TestSimpleCompare:
 		assert_string_contains(result.summary, 'Cannot')
 		assert_string_contains(result.summary, '!=')
 
-	func test_comparing_equal_dictionaries_includes_disclaimer():
-		var d1 = {}
-		var d2 = d1
-		var result = _comparator.simple(d1, d2)
-		assert_true(result.are_equal, result.summary)
-		assert_string_contains(result.summary, _comparator.DICTIONARY_DISCLAIMER)
-
-	func test_comparing_different_dictionaries_includes_disclaimer():
-		var result = _comparator.simple({}, {})
-		assert_false(result.are_equal, result.summary)
-		assert_string_contains(result.summary, _comparator.DICTIONARY_DISCLAIMER)
-
 	func test_comparing_arrays_returns_array_diff_simple_summary():
 		var result = _comparator.simple([1, 2], [3, 4])
 		assert_string_contains(result.summary, '[1, 2] != [3, 4]')
+
+
 
 
 class TestShouldCompareIntToFloat:
@@ -125,53 +115,9 @@ class TestShouldCompareIntToFloat:
 
 	func test_when_enabled_does_not_change_how_dicts_treat_float_int():
 		_comparator.set_should_compare_int_to_float(true)
-		var result = _comparator.shallow({'a':1}, {'a':1.0})
+		var result = _comparator.deep({'a':1}, {'a':1.0})
 		assert_false(result.are_equal, result.summary)
 
-
-class TestShallowCompare:
-	extends GutTest
-
-	var _comparator  = null
-
-	func before_each():
-		_comparator = _utils.Comparator.new()
-
-	func test_comparing_arrays_are_equal_true_when_equal():
-		var result = _comparator.shallow([1], [1])
-		assert_true(result.are_equal)
-
-	func test_comparing_arrays_sets_summary():
-		var result = _comparator.shallow([2], [3])
-		assert_not_null(result.summary)
-
-	func test_comparing_dictionaries_populates_different_keys():
-		var result = _comparator.shallow({'a':1}, {'b':2})
-		assert_true(result.differences.size() == 2)
-
-	func test_comparing_dictionaries_populates_are_equal():
-		var result = _comparator.shallow({}, {})
-		assert_true(result.are_equal)
-
-	func test_comparing_dictionaries_populates_summary():
-		var result = _comparator.shallow({}, {'a':1})
-		assert_not_null(result.summary)
-
-	func test_comparing_dictionaries_does_not_include_sub_dictionaries():
-		var result = _comparator.shallow({'a':{}}, {'a':{}})
-		assert_false(result.are_equal)
-
-	func test_comparing_arrays_does_not_include_sub_dictionaries():
-		var result = _comparator.shallow([{'a':1}], [{'a':1}])
-		assert_false(result.are_equal)
-
-	func test_works_with_different_datatypes():
-		var result = _comparator.shallow({}, [])
-		assert_false(result.are_equal)
-
-	func test_works_with_primitives():
-		var result =  _comparator.shallow(1, 1)
-		assert_true(result.are_equal)
 
 
 class TestDeepCompare:
@@ -220,7 +166,7 @@ class TestDeepCompare:
 
 
 class TestGodot4ArrayDictionary:
-	extends GutTest
+	extends 'res://test/gut_test.gd'
 
 	var _comparator  = null
 

--- a/test/unit/test_diff_formatter.gd
+++ b/test/unit/test_diff_formatter.gd
@@ -6,18 +6,17 @@ class TestFormatter:
 	var Formatter = load('res://addons/gut/diff_formatter.gd')
 	var DiffTool = _utils.DiffTool
 
+	func test_demo_eq_format():
+		assert_eq([], [])
+		assert_eq([1, 2, 3], [1, 2, 3])
+		assert_eq({}, {})
+		assert_eq({'a':1}, {'a':1})
+
 	func test_equal_arrays():
 		pass_test(Formatter.new().make_it(DiffTool.new([1, 2, 3], [1, 2, 3])))
 
 	func test_equal_dictionaries():
 		pass_test(Formatter.new().make_it(DiffTool.new({}, {})))
-
-	func test_when_shallow_ditionaries_in_arrays_are_not_checked_for_values():
-		var d1 = {'a': 1, 'dne_in_d2':{'x':'x', 'y':'y', 'z':'z'}, 'r':1}
-		var d2 = {'a': 2, 'dne_in_d1':{'xx':'x', 'yy':'y', 'zz':'z'}, 'r':2}
-
-		var diff = DiffTool.new(d1, d2, _utils.DIFF.DEEP)
-		pass_test(Formatter.new().make_it(diff))
 
 
 	func test_works_with_strings_and_numbers():
@@ -71,24 +70,6 @@ class TestFormatter:
 		var diff = DiffTool.new(a1, a2, _utils.DIFF.DEEP)
 		pass_test(Formatter.new().make_it(diff))
 
-	func test_mix_of_array_and_dictionaries_shallow():
-		var a1 = [
-			'a', 'b', 'c',
-			[1, 2, 3, 4],
-			{'a':1, 'b':2, 'c':3},
-			[{'a':1}, {'b':2}]
-		]
-		var a2 = [
-			'a', 2, 'c',
-			['a', 2, 3, 'd'],
-			{'a':11, 'b':12, 'c':13},
-			[{'a':'diff'}, {'b':2}]
-		]
-		var diff = DiffTool.new(a1, a2, _utils.DIFF.SHALLOW)
-		print(_strutils.type2str(diff.differences[3]))
-		print('brackets = ', diff.differences[3].get_brackets())
-		pass_test(Formatter.new().make_it(diff))
-
 
 	func test_multiple_sub_arrays():
 		var a1 = [
@@ -140,12 +121,6 @@ class TestUsingAssertNe:
 	extends GutTest
 
 	var DiffTool = _utils.DiffTool
-
-	func test_when_shallow_ditionaries_in_arrays_are_not_checked_for_values():
-		var d1 = {'a': 1, 'dne_in_d2':{'x':'x', 'y':'y', 'z':'z'}, 'r':1}
-		var d2 = {'a': 2, 'dne_in_d1':{'xx':'x', 'yy':'y', 'zz':'z'}, 'r':2}
-		assert_ne(d1, d2)
-
 
 	func test_works_with_strings_and_numbers():
 		var a1 = [0, 1, 2, 3, 4]

--- a/test/unit/test_diff_tool.gd
+++ b/test/unit/test_diff_tool.gd
@@ -66,8 +66,8 @@ class TestArrayDiff:
 		assert_eq(diff.get_diff_type(), _utils.DIFF.DEEP)
 
 	func test_constructor_sets_diff_type():
-		var diff = DiffTool.new([], [], _utils.DIFF.SHALLOW)
-		assert_eq(diff.get_diff_type(), _utils.DIFF.SHALLOW)
+		var diff = DiffTool.new([], [], _utils.DIFF.SIMPLE)
+		assert_eq(diff.get_diff_type(), _utils.DIFF.SIMPLE)
 
 	func test_is_equal_is_true_when_all_elements_match():
 		var ad = DiffTool.new([1, 2, 3], [1, 2, 3])
@@ -131,19 +131,11 @@ class TestArrayDiff:
 		var ad  = DiffTool.new(a1, a2)
 		assert_string_contains(ad.summarize(), 'double of test.gd')
 
-
-	func test_diff_with_dictionaries_fails_when_not_same_reference_but_same_values():
-		var a1 = [{'a':1}, {'b':2}]
-		var a2 = [{'a':1}, {'b':2}]
-		var diff = DiffTool.new(a1, a2, _utils.DIFF.SHALLOW)
-		assert_false(diff.are_equal, diff.summarize())
-
-
 	func test_dictionaries_in_sub_arrays():
 		var a1 = [[{'a': 1}]]
 		var a2 = [[{'a': 1}]]
-		var diff = DiffTool.new(a1, a2, _utils.DIFF.SHALLOW)
-		assert_false(diff.are_equal, diff.summarize())
+		var diff = DiffTool.new(a1, a2, _utils.DIFF.SIMPLE)
+		assert_true(diff.are_equal, diff.summarize())
 
 
 class TestArrayDeepDiff:
@@ -237,13 +229,9 @@ class TestDictionaryDiff:
 		var dd = DiffTool.new({}, {})
 		assert_not_null(dd)
 
-	func test_constructor_defaults_diff_type_to_shallow():
+	func test_constructor_defaults_diff_type_to_deep():
 		var diff = DiffTool.new({}, {})
 		assert_eq(diff.get_diff_type(), _utils.DIFF.DEEP)
-
-	func test_constructor_sets_diff_type():
-		var diff = DiffTool.new({}, {}, _utils.DIFF.SHALLOW)
-		assert_eq(diff.get_diff_type(), _utils.DIFF.SHALLOW)
 
 	func test_get_differences_returns_empty_array_when_matching():
 		var dd = DiffTool.new({'a':'asdf'}, {'a':'asdf'})
@@ -257,7 +245,7 @@ class TestDictionaryDiff:
 		var dd = DiffTool.new({'a':'asdf', 'b':1}, {'a':'asdf'})
 		assert_eq(dd.get_differences().keys(), ['b'])
 
-	func test_get_differetn_keys_returns_missing_indexes_in_d1():
+	func test_get_different_keys_returns_missing_indexes_in_d1():
 		var dd = DiffTool.new({'a':'asdf'}, {'a':'asdf', 'b':1})
 		assert_eq(dd.get_differences().keys(), ['b'])
 
@@ -335,18 +323,6 @@ class TestDictionaryDiff:
 		var d2 = {'a':[{'b':1}]}
 		var diff = DiffTool.new(d1, d2)
 		assert_true(diff.are_equal, diff.summarize())
-
-	func test_when_shallow_sub_dictionaries_are_not_checked_for_values():
-		var d1 = {'a':1, 'b':{'a':99}}
-		var d2 = {'a':1, 'b':{'a':99}}
-		var diff = DiffTool.new(d1, d2, _utils.DIFF.SHALLOW)
-		assert_false(diff.are_equal, diff.summarize())
-
-	func test_when_shallow_ditionaries_in_arrays_are_not_checked_for_values():
-		var d1 = {'a':[{'b':1}]}
-		var d2 = {'a':[{'b':1}]}
-		var diff = DiffTool.new(d1, d2, _utils.DIFF.SHALLOW)
-		assert_false(diff.are_equal, diff.summarize())
 
 
 	func test_when_deep_diff_then_different_arrays_contains_DiffTool():

--- a/test/unit/test_diff_tool.gd
+++ b/test/unit/test_diff_tool.gd
@@ -55,8 +55,6 @@ class TestArrayCompareResultInterace:
 class TestArrayDiff:
 	extends 'res://addons/gut/test.gd'
 
-	var skip_script = '4.0 Dictionary and array compare broke'
-
 	var DiffTool = _utils.DiffTool
 
 	func test_can_instantiate_with_two_arrays():
@@ -118,7 +116,7 @@ class TestArrayDiff:
 		assert_string_contains(ad.summarize(), ' == ')
 
 	func test_diff_display_with_classes():
-		var d_test = double('res://addons/gut/test.gd').new()
+		var d_test = double(GutTest).new()
 		var a1 = [gut, d_test]
 		var a2 = [d_test, gut]
 		var ad  = DiffTool.new(a1, a2)
@@ -126,8 +124,8 @@ class TestArrayDiff:
 		assert_string_contains(ad.summarize(), 'double of test.gd')
 
 	func test_diff_display_with_classes2():
-		var d_test_1 = double('res://addons/gut/test.gd').new()
-		var d_test_2 = double('res://addons/gut/test.gd').new()
+		var d_test_1 = double(GutTest).new()
+		var d_test_2 = double(GutTest).new()
 		var a1 = [d_test_1, d_test_2]
 		var a2 = [d_test_2, d_test_1]
 		var ad  = DiffTool.new(a1, a2)
@@ -150,8 +148,6 @@ class TestArrayDiff:
 
 class TestArrayDeepDiff:
 	extends 'res://addons/gut/test.gd'
-
-	var skip_script = '4.0 Dictionary and array compare broke'
 
 	var DiffTool = _utils.DiffTool
 
@@ -188,8 +184,6 @@ class TestArrayDeepDiff:
 
 class TestDictionaryCompareResultInterace:
 	extends 'res://addons/gut/test.gd'
-
-	var skip_script = '4.0 Dictionary and array compare broke'
 
 	var DiffTool = _utils.DiffTool
 
@@ -236,8 +230,6 @@ class TestDictionaryCompareResultInterace:
 
 class TestDictionaryDiff:
 	extends 'res://addons/gut/test.gd'
-
-	var skip_script = '4.0 Dictionary and array compare broke'
 
 	var DiffTool = _utils.DiffTool
 

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -156,9 +156,6 @@ class TestAssertEq:
 		]
 	]
 	func test_with_array(p = use_parameters(array_vals)):
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		gr.test.assert_eq(p[0], p[1])
 		if(p[2]):
 			assert_pass(gr.test)
@@ -173,9 +170,6 @@ class TestAssertEq:
 		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
 
 	func test_dictionary_not_compared_by_value():
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		var d  = {'a':1}
 		var d2 = {'a':1}
 		gr.test.assert_eq(d, d2)
@@ -226,9 +220,6 @@ class TestAssertNe:
 		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
 
 	func test_dictionary_not_compared_by_value():
-		pending('4.0 Dictionary and array compare broke')
-		return
-
 		var d  = {'a':1}
 		var d2 = {'a':1}
 		gr.test.assert_ne(d, d2)
@@ -1831,8 +1822,6 @@ class TestPassFailTestMethods:
 # ------------------------------------------------------------------------------
 class TestCompareDeepShallow:
 	extends BaseTestClass
-
-	var skip_script = 'Not implemented in 4.0'
 
 	func test_compare_shallow_uses_compare():
 		var d_compare = double(_utils.Comparator).new()

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -93,11 +93,6 @@ class TestMiscTests:
 		gr.test.set_logger(dlog)
 		assert_eq(gr.test.get_logger(), dlog)
 
-	func test_not_freeing_children_generates_warning():
-		pass
-		# I cannot think of a way to test this without some giant amount of
-		# testing legwork.
-
 
 # ------------------------------------------------------------------------------
 class TestAssertEq:
@@ -147,7 +142,7 @@ class TestAssertEq:
 		[[10, 20.0, 30], [10.0, 20, 30.0], false],
 		[[1, 2], [1, 2, 3, 4, 5], false],
 		[[1, 2, 3, 4, 5], [1, 2], false],
-		[[{'a':1}], [{'a':1}], false],
+		[[{'a':1}], [{'a':1}], true],
 		[[[1, 2], [3, 4]], [[5, 6], [7, 8]], false],
 		[
 			[[1, [2, 3]], [4, [5, 6]]],
@@ -167,14 +162,12 @@ class TestAssertEq:
 		var d_pointer = d
 		gr.test.assert_eq(d, d_pointer)
 		assert_pass(gr.test)
-		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
 
-	func test_dictionary_not_compared_by_value():
+	func test_dictionary_are_compared_by_value():
 		var d  = {'a':1}
 		var d2 = {'a':1}
 		gr.test.assert_eq(d, d2)
-		assert_fail(gr.test)
-		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
+		assert_pass(gr.test)
 
 
 # ------------------------------------------------------------------------------
@@ -204,7 +197,8 @@ class TestAssertNe:
 	var array_vals = [
 		[[1, 2, 3], ['1', '2', '3'], true],
 		[[1, 2, 3], [1, 2, 3], false],
-		[[1, 2.0, 3], [1.0, 2, 3.0], true]]
+		[[1, 2.0, 3], [1.0, 2, 3.0], true]
+	]
 	func test_with_array(p = use_parameters(array_vals)):
 		gr.test.assert_ne(p[0], p[1])
 		if(p[2]):
@@ -217,14 +211,12 @@ class TestAssertNe:
 		var d_pointer = d
 		gr.test.assert_ne(d, d_pointer)
 		assert_fail(gr.test)
-		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
 
-	func test_dictionary_not_compared_by_value():
-		var d  = {'a':1}
+	func test_dictionary_are_compared_by_value():
+		var d  = {'a':2}
 		var d2 = {'a':1}
 		gr.test.assert_ne(d, d2)
 		assert_pass(gr.test)
-		assert_string_contains(gr.test._fail_pass_text[0], _compare.DICTIONARY_DISCLAIMER)
 
 
 # ------------------------------------------------------------------------------
@@ -1823,16 +1815,6 @@ class TestPassFailTestMethods:
 class TestCompareDeepShallow:
 	extends BaseTestClass
 
-	func test_compare_shallow_uses_compare():
-		var d_compare = double(_utils.Comparator).new()
-		gr.test._compare = d_compare
-		var result = gr.test.compare_shallow([], [])
-		assert_called(d_compare, 'shallow')
-
-	func test_compare_shallow_sets_max_differences():
-		var result = gr.test.compare_shallow([], [], 10)
-		assert_eq(result.max_differences, 10)
-
 	func test_compare_deep_uses_compare():
 		var d_compare = double(_utils.Comparator).new()
 		gr.test._compare = d_compare
@@ -1859,20 +1841,16 @@ class TestCompareDeepShallow:
 		gr.test.assert_ne_deep({'a':1}, {'a':1})
 		assert_fail(gr.test)
 
-	func test_assert_eq_shallow_pass_with_same():
+	func test_assert_shallow_fails_due_to_removed():
 		gr.test.assert_eq_shallow({'a':1}, {'a':1})
-		assert_pass(gr.test)
-
-	func test_assert_eq_shallow_fails_with_different():
-		gr.test.assert_eq_shallow({'a':12}, {'a':1})
 		assert_fail(gr.test)
 
-	func test_assert_ne_shallow_passes_with_different():
-		gr.test.assert_ne_shallow({'a':12}, {'a':1})
-		assert_pass(gr.test)
+	func test_assert_ne_shallow_fails_due_to_removed():
+		gr.test.assert_ne_shallow({'a':1}, {'a':2})
+		assert_fail(gr.test)
 
-	func test_assert_ne_shallow_fails_with_same():
-		gr.test.assert_ne_shallow({'a':1}, {'a':1})
+	func test_compare_shallow_results_in_fail_and_warning():
+		gr.test.compare_shallow([], [])
 		assert_fail(gr.test)
 
 

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1973,3 +1973,48 @@ class TestAssertBackedProperty:
 		var test_node = autofree(TestNode.new())
 		gr.test_with_gut.assert_property_with_backing_variable(test_node, "backed_set_broke", 12, 0)
 		assert_fail_pass(gr.test_with_gut, 2, SUB_ASSERT_COUNT - 2)
+
+
+# ------------------------------------------------------------------------------
+class TestAssertSameAndAssertNotSame:
+	extends BaseTestClass
+
+	var _a1 = []
+	var _a2 = []
+	var _d1 = {}
+	var _d2 = {}
+	var _same_values = [
+		[1, 1],
+		['a', 'a'],
+		[Vector3(1, 2, 3), Vector3(1, 2, 3)],
+		[_a1, _a1],
+		[_d1, _d1]
+	]
+
+	var _not_same_values = [
+		[1, 2],
+		['a', 'b'],
+		[Vector3(1, 1, 1), Vector3(5, 5, 5)],
+		[_a1, _a2],
+		[_d1, _d2],
+		[1, _a1],
+		['b', _d2]
+	]
+
+	func test_assert_same_passes_when_values_are_same(p = use_parameters(_same_values)):
+		gr.test_with_gut.assert_same(p[0], p[1])
+		assert_pass(gr.test_with_gut)
+
+	func test_assert_same_fails_when_values_are_not_the_same(p = use_parameters(_not_same_values)):
+		gr.test_with_gut.assert_same(p[0], p[1])
+		assert_fail(gr.test_with_gut)
+
+	func test_assert_not_same_fails_when_values_are_same(p = use_parameters(_same_values)):
+		gr.test_with_gut.assert_not_same(p[0], p[1])
+		assert_fail(gr.test_with_gut)
+
+	func test_assert_not_same_fails_when_values_are_not_the_same(p = use_parameters(_not_same_values)):
+		gr.test_with_gut.assert_not_same(p[0], p[1])
+		assert_pass(gr.test_with_gut)
+
+


### PR DESCRIPTION
* Compares dictionaries and arrays by value using `==` by default.  This matches Godot 4's behavior.
* Removed shallow compare methods and asserts.
* Added `assert_same` and `assert_not_same` which can be used to compare dictionaries/arrays by reference.
