### PR TITLE
fix exit code when should_exit is set

### DIFF
--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -287,23 +287,19 @@ func _on_tests_finished(should_exit, should_exit_on_success):
 			var lgr = _tester.logger
 			lgr.error('No directories configured.  Add directories with options or a super.gutconfig.json file.  Use the -gh option for more information.')
 
+	var exit_code = 0
 	if(_tester.get_fail_count()):
-		set_exit_code(1)
+		exit_code = 1
 
 	# Overwrite the exit code with the post_script
 	var post_inst = _tester.get_post_run_script_instance()
 	if(post_inst != null and post_inst.get_exit_code() != null):
-		set_exit_code(post_inst.get_exit_code())
+		exit_code = post_inst.get_exit_code()
 
 	if(should_exit or (should_exit_on_success and _tester.get_fail_count() == 0)):
-		quit()
+		quit(exit_code)
 	else:
 		print("Tests finished, exit manually")
-
-func set_exit_code(val):
-	pass
-	# OS.exit_code doesn't exist anymore, but when we find a solution it just
-	# goes here.
 
 
 # ------------------------------------------------------------------------------
@@ -313,7 +309,6 @@ func _init():
 	if(!_utils.is_version_ok()):
 		print("\n\n", _utils.get_version_text())
 		push_error(_utils.get_bad_version_text())
-		set_exit_code(1)
-		quit()
+		quit(1)
 	else:
 		_run_gut()

--- a/wiki/Hooks.md
+++ b/wiki/Hooks.md
@@ -43,8 +43,6 @@ The built in `abort()` method will cause the run to end immediately after the `r
 ### Exit Code (post-run only)
 The `set_exit_code(code)` method will set an exit code that will be used when running from the command line.  The default behavior is to return `0` when all tests pass and `1` if any  tests fail (pending tests do not affect the exit code).  If you call `set_exit_code` then the value passed will be used.
 
-**Note** Any call directly to `OS.exit_code` will be overwritten by `gut_cmdln`.
-
 **Note** Calling `set_exit_code` in the pre-run script will not affect the actual exit code.  You could use `gut.get_pre_run_script_instance().get_exit_code()` in your post-run script to get you any value you've set via `set_exit_code` in your pre-run script.
 
 


### PR DESCRIPTION
With GUT 9, gut_cmdln exits with exit code 0 even if tests failed.
This should fix this, at least if `-gexit` (`should_exit`) is set.
When manually exiting GUT (`-gexit` not set or with `-gexit_on_success`), the exit code will still be 0.
However, I don't think it's that important to have a exit code != 0, when manually running GUT,
since the exit code is mainly relevant for CI pipelines, which probably always run with `-gexit`.

Note: There is one more uncommented usage of `OS.exit_code` [here](https://github.com/bitwes/Gut/blob/godot_4/addons/gut/gut.gd#L1145).
I'm not quite sure how to fix it. Maybe just exit immediately?
