### PR TITLE
Wait until object is freed

### DIFF
--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -7,6 +7,8 @@ var _wait_time = 0.0
 var _wait_frames = 0
 var _signal_to_wait_on = null
 
+var _object_waiting_to_be_freed: Variant = null
+
 var _elapsed_time = 0.0
 var _elapsed_frames = 0
 
@@ -22,6 +24,10 @@ func _physics_process(delta):
 		if(_elapsed_frames >= _wait_frames):
 			_end_wait()
 
+	var is_waiting_for_object_to_be_freed := hash(_object_waiting_to_be_freed) != hash(null)
+	if is_waiting_for_object_to_be_freed:
+		if not is_instance_valid(_object_waiting_to_be_freed):
+			_end_wait()
 
 func _end_wait():
 	if(_signal_to_wait_on != null and _signal_to_wait_on.is_connected(_signal_callback)):
@@ -30,6 +36,7 @@ func _end_wait():
 	_wait_time = 0.0
 	_wait_frames = 0
 	_signal_to_wait_on = null
+	_object_waiting_to_be_freed = null
 	_elapsed_time = 0.0
 	_elapsed_frames = 0
 	timeout.emit()
@@ -64,7 +71,11 @@ func wait_for_signal(the_signal, x):
 	_wait_time = x
 	wait_started.emit()
 
+func wait_until_freed(object, x):
+	_object_waiting_to_be_freed = object
+	_wait_time = x
+	wait_started.emit()
 
 func is_waiting():
-	return _wait_time != 0.0 || _wait_frames != 0
+	return _wait_time != 0.0 || _wait_frames != 0 || _object_waiting_to_be_freed != null
 

--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -7,7 +7,7 @@ var _wait_time = 0.0
 var _wait_frames = 0
 var _signal_to_wait_on = null
 
-var _object_waiting_to_be_freed: Variant = null
+var _object_waiting_to_be_freed: Node = null
 
 var _elapsed_time = 0.0
 var _elapsed_frames = 0
@@ -71,9 +71,9 @@ func wait_for_signal(the_signal, x):
 	_wait_time = x
 	wait_started.emit()
 
-func wait_until_freed(object, x):
+func wait_until_freed(object: Node, max_wait: float):
 	_object_waiting_to_be_freed = object
-	_wait_time = x
+	_wait_time = max_wait
 	wait_started.emit()
 
 func is_waiting():

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -1135,6 +1135,14 @@ func set_wait_frames(frames, text=''):
 	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', text))
 	return _awaiter.timeout
 
+# ------------------------------------------------------------------------------
+# Uses the awaiter to wait until the object has been freed or a maximum amount
+# of time. The signal emitted is returned.
+# ------------------------------------------------------------------------------
+func set_object_to_wait_until_freed(object, max_wait, text=''):
+	_awaiter.wait_until_freed(object, max_wait)
+	_lgr.yield_msg(str('-- Awaiting for object "', object.get_name(), '" to be freed or for ', max_wait, ' second(s) -- ', text))
+	return _awaiter.timeout
 
 # ------------------------------------------------------------------------------
 # Wait for a signal or a maximum amount of time.  The signal emitted is returned.

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -1139,7 +1139,7 @@ func set_wait_frames(frames, text=''):
 # Uses the awaiter to wait until the object has been freed or a maximum amount
 # of time. The signal emitted is returned.
 # ------------------------------------------------------------------------------
-func set_object_to_wait_until_freed(object, max_wait, text=''):
+func set_object_to_wait_until_freed(object: Node, max_wait: float, text: String = ''):
 	_awaiter.wait_until_freed(object, max_wait)
 	_lgr.yield_msg(str('-- Awaiting for object "', object.get_name(), '" to be freed or for ', max_wait, ' second(s) -- ', text))
 	return _awaiter.timeout

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1205,8 +1205,8 @@ func yield_frames(frames, msg=''):
 # -------------------------------------------------------------------------------------
 # Yield until the object is freed or a maximum amount of time, whichever comes first.
 # -------------------------------------------------------------------------------------
-func wait_until_freed(object, max_wait, msg=''):
-	var to_return = gut.set_object_to_wait_until_freed(object, max_wait, msg)
+func wait_until_freed(object: Node, max_wait_s: float, msg: String =''):
+	var to_return = gut.set_object_to_wait_until_freed(object, max_wait_s, msg)
 	return to_return
 
 func get_summary():

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1202,6 +1202,13 @@ func yield_frames(frames, msg=''):
 	var to_return = wait_frames(frames, msg)
 	return to_return
 
+# -------------------------------------------------------------------------------------
+# Yield until the object is freed or a maximum amount of time, whichever comes first.
+# -------------------------------------------------------------------------------------
+func wait_until_freed(object, max_wait, msg=''):
+	var to_return = gut.set_object_to_wait_until_freed(object, max_wait, msg)
+	return to_return
+
 func get_summary():
 	return _summary
 

--- a/documentation/docs/Asserts-and-Methods.md
+++ b/documentation/docs/Asserts-and-Methods.md
@@ -1265,6 +1265,10 @@ See [Awaiting](Awaiting)
 `wait_for_signal(sig, max_wait, msg='')`<br>
 See [Awaiting](Awaiting)
 
+### wait_until_freed
+`wait_until_freed(object, max_wait, msg='')`<br>
+See [Awaiting](Awaiting)
+
 ### double
 `double(path_or_class, inner_class_path=null)`<br>
 This will return a double of a class.  See [Doubles](Doubles) for more information.

--- a/documentation/docs/Awaiting.md
+++ b/documentation/docs/Awaiting.md
@@ -4,7 +4,8 @@ If you aren't sure about coroutines and using `await`, [Godot explains it pretty
 If you want to pause test execution for some amount of time/frames or until a signal is emitted use `await` and one of GUT's "wait" methods:
 * `wait_for_signal`
 * `wait_seconds`
-* `wait_frames`.
+* `wait_frames`
+* `wait_until_freed`
 
 Calling `await` without using one of GUT's "wait" methods is discouraged.  When you use these methods, GUT provides output to indicate that execution is paused.  If you don't use them it can look like your tests have stopped running.
 
@@ -59,6 +60,21 @@ func test_wait_for_some_frames():
 	gut.assert_eq(my_object.some_property, 'some value')
 ```
 
+## wait_until_freed
+```
+wait_until_freed(object, max_wait, msg=''):
+```
+
+This method will pause execution until `object` has been freed or until `max_wait` seconds have passed, whichever comes first.
+
+The optional `msg` parameter is logged so you know why test execution is paused.
+``` gdscript
+my_object.do_something()
+# wait for my_object to be freed
+# or 5 seconds, whichever comes first.
+await wait_until_freed(my_object.my_signal, 5)
+assert_freed(my_object, 'Maybe it did, maybe it didnt, but we still got here.')
+```
 
 ## pause_before_teardown
 Sometimes, as you are developing your tests you may want to verify something before the any of the teardown methods are called or just look at things a bit.  If you call `pause_before_teardown()` anywhere in your test then GUT will pause execution until you press the "Continue" button in the GUT GUI.  You can also specify an option to ignore all calls to `pause_before_teardown` through the GUT Panel, command line, or `.gutconfig` in case you get lazy and don't want to remove them.  You should always remove them, but I know you won't because I didn't, so I made that an option.

--- a/test/unit/test_awaiter.gd
+++ b/test/unit/test_awaiter.gd
@@ -67,14 +67,12 @@ func test_is_waiting_while_waiting_on_frames():
 	await get_tree().create_timer(.1).timeout
 	assert_true(a.is_waiting())
 
-
 func test_wait_started_emitted_when_waiting_on_signal():
 	var s = Signaler.new()
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 	a.wait_for_signal(s.the_signal, 10)
 	assert_signal_emitted(a, 'wait_started')
-
 
 func test_can_wait_for_signal():
 	var s = Signaler.new()
@@ -97,7 +95,6 @@ func test_can_wait_for_signal_with_parameters():
 	# gotta wait for the 2 additional frames
 	await get_tree().create_timer(.05).timeout
 	assert_signal_emitted(a, 'timeout')
-
 
 func test_after_wait_for_signal_signal_is_disconnected():
 	var s = Signaler.new()
@@ -143,3 +140,57 @@ func test_after_timeout_signal_is_disconnected():
 	a.wait_for_signal(s.the_signal, .1)
 	await get_tree().create_timer(.5).timeout
 	assert_not_connected(s, a, 'the_signal')
+
+func test_wait_started_emitted_when_wait_until_freed():
+	var node := Node.new()
+	var a = add_child_autoqfree(Awaiter.new())
+	watch_signals(a)
+
+	a.wait_until_freed(node, 10)
+
+	assert_signal_emitted(a, 'wait_started')
+
+func test_can_wait_until_freed():
+	var node := Node.new()
+	var a = add_child_autoqfree(Awaiter.new())
+	watch_signals(a)
+
+	a.wait_until_freed(node, 10)
+	await get_tree().create_timer(.5).timeout
+	node.queue_free()
+
+	await get_tree().create_timer(.05).timeout
+	assert_signal_emitted(a, 'timeout')
+
+func test_when_object_not_freed_then_max_time_is_waited():
+	var node := Node.new()
+	var a = add_child_autoqfree(Awaiter.new())
+	watch_signals(a)
+
+	a.wait_until_freed(node, .5)
+	await get_tree().create_timer(.8).timeout
+
+	assert_signal_emitted(a, 'timeout')
+
+func test_is_waiting_when_waiting_on_object_to_be_freed():
+	var node := Node.new()
+	var a = add_child_autoqfree(Awaiter.new())
+	watch_signals(a)
+
+	a.wait_until_freed(node, .5)
+	await get_tree().create_timer(.1).timeout
+
+	assert_true(a.is_waiting())
+
+func test_is_not_paused_when_object_freed_before_max_time():
+	var node := Node.new()
+	var a = add_child_autoqfree(Awaiter.new())
+	watch_signals(a)
+
+	a.wait_until_freed(node, 10)
+	await get_tree().create_timer(.5).timeout
+	node.queue_free()
+
+	# gotta wait for the 2 additional frames
+	await get_tree().create_timer(.05).timeout
+	assert_false(a.is_waiting())

--- a/test/unit/test_awaiter.gd
+++ b/test/unit/test_awaiter.gd
@@ -142,7 +142,7 @@ func test_after_timeout_signal_is_disconnected():
 	assert_not_connected(s, a, 'the_signal')
 
 func test_wait_started_emitted_when_wait_until_freed():
-	var node := Node.new()
+	var node = add_child_autoqfree(Node.new())
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 
@@ -151,7 +151,7 @@ func test_wait_started_emitted_when_wait_until_freed():
 	assert_signal_emitted(a, 'wait_started')
 
 func test_can_wait_until_freed():
-	var node := Node.new()
+	var node = add_child_autoqfree(Node.new())
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 
@@ -163,7 +163,7 @@ func test_can_wait_until_freed():
 	assert_signal_emitted(a, 'timeout')
 
 func test_when_object_not_freed_then_max_time_is_waited():
-	var node := Node.new()
+	var node = add_child_autoqfree(Node.new())
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 
@@ -173,7 +173,7 @@ func test_when_object_not_freed_then_max_time_is_waited():
 	assert_signal_emitted(a, 'timeout')
 
 func test_is_waiting_when_waiting_on_object_to_be_freed():
-	var node := Node.new()
+	var node = add_child_autoqfree(Node.new())
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 
@@ -183,7 +183,7 @@ func test_is_waiting_when_waiting_on_object_to_be_freed():
 	assert_true(a.is_waiting())
 
 func test_is_not_paused_when_object_freed_before_max_time():
-	var node := Node.new()
+	var node = add_child_autoqfree(Node.new())
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -87,7 +87,15 @@ class TestTheNewWaitMethods:
 		await wait_for_signal(signaler.the_signal, 1)
 		assert_between(counter.time, .9, 1.1)
 
+	func test_wait_until_freed_waits_until_object_is_freed():
+		var signaler = add_child_autoqfree(TimedSignaler.new())
+		signaler.the_signal.connect(signaler.queue_free)
+		signaler.emit_after(.1)
 
+		await wait_until_freed(signaler, 1)
+
+		assert_between(counter.time, 0, .2)
+		assert_freed(signaler)
 
 # ------------------------------------
 # Could not get these to trigger the error I was trying to replicate.  This was


### PR DESCRIPTION
I think it could be useful. For example, in my game I want to test that when I hit an enemy, then it dies and is freed. But I found it awkward to await on signals on this soon-to-be null object

# Before

```
enemy.set_name('node_name')
enemy.set_linear_velocity(Vector2.LEFT * 1000)

# Have to wait, but it's hard to guess for how long and slows test runs
wait_seconds(10)
# Or create a custom signal just for the test. It works but gives this awkward error message ==> ERROR: Parameter "obj" is null.
await wait_for_signal(enemy.damaged, 10)

assert_freed(enemy, 'node_name')
```

# After

```
enemy.set_name('node_name')
enemy.set_linear_velocity(Vector2.LEFT * 1000)

await wait_until_freed(enemy, 10)

assert_freed(enemy, 'node_name')
```