### PR TITLE
chore(simulate): apply PR #409 to godot_4 branch

### DIFF
--- a/addons/gut/gut_to_move.gd
+++ b/addons/gut/gut_to_move.gd
@@ -60,16 +60,34 @@ func file_touch(path):
 	FileAccess.open(path, FileAccess.WRITE)
 
 # ------------------------------------------------------------------------------
-# Call _process or _fixed_process, if they exist, on obj and all it's children
-# and their children and so and so forth.  Delta will be passed through to all
-# the _process or _fixed_process methods.
+# Simulate a number of frames by calling '_process' and '_physics_process' (if
+# the methods exist) on an object and all of its descendents. The specified frame
+# time, 'delta', will be passed to each simulated call.
+#
+# NOTE: Objects can disable their processing methods using 'set_process(false)' and
+# 'set_physics_process(false)'. This is reflected in the 'Object' methods
+# 'is_processing()' and 'is_physics_processing()', respectively. To make 'simulate'
+# respect this status, for example if you are testing an object which toggles
+# processing, pass 'check_is_processing' as 'true'.
 # ------------------------------------------------------------------------------
-func simulate(obj, times, delta):
+func simulate(obj, times, delta, check_is_processing: bool = false):
 	for _i in range(times):
-		if(obj.has_method("_process")):
+		if (
+			obj.has_method("_process")
+			and (
+				not check_is_processing
+				or obj.is_processing()
+			)
+		):
 			obj._process(delta)
-		if(obj.has_method("_physics_process")):
+		if(
+			obj.has_method("_physics_process")
+			and (
+				not check_is_processing
+				or obj.is_physics_processing()
+			)
+		):
 			obj._physics_process(delta)
 
 		for kid in obj.get_children():
-			simulate(kid, 1, delta)
+			simulate(kid, 1, delta, check_is_processing)

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1357,8 +1357,8 @@ func stub(thing, p2, p3=null):
 # ------------------------------------------------------------------------------
 # convenience wrapper.
 # ------------------------------------------------------------------------------
-func simulate(obj, times, delta):
-	gut.simulate(obj, times, delta)
+func simulate(obj, times, delta, check_is_processing: bool = false):
+	gut.simulate(obj, times, delta, check_is_processing)
 
 # ------------------------------------------------------------------------------
 # Replace the node at base_node.get_node(path) with with_this.  All references


### PR DESCRIPTION
PR #409 has not been merged into the `godot_4` branch, so this PR applies the same changes to that branch. A few minor changes were made to the test code (in `test/unit/test_gut.gd`):

1. `assert_pass` no longer exists on `TestSimulate`, so I removed those assertions. If you'd prefer, I can update `TestSimulate` to manage assertion counts (like how `TestEverythingElse` does it) and then re-add the `assert_pass` calls.
2. I noticed that the local variable name `is_processing` in `test_simulate_calls_process_if_object_is_processing_and_check_is_true` shadows a built-in method, so I updated a number of local variable names in the tests to fix this issue while keeping naming consistent.
3. I now manually construct a few object arrays instead of using for loops (e.g. in `test_simulate_calls_process_on_descendents_if_objects_are_processing`), as they were kind of confusing when trying to understand the test.