### PR TITLE
Fix untyped declaration error in Godot 4.2

### DIFF
--- a/addons/gut/stubber.gd
+++ b/addons/gut/stubber.gd
@@ -26,7 +26,7 @@ func _init():
 # the source and grab the hash out of it and return it.  Super Rube Golbergery,
 # but tons of fun.
 func _make_crazy_dynamic_over_engineered_class_db_hash():
-	var text = "var all_the_classes = {\n"
+	var text = "var all_the_classes: Dictionary = {\n"
 	for classname in ClassDB.get_class_list():
 		if(ClassDB.can_instantiate(classname)):
 			text += str('"', classname, '": ', classname, ", \n")


### PR DESCRIPTION
If the user sets the `debug/gdscript/warnings/untyped_declaration` property in their project to `Error`, tests will fail to run even if `Exclude Addons` is checked. This is probably because this particular bit of code is created dynamically from a string, so the editor doesn't realize that it's actually from an addon.