### PR TITLE
Godot 4 i485

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     * If you have an invalid Double Strategy set via command line or gutconfig, the default will be used.  So if you are explicity setting it to the old `INCLUDE_SUPER`, it will use `SCRIPT_ONLY`.
     * You can now set the default double strategy in the GutPanel in the Editor.
 * Added `GutControl` to aid in running tests in a deployed game.  Instructions and sample code can be found [in the wiki](https://bitwes.github.io/GutWiki/Godot4/Running-On-Devices.html).
+* __Issue i485__ GUT prints a warning and ignores scripts that do not extend `GutTest`.
 
 
 # 9.0.1

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -186,7 +186,7 @@ func _get_inner_test_class_names(loaded):
 					inner_classes.append(key)
 				else:
 					_lgr.warn(str('Ignoring Inner Class ', key,
-						' because it does not extend res://addons/gut/test.gd'))
+						' because it does not extend GutTest'))
 
 			# This could go deeper and find inner classes within inner classes
 			# but requires more experimentation.  Right now I'm keeping it at
@@ -204,6 +204,8 @@ func _parse_script(test_script):
 		_populate_tests(test_script)
 		scripts_found.append(test_script.path)
 		inner_classes = _get_inner_test_class_names(loaded)
+	else:
+		return []
 
 	for i in range(inner_classes.size()):
 		var loaded_inner = loaded.get(inner_classes[i])
@@ -233,8 +235,20 @@ func add_script(path):
 
 	var ts = TestScript.new(_utils, _lgr)
 	ts.path = path
+	# Append right away because if we don't test_doubler.gd.TestInitParameters
+	# will HARD crash.  I couldn't figure out what was causing the issue but
+	# appending right away, and then removing if it's not valid seems to fix
+	# things.  It might have to do with the ordering of the test classes in
+	# the test collecter.  I'm not really sure.
 	scripts.append(ts)
-	return _parse_script(ts)
+	var parse_results = _parse_script(ts)
+
+	if(parse_results.find(path) == -1):
+		_lgr.warn(str('Ignoring script ', path, ' because it does not extend GutTest'))
+		scripts.remove(scripts.find(ts))
+
+	return parse_results
+
 
 func clear():
 	scripts.clear()

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -245,7 +245,7 @@ func add_script(path):
 
 	if(parse_results.find(path) == -1):
 		_lgr.warn(str('Ignoring script ', path, ' because it does not extend GutTest'))
-		scripts.remove(scripts.find(ts))
+		scripts.remove_at(scripts.find(ts))
 
 	return parse_results
 

--- a/test/resources/parsing_and_loading_samples/test_does_not_extend_guttest.gd
+++ b/test/resources/parsing_and_loading_samples/test_does_not_extend_guttest.gd
@@ -1,0 +1,19 @@
+# This file should be ignored by add_script since it does not extend GutTest
+func before_all():
+    print("should be ignored")
+
+
+# This class matches the default prefix but should be ignored because it does
+# not extend GutTest
+class TestDoesNotExtendTest:
+
+    func before_all():
+        print("should be ignored")
+
+
+# This class should be ignored because the outer script does not extend GutTest.
+class TestExtendsButShouldBeIgnored:
+    extends GutTest
+
+    func before_all():
+        print("should be ignored")

--- a/test/unit/test_test_collector.gd
+++ b/test/unit/test_test_collector.gd
@@ -50,6 +50,16 @@ class TestTestCollector:
 
 		assert_eq(gr.tc.scripts.size(), 3)
 
+	func test_add_script_ignores_non_guttest_scripts():
+		var script_path = SCRIPTS_ROOT + 'test_does_not_extend_guttest.gd'
+		var result = gr.tc.add_script(script_path)
+		assert_false(gr.tc.has_script(script_path), 'does not have the script')
+		assert_eq(result, [], 'No scripts or inner classes should have been found')
+
+	func test_add_script_ignores_inner_classes_in_non_guttest_scripts():
+		var script_path = SCRIPTS_ROOT + 'test_does_not_extend_guttest.gd'
+		gr.tc.add_script(script_path)
+		assert_false(gr.tc.has_script(script_path + '.TestExtendsButShouldBeIgnored'))
 
 	func test_can_change_test_class_prefix():
 		gr.tc.set_test_class_prefix('DifferentPrefix')


### PR DESCRIPTION
GUT prints a warning and ignores scripts that do not extend `GutTest`.