### PR TITLE
Added assert_gte and assert_lte

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -368,12 +368,34 @@ func assert_gt(got, expected, text=""):
 			_fail(disp)
 
 # ------------------------------------------------------------------------------
+# Asserts got is greater than or equal to expected
+# ------------------------------------------------------------------------------
+func assert_gt(got, expected, text=""):
+	var disp = "[" + _str(got) + "] expected to be >= than [" + _str(expected) + "]:  " + text
+	if(_do_datatypes_match__fail_if_not(got, expected, text)):
+		if(got >= expected):
+			_pass(disp)
+		else:
+			_fail(disp)
+
+# ------------------------------------------------------------------------------
 # Asserts got is less than expected
 # ------------------------------------------------------------------------------
 func assert_lt(got, expected, text=""):
 	var disp = "[" + _str(got) + "] expected to be < than [" + _str(expected) + "]:  " + text
 	if(_do_datatypes_match__fail_if_not(got, expected, text)):
 		if(got < expected):
+			_pass(disp)
+		else:
+			_fail(disp)
+
+# ------------------------------------------------------------------------------
+# Asserts got is less than or equal to expected
+# ------------------------------------------------------------------------------
+func assert_lte(got, expected, text=""):
+	var disp = "[" + _str(got) + "] expected to be <= than [" + _str(expected) + "]:  " + text
+	if(_do_datatypes_match__fail_if_not(got, expected, text)):
+		if(got <= expected):
 			_pass(disp)
 		else:
 			_fail(disp)


### PR DESCRIPTION
I just started writing unit tests for my project with Gut and noticed that while there's `assert_lt` and `assert_gt` in `GutTest`, there's no `assert_lte` or `assert_gte`. These seemed very straightforward to add to the code, so I went ahead and added them. If these functions were somewhere else in the code and I just missed them, let me know and I can close this merge request.

I also saw there were some unit tests in the project, but I can't figure out how to run them, and I don't see a guide anywhere on how to do so. Any advice on how to run the unit tests would be appreciated!

I also saw that the functions are documented on the wiki, but I am unsure how to update that.

