### PR TITLE
I570 doubling and static typed things

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -10,7 +10,7 @@
   "hide_orphans": true,
   "should_exit": true,
   "ignore_pause": true,
-  "log_level": 3,
+  "log_level": 0,
   "double_strategy": "script_only",
   "inner_class": "",
   "disable_colors": false,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# vNext
+* __Issue__ #570 Doubling scripts that contain a statically typed variable of another class_name script (`var foo := Foo.new()` where foo is a `class_name` in another script) could cause errors.
 
 # 9.2.0
 ## Configuration Changes

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -26,7 +26,6 @@ class PackedSceneDouble:
 
 			inst.set_script(_script)
 			for exported_value in export_props:
-				print('setting ', exported_value)
 				inst.set(exported_value[0], exported_value[1])
 
 		return inst

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -511,7 +511,7 @@ func pp(dict, indent=''):
 var _created_script_count = 0
 func create_script_from_source(source, override_path=null):
 	_created_script_count += 1
-	var r_path = ''#str('workaround for godot issue #65263 (', _created_script_count, ')')
+	var r_path = str('gut_dynamic_script_', _created_script_count)
 	if(override_path != null):
 		r_path = override_path
 

--- a/test/resources/implicit_initializer_class.gd
+++ b/test/resources/implicit_initializer_class.gd
@@ -1,0 +1,4 @@
+# Used to replicate issue #570.
+class_name ImplicitInitializerIssue
+
+var foo = 'bar'

--- a/test/resources/implicit_initializer_class.gd
+++ b/test/resources/implicit_initializer_class.gd
@@ -1,4 +1,5 @@
-# Used to replicate issue #570.
+# Used to replicate issue #570 which caused a Godot Engine error:
+#   ERROR: Parameter "p_script->implicit_initializer" is null.
 class_name ImplicitInitializerIssue
 
 var foo = 'bar'

--- a/test/resources/uses_implicit_initializer.gd
+++ b/test/resources/uses_implicit_initializer.gd
@@ -1,0 +1,3 @@
+extends Node
+
+var iii := ImplicitInitializerIssue.new()

--- a/test/unit/test_bugs/test_i570_implicit_initializer.gd
+++ b/test/unit/test_bugs/test_i570_implicit_initializer.gd
@@ -1,0 +1,46 @@
+extends GutTest
+
+# ImplicitInitializerIssue class defined in res://test/resources/implicit_initializer_class
+
+# This test works fine
+func test_double_foo():
+	var DoubleImplicitInitializer = double(ImplicitInitializerIssue)
+	var d = DoubleImplicitInitializer.new()
+	assert_not_null(d)
+	assert_is(d, DoubleImplicitInitializer)
+
+
+# This works, but will cause the next double of Foo to error
+func test_double_node_uses_foo():
+	var DoubleUses = double(load('res://test/resources/uses_implicit_initializer.gd'))
+	assert_not_null(DoubleUses, 'double class was created')
+
+	var inst = DoubleUses.new()
+	assert_not_null(inst, 'instance is not null')
+	assert_not_null(inst.iii, 'instance foo var was initialized')
+
+
+# This test fails because the p_script->implicit_initializer error cause the
+# object returned to not be a Foo.
+func test_double_foo_after_doubling_node_uses_foo():
+	var DoubleImplicitInitializer = double(ImplicitInitializerIssue)
+	var d = DoubleImplicitInitializer.new()
+	assert_not_null(d)
+	assert_is(d, DoubleImplicitInitializer,
+		'this failes because of the p_script->implicit_initializer error')
+
+
+
+# Future attempts to double Foo will result in DoubleFoo being null because GUT
+# thinks that Foo is an Inner Class of something.  So double(Foo) results in a
+# GUT error.  For reference, this is how GUT determines if a thing is an Inner
+# Class:
+# func is_inner_class(obj):
+#	return is_gdscript(obj) and obj.resource_path == ''
+func test_double_foo_after_doubling_node_uses_foo_again():
+	var DoubleImplicitInitializer = double(ImplicitInitializerIssue)
+	var d = DoubleImplicitInitializer.new()
+	assert_not_null(d)
+	assert_is(d, DoubleImplicitInitializer,
+		'this failes because of the p_script->implicit_initializer error')
+


### PR DESCRIPTION
All doubles now have the `resource_path` set to a unique value which appears to work around #570.