### PR TITLE
add debugger version of gut_cmdln

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # vNext
 * __Issue__ #570 Doubling scripts that contain a statically typed variable of another class_name script (`var foo := Foo.new()` where foo is a `class_name` in another script) could cause errors.
+* Add support for running tests through the debugger via VSCode via the gut-extension.
 
 # 9.2.0
 ## Configuration Changes

--- a/addons/gut/gut_cmdln.gd
+++ b/addons/gut/gut_cmdln.gd
@@ -269,7 +269,12 @@ func _run_gut():
 			_tester = runner.get_gut()
 			_tester.connect('end_run', Callable(self,'_on_tests_finished').bind(_final_opts.should_exit, _final_opts.should_exit_on_success))
 
-			runner.run_tests()
+			run_tests(runner)
+
+
+func run_tests(runner):
+	runner.run_tests()
+
 
 func _end_run(exit_code=-9999):
 	if(is_instance_valid(_utils)):

--- a/addons/gut/gut_vscode_debugger.gd
+++ b/addons/gut/gut_vscode_debugger.gd
@@ -1,0 +1,43 @@
+# ------------------------------------------------------------------------------
+# Entry point for using the debugger through VSCode.  The gut-extension for
+# VSCode launches this instead of gut_cmdln.gd when running tests through the
+# debugger.
+#
+# This could become more complex overtime, but right now all we have to do is
+# to make sure the console printer is enabled or you do not get any output.
+# ------------------------------------------------------------------------------
+extends 'res://addons/gut/gut_cmdln.gd'
+
+func run_tests(runner):
+	runner.get_gut().get_logger().disable_printer('console', false)
+	runner.run_tests()
+
+
+# ##############################################################################
+#(G)odot (U)nit (T)est class
+#
+# ##############################################################################
+# The MIT License (MIT)
+# =====================
+#
+# Copyright (c) 2023 Tom "Butch" Wesley
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ##############################################################################


### PR DESCRIPTION
Down an dirty way to enable the console printer when running debugger via vscode.