### PR TITLE
I485 ignore non guttest scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 # 7.4.2
-
+* __Issue i485__ GUT prints a warning and ignores scripts that do not extend `GutTest`.
 
 # 7.4.1
 * __Issue i393__ 7.4.0 broke running from a scene.  On a side note, try the new and improved Gut Panel!  It __did not__ break in the last release and was significantly improved!

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -166,7 +166,7 @@ func _get_inner_test_class_names(loaded):
 					inner_classes.append(key)
 				else:
 					_lgr.warn(str('Ignoring Inner Class ', key,
-						' because it does not extend res://addons/gut/test.gd'))
+						' because it does not extend GutTest'))
 
 			# This could go deeper and find inner classes within inner classes
 			# but requires more experimentation.  Right now I'm keeping it at
@@ -211,10 +211,18 @@ func add_script(path):
 		_lgr.error('Could not find script:  ' + path)
 		return
 
+
+
 	var ts = TestScript.new(_utils, _lgr)
 	ts.path = path
-	scripts.append(ts)
-	return _parse_script(ts)
+	var parse_results = _parse_script(ts)
+	if(parse_results.find(path) == -1):
+		_lgr.warn(str('Ignoring script ', path,
+		' because it does not extend GutTest'))
+	else:
+		scripts.append(ts)
+
+	return parse_results
 
 func clear():
 	scripts.clear()

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -184,6 +184,8 @@ func _parse_script(test_script):
 		_populate_tests(test_script)
 		scripts_found.append(test_script.path)
 		inner_classes = _get_inner_test_class_names(loaded)
+	else:
+		return []
 
 	for i in range(inner_classes.size()):
 		var loaded_inner = loaded.get(inner_classes[i])
@@ -201,6 +203,7 @@ func _parse_script(test_script):
 # Public
 # -----------------
 func add_script(path):
+	print('adding ', path)
 	# SHORTCIRCUIT
 	if(has_script(path)):
 		return []
@@ -211,18 +214,22 @@ func add_script(path):
 		_lgr.error('Could not find script:  ' + path)
 		return
 
-
-
 	var ts = TestScript.new(_utils, _lgr)
 	ts.path = path
+	# Append right away because if we don't test_doubler.gd.TestInitParameters
+	# will HARD crash.  I couldn't figure out what was causing the issue but
+	# appending right away, and then removing if it's not valid seems to fix
+	# things.  It might have to do with the ordering of the test classes in
+	# the test collecter.  I'm not really sure.
+	scripts.append(ts)
 	var parse_results = _parse_script(ts)
+
 	if(parse_results.find(path) == -1):
-		_lgr.warn(str('Ignoring script ', path,
-		' because it does not extend GutTest'))
-	else:
-		scripts.append(ts)
+		_lgr.warn(str('Ignoring script ', path, ' because it does not extend GutTest'))
+		scripts.remove(scripts.find(ts))
 
 	return parse_results
+
 
 func clear():
 	scripts.clear()

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -203,7 +203,6 @@ func _parse_script(test_script):
 # Public
 # -----------------
 func add_script(path):
-	print('adding ', path)
 	# SHORTCIRCUIT
 	if(has_script(path)):
 		return []

--- a/test/resources/parsing_and_loading_samples/test_does_not_extend_guttest.gd
+++ b/test/resources/parsing_and_loading_samples/test_does_not_extend_guttest.gd
@@ -1,0 +1,19 @@
+# This file should be ignored by add_script since it does not extend GutTest
+func before_all():
+    print("should be ignored")
+
+
+# This class matches the default prefix but should be ignored because it does
+# not extend GutTest
+class TestDoesNotExtendTest:
+
+    func before_all():
+        print("should be ignored")
+
+
+# This class should be ignored because the outer script does not extend GutTest.
+class TestExtendsButShouldBeIgnored:
+    extends GutTest
+
+    func before_all():
+        print("should be ignored")

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -519,7 +519,6 @@ class TestInitParameters:
 
 	func before_all():
 		gut.get_doubler()._print_source = false
-		print(gut.get_test_collector().to_s())
 
 	func before_each():
 		DoubledClass = double(

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -519,6 +519,7 @@ class TestInitParameters:
 
 	func before_all():
 		gut.get_doubler()._print_source = false
+		print(gut.get_test_collector().to_s())
 
 	func before_each():
 		DoubledClass = double(

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -271,9 +271,9 @@ func test_simulate_checks_process_on_all_nodes():
 	gr.test_gut.simulate(objs[0], 5, 0.2)
 
 	gr.test.assert_eq(objs[0].call_count, 5, "_process should have been called 5 times")
-	gr.test.assert_eq(objs[0].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[0].delta_sum, 1.0, "The delta value should have been passed in and summed")
 	gr.test.assert_eq(objs[2].call_count, 5, "_process should have been called 5 times")
-	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")
 
 	assert_pass(4)
 
@@ -318,7 +318,7 @@ func test_simulate_calls_process_on_descendents_if_objects_are_processing():
 
 	gr.test.assert_eq(objs[0].call_count, 0, "_process should not have been called")
 	gr.test.assert_eq(objs[2].call_count, 5, "_process should have been called 5 times")
-	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")
 
 	assert_pass(3)
 
@@ -358,13 +358,13 @@ func test_simulate_calls_physics_process_on_descendents_if_objects_have_method()
 			objs.append(autofree(WithoutPhysicsProcess.new()))
 		if(i > 0):
 			objs[i - 1].add_child(objs[i])
-	
+
 	gr.test_gut.simulate(objs[0], 5, 0.2)
 
 	gr.test.assert_eq(objs[0].call_count, 5, "_physics_process should have been called 5 times")
-	gr.test.assert_eq(objs[0].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[0].delta_sum, 1.0, "The delta value should have been passed in and summed")
 	gr.test.assert_eq(objs[2].call_count, 5, "_physics_process should have been called 5 times")
-	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")
 
 	assert_pass(4)
 
@@ -409,7 +409,7 @@ func test_simulate_calls_physics_process_on_descendents_if_objects_are_processin
 
 	gr.test.assert_eq(objs[0].call_count, 0, "_physics_process should not have been called")
 	gr.test.assert_eq(objs[2].call_count, 5, "_physics_process should have been called 5 times")
-	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")	
+	gr.test.assert_eq(objs[2].delta_sum, 1.0, "The delta value should have been passed in and summed")
 
 	assert_pass(3)
 

--- a/test/unit/test_test_collector.gd
+++ b/test/unit/test_test_collector.gd
@@ -50,6 +50,16 @@ class TestTestCollector:
 
 		assert_eq(gr.tc.scripts.size(), 3)
 
+	func test_add_script_ignores_non_guttest_scripts():
+		var script_path = SCRIPTS_ROOT + 'test_does_not_extend_guttest.gd'
+		var result = gr.tc.add_script(script_path)
+		assert_false(gr.tc.has_script(script_path), 'does not have the script')
+		assert_eq(result, [], 'No scripts or inner classes should have been found')
+
+	func test_add_script_ignores_inner_classes_in_non_guttest_scripts():
+		var script_path = SCRIPTS_ROOT + 'test_does_not_extend_guttest.gd'
+		gr.tc.add_script(script_path)
+		assert_false(gr.tc.has_script(script_path + '.TestExtendsButShouldBeIgnored'))
 
 	func test_can_change_test_class_prefix():
 		gr.tc.set_test_class_prefix('DifferentPrefix')


### PR DESCRIPTION
GUT will now print a warning and ignore scripts that do not extend `GutTest`.