### PR TITLE
i523 Add precision for float, vector2, vector3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # 9.1.2
 * Documentation and repo changes.
-* __Issue #536__ Theme refernces font instead of embedding it.
+* __Issue__ #536 Theme refernces font instead of embedding it.
+* __Issue__ #523 "got" values are printed with extra precision for float, Vector2, and Vector3 when using `assert_almost_eq`, `assert_almost_ne`, `assert_between` and `assert_not_between`.
 
 
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -88,6 +88,18 @@ func _init():
 func _str(thing):
 	return _strutils.type2str(thing)
 
+func _str_precision(value, precision):
+	var to_return = _str(value)
+	var format = str('%.', precision, 'f')
+	if(typeof(value) == TYPE_FLOAT):
+		to_return = format % value
+	elif(typeof(value) == TYPE_VECTOR2):
+		to_return = str('VECTOR2(', format % value.x, ', ', format %value.y, ')')
+	elif(typeof(value) == TYPE_VECTOR3):
+		to_return = str('VECTOR3(', format % value.x, ', ', format %value.y, ', ', format % value.z, ')')
+
+	return to_return
+
 # ------------------------------------------------------------------------------
 # Fail an assertion.  Causes test and script to fail as well.
 # ------------------------------------------------------------------------------
@@ -314,12 +326,11 @@ func assert_ne(got, not_expected, text=""):
 		else:
 			_pass(disp)
 
-
 # ------------------------------------------------------------------------------
 # Asserts that the expected value almost equals the value got.
 # ------------------------------------------------------------------------------
 func assert_almost_eq(got, expected, error_interval, text=''):
-	var disp = "[" + _str(got) + "] expected to equal [" + _str(expected) + "] +/- [" + str(error_interval) + "]:  " + text
+	var disp = "[" + _str_precision(got, 20) + "] expected to equal [" + _str(expected) + "] +/- [" + str(error_interval) + "]:  " + text
 	if(_do_datatypes_match__fail_if_not(got, expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)):
 		if not _is_almost_eq(got, expected, error_interval):
 			_fail(disp)
@@ -330,7 +341,7 @@ func assert_almost_eq(got, expected, error_interval, text=''):
 # Asserts that the expected value does not almost equal the value got.
 # ------------------------------------------------------------------------------
 func assert_almost_ne(got, not_expected, error_interval, text=''):
-	var disp = "[" + _str(got) + "] expected to not equal [" + _str(not_expected) + "] +/- [" + str(error_interval) + "]:  " + text
+	var disp = "[" + _str_precision(got, 20) + "] expected to not equal [" + _str(not_expected) + "] +/- [" + str(error_interval) + "]:  " + text
 	if(_do_datatypes_match__fail_if_not(got, not_expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)):
 		if _is_almost_eq(got, not_expected, error_interval):
 			_fail(disp)
@@ -338,22 +349,24 @@ func assert_almost_ne(got, not_expected, error_interval, text=''):
 			_pass(disp)
 
 # ------------------------------------------------------------------------------
-# Helper function which correctly compares two variables,
-# while properly handling vector2/3 types
+# Helper function compares a value against a expected and a +/- range.  Compares
+# all components of Vector2 and Vector3 as well.
 # ------------------------------------------------------------------------------
 func _is_almost_eq(got, expected, error_interval) -> bool:
 	var result = false
+	var upper = expected + error_interval
+	var lower = expected - error_interval
+
 	if typeof(got) == TYPE_VECTOR2:
-		if got.x >= (expected.x - error_interval.x) and got.x <= (expected.x + error_interval.x):
-			if got.y >= (expected.y - error_interval.y) and got.y <= (expected.y + error_interval.y):
-				result = true
+		result = got.x >= lower.x and got.x <= upper.x and \
+				got.y >= lower.y and got.y <= upper.y
 	elif typeof(got) == TYPE_VECTOR3:
-		if got.x >= (expected.x - error_interval.x) and got.x <= (expected.x + error_interval.x):
-			if got.y >= (expected.y - error_interval.y) and got.y <= (expected.y + error_interval.y):
-				if got.z >= (expected.z - error_interval.z) and got.z <= (expected.z + error_interval.z):
-					result = true
-	elif(got >= (expected - error_interval) and got <= (expected + error_interval)):
-		result = true
+		result = got.x >= lower.x and got.x <= upper.x and \
+				got.y >= lower.y and got.y <= upper.y and \
+				got.z >= lower.z and got.z <= upper.z
+	else:
+		result = got >= (lower) and got <= (upper)
+
 	return(result)
 
 # ------------------------------------------------------------------------------
@@ -408,7 +421,7 @@ func assert_false(got, text=""):
 # Asserts value is between (inclusive) the two expected values.
 # ------------------------------------------------------------------------------
 func assert_between(got, expect_low, expect_high, text=""):
-	var disp = "[" + _str(got) + "] expected to be between [" + _str(expect_low) + "] and [" + str(expect_high) + "]:  " + text
+	var disp = "[" + _str_precision(got, 20) + "] expected to be between [" + _str(expect_low) + "] and [" + str(expect_high) + "]:  " + text
 
 	if(_do_datatypes_match__fail_if_not(got, expect_low, text) and _do_datatypes_match__fail_if_not(got, expect_high, text)):
 		if(expect_low > expect_high):
@@ -424,7 +437,7 @@ func assert_between(got, expect_low, expect_high, text=""):
 # Asserts value is not between (exclusive) the two expected values.
 # ------------------------------------------------------------------------------
 func assert_not_between(got, expect_low, expect_high, text=""):
-	var disp = "[" + _str(got) + "] expected not to be between [" + _str(expect_low) + "] and [" + str(expect_high) + "]:  " + text
+	var disp = "[" + _str_precision(got, 20) + "] expected not to be between [" + _str(expect_low) + "] and [" + str(expect_high) + "]:  " + text
 
 	if(_do_datatypes_match__fail_if_not(got, expect_low, text) and _do_datatypes_match__fail_if_not(got, expect_high, text)):
 		if(expect_low > expect_high):

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -10,7 +10,7 @@ class BaseTestClass:
 	# !! Use this for debugging to see the results of all the subtests that
 	# are run using assert_fail_pass, assert_fail and assert_pass that are
 	# built into this class
-	var _print_all_subtests = false
+	var _print_all_subtests = true
 
 	# GlobalReset(gr) variables to be used by tests.
 	# The values of these are reset in the setup or
@@ -202,7 +202,6 @@ class TestAssertEq:
 		assert_pass(gr.test)
 
 	func test_comparing_callable_does_not_error():
-		_print_all_subtests = true
 		gr.test.assert_eq(test_comparing_callable_does_not_error, '1')
 		assert_fail(gr.test)
 		assert_fail_msg_contains(gr.test, 'Cannot compare CALLABLE')
@@ -331,6 +330,30 @@ class TestAssertAlmostEq:
 		gr.test.assert_almost_eq(Vector3(1.0, 2.0, 3.0), Vector3(1.0, 1.0, 1.0), Vector3(2.0, 2.0, 2.0), "Should pass, Vector3(1.0, 2.0, 3.0) == Vector3(1.0, 1.0, 1.0) +/- Vector3(2.0, 2.0, 2.0)")
 		assert_pass(gr.test)
 
+	func test_fail_message_includes_extra_precision_for_floats():
+		gr.test.assert_almost_eq(.500000000012300000, .499, .001)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
+
+	func test_fail_message_includes_extra_precision_for_vector2():
+		var got = Vector2(1.0001230, 1.003450)
+		var expected = Vector2(.999, .999)
+		var pad = Vector2(.001, .001)
+		gr.test.assert_almost_eq(got, expected, pad)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
+		assert_fail_msg_contains(gr.test, '03450')
+
+	func test_fail_message_includes_extra_precision_for_vector3():
+		var got = Vector3(1.0001230, 1.003450, 1.0032101)
+		var expected = Vector3(.999, .999, .999)
+		var pad = Vector3(.001, .001, .001)
+		gr.test.assert_almost_eq(got, expected, pad)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
+		assert_fail_msg_contains(gr.test, '03450')
+		assert_fail_msg_contains(gr.test, '03210')
+
 
 # ------------------------------------------------------------------------------
 class TestAssertAlmostNe:
@@ -399,6 +422,12 @@ class TestAssertAlmostNe:
 	func test_fails_with_vector3s_y_z_within_range():
 		gr.test.assert_almost_ne(Vector3(1.0, 2.0, 3.0), Vector3(1.0, 1.0, 1.0), Vector3(2.0, 2.0, 2.0), "Should fail, Vector3(1.0, 2.0, 3.0) == Vector3(1.0, 1.0, 1.0) +/- Vector3(2.0, 2.0, 2.0)")
 		assert_fail(gr.test)
+
+	func test_fail_message_includes_extra_precision_for_floats():
+		gr.test.assert_almost_ne(.500000000012300000, .5, .001)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
+
 
 
 # ------------------------------------------------------------------------------
@@ -496,6 +525,11 @@ class TestAssertBetween:
 		gr.test.assert_between('q', 'z', 'a', "Should fail")
 		assert_fail(gr.test)
 
+	func test_fail_message_includes_extra_precision_for_floats():
+		gr.test.assert_between(.50000000012300100, .498, .5)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
+
 
 # ------------------------------------------------------------------------------
 class TestAssertNotBetween:
@@ -544,6 +578,11 @@ class TestAssertNotBetween:
 	func test_with_invalid_string_range():
 		gr.test.assert_not_between('q', 'z', 'a', "Should fail: Invalid range")
 		assert_fail(gr.test)
+
+	func test_fail_message_includes_extra_precision_for_floats():
+		gr.test.assert_not_between(.50000000012300100, .498, .51)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, '01230')
 
 
 # ------------------------------------------------------------------------------

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -10,7 +10,7 @@ class BaseTestClass:
 	# !! Use this for debugging to see the results of all the subtests that
 	# are run using assert_fail_pass, assert_fail and assert_pass that are
 	# built into this class
-	var _print_all_subtests = true
+	var _print_all_subtests = false
 
 	# GlobalReset(gr) variables to be used by tests.
 	# The values of these are reset in the setup or


### PR DESCRIPTION
Extra precision added for float, vector2, vector3 in assert_almost_eq, assert_almost_ne, assert_between, assert_not_between.