### PR TITLE
Add note about file name requirement.

### DIFF
--- a/documentation/docs/Quick-Start.md
+++ b/documentation/docs/Quick-Start.md
@@ -21,7 +21,8 @@ You can also run tests via the [command line](Command-Line) and through [VSCode]
 ## Creating Tests
 [More Information](Creating-Tests)
 
-All test scripts must extend `GutTest` (`res://addons/gut/test.gd`) script supplied by GUT.
+* All test scripts must extend `GutTest` (`res://addons/gut/test.gd`) script supplied by GUT.
+* All test files must begin with `test_` to be found by GUT.
 ```
 extends GutTest
 ```

--- a/documentation/docs/Quick-Start.md
+++ b/documentation/docs/Quick-Start.md
@@ -22,7 +22,7 @@ You can also run tests via the [command line](Command-Line) and through [VSCode]
 [More Information](Creating-Tests)
 
 * All test scripts must extend `GutTest` (`res://addons/gut/test.gd`) script supplied by GUT.
-* All test files must begin with `test_` to be found by GUT.
+* By default, all test files must begin with `test_` to be found by GUT. You can change the prefix and suffix of test files in the GUT settings.
 ```
 extends GutTest
 ```


### PR DESCRIPTION
Hi,

I did not see this requirement listed anywhere and it was the only way I could get GUT to find my tests I named my test file class_name_test.gd).

Is there another way?