### PR TITLE
Fix InputSender not emiting the `gui_input` signal

### DIFF
--- a/addons/gut/input_sender.gd
+++ b/addons/gut/input_sender.gd
@@ -280,13 +280,16 @@ func _send_event(event):
 			if(_auto_flush_input):
 				Input.flush_buffered_events()
 		else:
-			if(r.has_method("_input")):
+			if(r.has_method(&"_input")):
 				r._input(event)
 
-			if(r.has_method("_gui_input")):
+			if(r.has_signal(&"gui_input")):
+				r.gui_input.emit(event)
+
+			if(r.has_method(&"_gui_input")):
 				r._gui_input(event)
 
-			if(r.has_method("_unhandled_input")):
+			if(r.has_method(&"_unhandled_input")):
 				r._unhandled_input(event)
 
 

--- a/test/unit/test_input_sender.gd
+++ b/test/unit/test_input_sender.gd
@@ -6,11 +6,7 @@ class HasInputEvents:
 
 	var input_event = null
 	var gui_event = null
-	var gui_signal_event = null
 	var unhandled_event = null
-
-	func _init() -> void:
-		gui_input.connect(_on_gui_input_emitted)
 
 	func _input(event):
 		input_event = event
@@ -18,8 +14,6 @@ class HasInputEvents:
 		gui_event = event
 	func _unhandled_input(event):
 		unhandled_event = event
-	func _on_gui_input_emitted(event):
-		gui_signal_event = event
 
 
 class InputEventsOrder:
@@ -455,12 +449,13 @@ class TestSendEvent:
 		sender.send_event(event)
 		assert_eq(r.gui_event, event)
 	
-	func test_sends_event_to_gui_input_signal():
-		var r = autofree(HasInputEvents.new())
-		var sender = InputSender.new(r)
-		var event = InputEventKey.new()
-		sender.send_event(event)
-		assert_eq(r.gui_signal_event, event)
+	func test_send_event_causes_receiver_to_emit_gui_input_signal():  
+		var r = autofree(HasInputEvents.new())  
+		watch_signals(r)  
+		var sender = InputSender.new(r)  
+		var event = InputEventKey.new()  
+		sender.send_event(event)  
+		assert_signal_emitted_with_parameters(r, 'gui_input', [event])  
 
 	func test_sends_event_to_unhandled_input():
 		var r = autofree(HasInputEvents.new())


### PR DESCRIPTION
InputSender will now emit the `gui_input` signal. I have verified the natural order with a [minimal project](https://github.com/bitwes/Gut/files/13818986/InputOrderTest.zip), wich gave me this order:
```
_input function
gui_input signa
_gui_input function
_unhandled_input function
```

So i basically just inserted the artificial signal emission between `_input()` and `_gui_input()` artificial calls.

Bonus: I turned Strings into StringNames, because it's the desired parameter's type of `has_method()` and `has_signal()`.


