### PR TITLE
Fix possible overzealous 3to4 conversion

### DIFF
--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -210,10 +210,10 @@ func extract_command_line_options(from, to):
 
 
 func _print_gutconfigs(values):
-	var header = """Here is a sample of a full super.gutconfig.json file.
+	var header = """Here is a sample of a full .gutconfig.json file.
 You do not need to specify all values in your own file.  The values supplied in
 this sample are what would be used if you ran gut w/o the -gprint_gutconfig_sample
-option (option priority:  command-line, super.gutconfig, default)."""
+option (option priority:  command-line, .gutconfig, default)."""
 	print("\n", header.replace("\n", ' '), "\n\n")
 	var resolved = values
 
@@ -258,7 +258,7 @@ func _run_gut():
 		elif(o.get_value('-gpo')):
 			print('All command line options and where they are specified.  ' +
 				'The "final" value shows which value will actually be used ' +
-				'based on order of precedence (default < super.gutconfig < cmd line).' + "\n")
+				'based on order of precedence (default < .gutconfig < cmd line).' + "\n")
 			print(opt_resolver.to_s_verbose())
 			quit()
 		elif(o.get_value('-gprint_gutconfig_sample')):
@@ -285,7 +285,7 @@ func _on_tests_finished(should_exit, should_exit_on_success):
 	if(_final_opts.dirs.size() == 0):
 		if(_tester.get_summary().get_totals().scripts == 0):
 			var lgr = _tester.logger
-			lgr.error('No directories configured.  Add directories with options or a super.gutconfig.json file.  Use the -gh option for more information.')
+			lgr.error('No directories configured.  Add directories with options or a .gutconfig.json file.  Use the -gh option for more information.')
 
 	if(_tester.get_fail_count()):
 		set_exit_code(1)


### PR DESCRIPTION
`super.gutconfig.json` → `.gutconfig.json` in some feedbacks