### PR TITLE
Disable a directory when running tests through editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 # 9.2.0
-* Documentation and repo changes.
+## Features
+* The Settings Subpanel now has on/off switches for directories, so you can turn them off if you want to run a subset of tests.
+
+## Bug Fixes
+* Documentation and branch changes.
 * __Issue__ #536 Theme refernces font instead of embedding it.
 * __Issue__ #523 "got" values are printed with extra precision for float, Vector2, and Vector3 when using `assert_almost_eq`, `assert_almost_ne`, `assert_between` and `assert_not_between`.
 * __Issue__ #436 Doubled Scenes now retain export variable values that were set in the editor.

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -245,7 +245,8 @@ func set_options(opts):
 		if(options.dirs.size() > i):
 			value = options.dirs[i]
 
-		_add_directory(str('directory_', i), value, str('Directory ', i))
+		var test_dir = _add_directory(str('directory_', i), value, str(i))
+		test_dir.enabled_button.visible = true
 
 
 	_add_title("XML Output")
@@ -311,7 +312,7 @@ func get_options(base_opts):
 	for i in range(DIRS_TO_LIST):
 		var key = str('directory_', i)
 		var val = _cfg_ctrls[key].value
-		if(val != '' and val != null):
+		if(_cfg_ctrls[key].enabled_button.button_pressed and val != '' and val != null):
 			dirs.append(val)
 	to_return.dirs = dirs
 

--- a/addons/gut/gui/gut_config_gui.gd
+++ b/addons/gut/gui/gut_config_gui.gd
@@ -240,13 +240,19 @@ func set_options(opts):
 	_titles.dirs = _add_title('Test Directories')
 	_add_boolean('include_subdirs', options.include_subdirs, 'Include Subdirs',
 		"Include subdirectories of the directories configured below.")
+
+	var dirs_to_load = options.configured_dirs
+	if(options.dirs.size() > dirs_to_load.size()):
+		dirs_to_load = options.dirs
+
 	for i in range(DIRS_TO_LIST):
 		var value = ''
-		if(options.dirs.size() > i):
-			value = options.dirs[i]
+		if(dirs_to_load.size() > i):
+			value = dirs_to_load[i]
 
 		var test_dir = _add_directory(str('directory_', i), value, str(i))
 		test_dir.enabled_button.visible = true
+		test_dir.enabled_button.button_pressed = options.dirs.has(value)
 
 
 	_add_title("XML Output")
@@ -309,12 +315,16 @@ func get_options(base_opts):
 	# Directories
 	to_return.include_subdirs = _cfg_ctrls.include_subdirs.value
 	var dirs = []
+	var configured_dirs = []
 	for i in range(DIRS_TO_LIST):
 		var key = str('directory_', i)
-		var val = _cfg_ctrls[key].value
-		if(_cfg_ctrls[key].enabled_button.button_pressed and val != '' and val != null):
-			dirs.append(val)
+		var ctrl = _cfg_ctrls[key]
+		if(ctrl.value != '' and ctrl.value != null):
+			configured_dirs.append(ctrl.value)
+			if(ctrl.enabled_button.button_pressed):
+				dirs.append(ctrl.value)
 	to_return.dirs = dirs
+	to_return.configured_dirs = configured_dirs
 
 	# XML Output
 	to_return.junit_xml_file = _cfg_ctrls.junit_xml_file.value

--- a/addons/gut/gui/panel_controls.gd
+++ b/addons/gut/gui/panel_controls.gd
@@ -192,10 +192,14 @@ class DirectoryControl:
 
 	var value_ctrl := LineEdit.new()
 	var dialog := FileDialog.new()
+	var enabled_button = CheckButton.new()
+
 	var _btn_dir := Button.new()
 
 	func _init(title, val, hint=""):
 		super._init(title, val, hint)
+
+		label.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 
 		_btn_dir.text = '...'
 		_btn_dir.pressed.connect(_on_dir_button_pressed)
@@ -203,15 +207,25 @@ class DirectoryControl:
 		value_ctrl.text = val
 		value_ctrl.size_flags_horizontal = value_ctrl.SIZE_EXPAND_FILL
 		value_ctrl.select_all_on_focus = true
+		value_ctrl.text_changed.connect(_on_value_changed)
 
 		dialog.file_mode = dialog.FILE_MODE_OPEN_DIR
 		dialog.unresizable = false
 		dialog.dir_selected.connect(_on_selected)
 		dialog.file_selected.connect(_on_selected)
 
+		enabled_button.button_pressed = true
+		enabled_button.visible = false
+
+		add_child(enabled_button)
 		add_child(value_ctrl)
 		add_child(_btn_dir)
 		add_child(dialog)
+
+	func _update_display():
+		var is_empty = value_ctrl.text == ''
+		enabled_button.button_pressed = !is_empty
+		enabled_button.disabled = is_empty
 
 
 	func _ready():
@@ -219,9 +233,14 @@ class DirectoryControl:
 			dialog.size = Vector2(1000, 700)
 		else:
 			dialog.size = Vector2(500, 350)
+		_update_display()
+
+	func _on_value_changed(new_text):
+		_update_display()
 
 	func _on_selected(path):
 		value_ctrl.text = path
+		_update_display()
 
 	func _on_dir_button_pressed():
 		dialog.current_dir = value_ctrl.text
@@ -289,7 +308,7 @@ class FileDialogSuperPlus:
 
 		_btn_res.text = 'res://'
 		_btn_user.text = 'user://'
-		_btn_os.text = 'OS'
+		_btn_os.text = '  OS  '
 
 		get_vbox().add_child(_dir_type_hbox)
 		get_vbox().move_child(_dir_type_hbox, 0)

--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -11,6 +11,9 @@ var valid_fonts = ['AnonymousPro', 'CourierPro', 'LobsterTwo', 'Default']
 var default_options = {
 	background_color = Color(.15, .15, .15, 1).to_html(),
 	config_file = 'res://.gutconfig.json',
+	# used by editor to handle enabled/disabled dirs.  All dirs configured go
+	# here and only the enabled dirs go into dirs
+	configured_dirs = [],
 	dirs = [],
 	disable_colors = false,
 	# double strategy can be the name of the enum value, the enum value or

--- a/scenes/TestPanelControls.gd
+++ b/scenes/TestPanelControls.gd
@@ -2,11 +2,24 @@ extends Node2D
 
 var PanelControls = load('res://addons/gut/gui/panel_controls.gd')
 
+@onready var _ctrls = {
+	pc_vbox = $PanelControls/VBox
+}
+
 var _save_load = PanelControls.SaveLoadControl.new('whatever', 1, 'hint')
+var _res_dir = PanelControls.DirectoryControl.new('some dir', 'res://', 'hint')
+var _res_dir_enabled = PanelControls.DirectoryControl.new('other dir', 'res://', 'hint')
+
+
 func _ready():
-	$PanelControls.add_child(_save_load)
+	#_save_load.dlg_load.show_diretory_types = false
+	#_save_load.dlg_load.show_user = false
+	#_save_load.dlg_save.show_os = false
 	
-	_save_load.dlg_load.show_diretory_types = false
-	_save_load.dlg_load.show_user = false
-	_save_load.dlg_save.show_os = false
+	_res_dir_enabled.enabled_button.visible = true
+	
+	_ctrls.pc_vbox.add_child(_save_load)
+	_ctrls.pc_vbox.add_child(_res_dir)
+	_ctrls.pc_vbox.add_child(_res_dir_enabled)
+
 	


### PR DESCRIPTION
Add a CheckButton to each directory in the Settings Subpanel.  When switched off, the directory will not be included when running tests.  This makes it easier to run a subset of tests through the editor.