### PR TITLE
Remove call to deprecated clear_text()

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -1093,8 +1093,6 @@ func p(text, level=0):
 # Runs all the scripts that were added using add_script
 # ------------------------------------------------------------------------------
 func test_scripts(run_rest=false):
-	clear_text()
-
 	if(_script_name != null and _script_name != ''):
 		var indexes = _get_indexes_matching_script_name(_script_name)
 		if(indexes == []):


### PR DESCRIPTION
This removes a deprecated call which was remarked in the test output.

```
[DEPRECATED]:  gut.clear_text

...
(rest of output omitted for brevity)
...

Warnings/Errors:
* 1 Deprecated calls.
```

In my own running from GUI and command line, I did not notice any negative effects from removing this call,
but if you are aware of any, then please reject this PR.

Resolves #468 