### PR TITLE
fixed #450 and #547

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * __Issue__ #485 GUT prints a warning and ignores scripts that do not extend `GutTest`.
 * Documentation changes for readthedocs.
 * __Issue__ #436 Doubled Scenes now retain export variable values that were set in the editor.
+* __Issue__ #547 GutPanel now saves output_font_name and output_font_size correctly.
+* __Issue__ #450 yield timer is now stopped to avoid possible leaking of yield time between tests.
 
 
 # 7.4.1

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -369,9 +369,9 @@ func get_options(base_opts):
 	to_return.should_exit_on_success = _cfg_ctrls.should_exit_on_success.pressed
 
 	#Output
-	to_return.panel_options.font_name = _cfg_ctrls.output_font_name.get_item_text(
+	to_return.panel_options.output_font_name = _cfg_ctrls.output_font_name.get_item_text(
 		_cfg_ctrls.output_font_name.selected)
-	to_return.panel_options.font_size = _cfg_ctrls.output_font_size.value
+	to_return.panel_options.output_font_size = _cfg_ctrls.output_font_size.value
 
 	# Runner Appearance
 	to_return.font_name = _cfg_ctrls.font_name.get_item_text(

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -345,6 +345,8 @@ func _yielding_callback(
 		_yielding_to.obj = null
 		_yielding_to.signal_name = ''
 
+	_yield_timer.stop()
+
 	if(from_obj):
 		# we must yield for a little longer after the signal is emitted so that
 		# the signal can propagate to other objects.  This was discovered trying

--- a/test/unit/test_gut_yielding.gd
+++ b/test/unit/test_gut_yielding.gd
@@ -163,15 +163,15 @@ class TestYieldFor:
 		yield(yield_for(1, 'waiting around for stuff'), YIELD)
 
 	func test_passing_assert_ends_yield():
-		yield(yield_for(0.5), YIELD)
+		yield(yield_for(0.2), YIELD)
 		pass_test('yield should stop.')
 
 	func test_failing_assert_ends_yield():
-		yield(yield_for(0.5), YIELD)
-		fail_test('yield should stop for this failure')
+		yield(yield_for(0.2), YIELD)
+		fail_test('yield should stop for this failure SHOULD FAIL')
 
 	func test_pending_ends_yield():
-		yield(yield_for(0.5), YIELD)
+		yield(yield_for(0.2), YIELD)
 		pending('this is pending but should end test')
 
 	func test_output_for_long_yields():
@@ -241,6 +241,7 @@ class TestYieldTo:
 		signaler.emit_after(.5)
 		yield(yield_to(signaler, 'the_signal', 5), YIELD)
 		assert_signal_emitted(signaler, 'the_signal')
+
 
 
 class TestYieldFrames:


### PR DESCRIPTION
Yield timer is now stopped to be extra sure that yield time does not leak between tests.  `output_font_name` and `output_font_size` are now saved in the Gut Panel.  Yea, there's two bugs in this one PR.  I got lazy.  Settle down.