### PR TITLE
implement GutUtils as Object fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     * Output Subanel related settings have moved to the Output Subpanel.  Use the "..." button.
 * __Issue__ #557 Tests are now found in exported projects.
 * Fixed issue where the panel was not loading the double strategy correctly.
+* __Issue__ #542 GUT no longer generates orphans...again.
 
 
 

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -239,23 +239,23 @@ func _run_gut():
 
 	# SHORTCIRCUIT
 	if(!all_options_valid or load_result == -1):
-		quit(1)
+		_end_run(1)
 	else:
 		opt_resolver.config_opts = _gut_config.options
 
 		if(o.get_value('-gh')):
 			print(_utils.get_version_text())
 			o.print_help()
-			quit()
+			_end_run(0)
 		elif(o.get_value('-gpo')):
 			print('All command line options and where they are specified.  ' +
 				'The "final" value shows which value will actually be used ' +
 				'based on order of precedence (default < .gutconfig < cmd line).' + "\n")
 			print(opt_resolver.to_s_verbose())
-			quit()
+			_end_run(0)
 		elif(o.get_value('-gprint_gutconfig_sample')):
 			_print_gutconfigs(opt_resolver.get_resolved_values())
-			quit()
+			_end_run(0)
 		else:
 			_final_opts = opt_resolver.get_resolved_values();
 			_gut_config.options = _final_opts
@@ -271,6 +271,12 @@ func _run_gut():
 
 			runner.run_tests()
 
+func _end_run(exit_code=-9999):
+	if(is_instance_valid(_utils)):
+		_utils.free()
+
+	if(exit_code != -9999):
+		quit(exit_code)
 
 # exit if option is set.
 func _on_tests_finished(should_exit, should_exit_on_success):
@@ -289,8 +295,9 @@ func _on_tests_finished(should_exit, should_exit_on_success):
 		exit_code = post_inst.get_exit_code()
 
 	if(should_exit or (should_exit_on_success and _tester.get_fail_count() == 0)):
-		quit(exit_code)
+		_end_run(exit_code)
 	else:
+		_end_run()
 		print("Tests finished, exit manually")
 
 
@@ -315,7 +322,7 @@ func _init():
 	if(!_utils.is_version_ok()):
 		print("\n\n", _utils.get_version_text())
 		push_error(_utils.get_bad_version_text())
-		quit(1)
+		_end_run(1)
 	else:
 		_run_gut()
 

--- a/addons/gut/method_maker.gd
+++ b/addons/gut/method_maker.gd
@@ -242,7 +242,6 @@ func get_function_text(meta, override_size=null):
 			text =  _get_init_text(meta, args, method_params, param_array)
 		else:
 			var decleration = str('func ', meta.name, '(', method_params, '):')
-			# decleration = str('# ', meta, "\n", decleration)
 			text = _func_text.format({
 				"func_decleration":decleration,
 				"method_name":meta.name,

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -1,5 +1,6 @@
 @tool
 class_name GutUtils
+extends Object
 # ------------------------------------------------------------------------------
 # Description
 # -----------
@@ -62,9 +63,6 @@ static func get_root_node():
 
 # ------------------------------------------------------------------------------
 # Get the ONE instance of utils
-# Since we can't have static variables we have to store the instance in the
-# tree.  This means you have to wait a bit for the main loop to be up and
-# running.
 # ------------------------------------------------------------------------------
 static func get_instance():
 	if(_the_instance == null):

--- a/test/unit/test_nothing.gd
+++ b/test/unit/test_nothing.gd
@@ -1,0 +1,43 @@
+extends GutTest
+# ------------------------------------------------------------------------------
+# This test script is used for spot checking orphans created by GUT.  If you
+# run GUT with just this script, and you get engine warnings about orphans or
+# resources still in use, then GUT has a problem.
+# ------------------------------------------------------------------------------
+func test_true():
+    assert_true(true)
+
+func test_false():
+    assert_false(false)
+
+func test_eq_n():
+    assert_eq(1, 1)
+
+func test_eq_s():
+    assert_eq('a', 'a')
+
+func test_with_double_of_script():
+    var d = double(load('res://test/resources/doubler_test_objects/double_me.gd')).new()
+    assert_not_null(d)
+
+func test_with_double_of_scene():
+    var d = double(load('res://test/resources/doubler_test_objects/double_me_scene.tscn')).instantiate()
+    assert_not_null(d)
+
+func test_with_script_partial_double_of_script():
+    var d = partial_double(load('res://test/resources/doubler_test_objects/double_me.gd')).new()
+    assert_not_null(d)
+
+func test_with_partial_double_of_scene():
+    var d = partial_double(load('res://test/resources/doubler_test_objects/double_me_scene.tscn')).instantiate()
+    assert_not_null(d)
+
+func test_with_spy_on_double_of_script():
+    var d = double(load('res://test/resources/doubler_test_objects/double_me.gd')).new()
+    d.get_value()
+    assert_called(d, 'get_value')
+
+func test_with_spy_on_partial_double_of_scene():
+    var d = partial_double(load('res://test/resources/doubler_test_objects/double_me_scene.tscn')).instantiate()
+    d.return_hello()
+    assert_called(d, 'return_hello')


### PR DESCRIPTION
Fixes #542.  `GutUtils` is now an `Object` and is freed at the end of the run.  Thanks to @ngburke  for the idea.