### PR TITLE
assert_eq: show raw string comparison

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -281,6 +281,7 @@ func assert_eq(got, expected, text=""):
 
 	if(_do_datatypes_match__fail_if_not(got, expected, text)):
 		var disp = "[" + _str(got) + "] expected to equal [" + _str(expected) + "]:  " + text
+		disp += "\nEscaped string comparison: \n" + _str(got).c_escape() + "\n" + _str(expected).c_escape()
 		var result = null
 
 		result = _compare.simple(got, expected)


### PR DESCRIPTION
Hello! Here's a nugget that I added to my project that saved my bacon a few times :)

In `assert_eq`, when showing the difference on a failure, long, multiline strings are hard to compare by eye. This adds an escape to the display text and lines up the expected and got so you can more easily your whitespace differences.