### PR TITLE
Output Time in exported results. Clean res:// from path. 

### DIFF
--- a/addons/gut/collected_test.gd
+++ b/addons/gut/collected_test.gd
@@ -10,18 +10,21 @@ var has_printed_name = false
 # the number of arguments the method has
 var arg_count = 0
 
+# the time it took to execute the test
+var time_taken : float = 0
+
 # The number of asserts in the test.  Converted to a property for backwards
 # compatibility.  This now reflects the text sizes instead of being a value
 # that can be altered externally.
 var assert_count = 0 :
-    get: return pass_texts.size() + fail_texts.size()
-    set(val): pass
+	get: return pass_texts.size() + fail_texts.size()
+	set(val): pass
 
 # Converted to propety for backwards compatibility.  This now cannot be set
 # externally
 var pending = false :
-    get: return is_pending()
-    set(val): pass
+	get: return is_pending()
+	set(val): pass
 
 # the line number when the test fails
 var line_number = -1
@@ -39,77 +42,77 @@ var was_run = false
 
 
 func did_pass():
-    return is_passing()
+	return is_passing()
 
 
 func add_fail(fail_text):
-    fail_texts.append(fail_text)
+	fail_texts.append(fail_text)
 
 
 func add_pending(pending_text):
-    pending_texts.append(pending_text)
+	pending_texts.append(pending_text)
 
 
 func add_pass(passing_text):
-    pass_texts.append(passing_text)
+	pass_texts.append(passing_text)
 
 
 # must have passed an assert and not have any other status to be passing
 func is_passing():
-    return pass_texts.size() > 0 and fail_texts.size() == 0 and pending_texts.size() == 0
+	return pass_texts.size() > 0 and fail_texts.size() == 0 and pending_texts.size() == 0
 
 
 # failing takes precedence over everything else, so any failures makes the
 # test a failure.
 func is_failing():
-    return fail_texts.size() > 0
+	return fail_texts.size() > 0
 
 
 # test is only pending if pending was called and the test is not failing.
 func is_pending():
-    return pending_texts.size() > 0 and fail_texts.size() == 0
+	return pending_texts.size() > 0 and fail_texts.size() == 0
 
 
 func is_risky():
-    return should_skip or (was_run and !did_something())
+	return should_skip or (was_run and !did_something())
 
 
 func did_something():
-    return is_passing() or is_failing() or is_pending()
+	return is_passing() or is_failing() or is_pending()
 
 
 func get_status_text():
-    var to_return = GutUtils.TEST_STATUSES.NO_ASSERTS
+	var to_return = GutUtils.TEST_STATUSES.NO_ASSERTS
 
-    if(should_skip):
-        to_return = GutUtils.TEST_STATUSES.SKIPPED
-    elif(!was_run):
-        to_return = GutUtils.TEST_STATUSES.NOT_RUN
-    elif(pending_texts.size() > 0):
-        to_return = GutUtils.TEST_STATUSES.PENDING
-    elif(fail_texts.size() > 0):
-        to_return = GutUtils.TEST_STATUSES.FAILED
-    elif(pass_texts.size() > 0):
-        to_return = GutUtils.TEST_STATUSES.PASSED
+	if(should_skip):
+		to_return = GutUtils.TEST_STATUSES.SKIPPED
+	elif(!was_run):
+		to_return = GutUtils.TEST_STATUSES.NOT_RUN
+	elif(pending_texts.size() > 0):
+		to_return = GutUtils.TEST_STATUSES.PENDING
+	elif(fail_texts.size() > 0):
+		to_return = GutUtils.TEST_STATUSES.FAILED
+	elif(pass_texts.size() > 0):
+		to_return = GutUtils.TEST_STATUSES.PASSED
 
-    return to_return
+	return to_return
 
 
 # Deprecated
 func get_status():
-    return get_status_text()
+	return get_status_text()
 
 
 func to_s():
-    var pad = '     '
-    var to_return = str(name, "[", get_status_text(), "]\n")
+	var pad = '     '
+	var to_return = str(name, "[", get_status_text(), "]\n")
 
-    for i in range(fail_texts.size()):
-        to_return += str(pad, 'Fail:  ', fail_texts[i])
-    for i in range(pending_texts.size()):
-        to_return += str(pad, 'Pending:  ', pending_texts[i], "\n")
-    for i in range(pass_texts.size()):
-        to_return += str(pad, 'Pass:  ', pass_texts[i], "\n")
-    return to_return
+	for i in range(fail_texts.size()):
+		to_return += str(pad, 'Fail:  ', fail_texts[i])
+	for i in range(pending_texts.size()):
+		to_return += str(pad, 'Pending:  ', pending_texts[i], "\n")
+	for i in range(pass_texts.size()):
+		to_return += str(pad, 'Pass:  ', pass_texts[i], "\n")
+	return to_return
 
 

--- a/addons/gut/collected_test.gd
+++ b/addons/gut/collected_test.gd
@@ -10,7 +10,7 @@ var has_printed_name = false
 # the number of arguments the method has
 var arg_count = 0
 
-# the time it took to execute the test
+# the time it took to execute the test in seconds
 var time_taken : float = 0
 
 # The number of asserts in the test.  Converted to a property for backwards

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -764,7 +764,7 @@ func _test_the_scripts(indexes=[]):
 				_current_test.has_printed_name = false
 				
 				var us_elapsed = Time.get_ticks_usec() - ticks_before
-				_current_test.time_taken = us_elapsed / 1000.0
+				_current_test.time_taken = us_elapsed / 1000000.0
 				
 				end_test.emit()
 

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -746,6 +746,8 @@ func _test_the_scripts(indexes=[]):
 			if((_unit_test_name != '' and _current_test.name.find(_unit_test_name) > -1) or
 				(_unit_test_name == '')):
 
+				var ticks_before := Time.get_ticks_usec()
+				
 				if(_current_test.arg_count > 1):
 					_lgr.error(str('Parameterized test ', _current_test.name,
 						' has too many parameters:  ', _current_test.arg_count, '.'))
@@ -760,6 +762,10 @@ func _test_the_scripts(indexes=[]):
 					_lgr.risky(str(_current_test.name, ' did not assert'))
 
 				_current_test.has_printed_name = false
+				
+				var us_elapsed = Time.get_ticks_usec() - ticks_before
+				_current_test.time_taken = us_elapsed / 1000.0
+				
 				end_test.emit()
 
 				# After each test, check to see if we shoudl wait a frame to

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -747,7 +747,7 @@ func _test_the_scripts(indexes=[]):
 				(_unit_test_name == '')):
 
 				var ticks_before := Time.get_ticks_usec()
-				
+
 				if(_current_test.arg_count > 1):
 					_lgr.error(str('Parameterized test ', _current_test.name,
 						' has too many parameters:  ', _current_test.arg_count, '.'))
@@ -762,10 +762,9 @@ func _test_the_scripts(indexes=[]):
 					_lgr.risky(str(_current_test.name, ' did not assert'))
 
 				_current_test.has_printed_name = false
-				
-				var us_elapsed = Time.get_ticks_usec() - ticks_before
-				_current_test.time_taken = us_elapsed / 1000000.0
-				
+
+				_current_test.time_taken = (Time.get_ticks_usec() - ticks_before) / 1000000.0
+
 				end_test.emit()
 
 				# After each test, check to see if we shoudl wait a frame to

--- a/addons/gut/junit_xml_export.gd
+++ b/addons/gut/junit_xml_export.gd
@@ -40,6 +40,7 @@ func _export_tests(script_result, classname):
 		to_return += add_attr("assertions", assert_count)
 		to_return += add_attr("status", test.status)
 		to_return += add_attr("classname", classname)
+		to_return += add_attr("time", test.time_taken)
 		to_return += ">\n"
 
 		to_return += _export_test_result(test)

--- a/addons/gut/junit_xml_export.gd
+++ b/addons/gut/junit_xml_export.gd
@@ -39,7 +39,7 @@ func _export_tests(script_result, classname):
 		to_return += add_attr("name", key)
 		to_return += add_attr("assertions", assert_count)
 		to_return += add_attr("status", test.status)
-		to_return += add_attr("classname", classname)
+		to_return += add_attr("classname", classname.replace("res://", ""))
 		to_return += add_attr("time", test.time_taken)
 		to_return += ">\n"
 
@@ -63,7 +63,7 @@ func _export_scripts(exp_results):
 	for key in exp_results.test_scripts.scripts.keys():
 		var s = exp_results.test_scripts.scripts[key]
 		to_return += "<testsuite "
-		to_return += add_attr("name", key)
+		to_return += add_attr("name", key.replace("res://", ""))
 		to_return += add_attr("tests", s.props.tests)
 		to_return += add_attr("failures", s.props.failures)
 		to_return += add_attr("skipped", s.props.pending)

--- a/addons/gut/result_exporter.gd
+++ b/addons/gut/result_exporter.gd
@@ -17,7 +17,8 @@ func _export_tests(collected_script):
 				"passing":test.pass_texts,
 				"failing":test.fail_texts,
 				"pending":test.pending_texts,
-				"orphans":test.orphans
+				"orphans":test.orphans,
+				"time_taken": test.time_taken 
 			}
 
 	return to_return

--- a/test/resources/exporter_test_files/test_time_taken.gd
+++ b/test/resources/exporter_test_files/test_time_taken.gd
@@ -1,0 +1,23 @@
+extends 'res://addons/gut/test.gd'
+
+func more_accurate_wait_time(time_to_wait_msec : int)->void:
+	gut._lgr.yield_msg(str('-- Awaiting ', time_to_wait_msec / 1000.0, ' second(s) -- '))
+	var start := Time.get_ticks_msec()
+	while (Time.get_ticks_msec() - start < time_to_wait_msec):
+		await get_tree().process_frame
+
+func test_pass_time_taken_about_half_s():
+	await more_accurate_wait_time(500)
+	assert_eq('one', 'one')
+
+func test_fail_time_taken_about_half_s():
+	await more_accurate_wait_time(500)
+	assert_eq(1, 'two')
+
+func test_pending_time_taken_about_half_s():
+	await more_accurate_wait_time(500)
+	pending('this has text')
+
+func test_pass_time_taken_about_2s():
+	await more_accurate_wait_time(2000)
+	assert_eq('one', 'one')

--- a/test/unit/test_junit_xml_export.gd
+++ b/test/unit/test_junit_xml_export.gd
@@ -53,7 +53,7 @@ func assert_is_valid_xml(xml : String)->void:
 				# check for required attributes
 				var required_attributes : Array = RESULT_XML_VALID_TAGS[tag_name].duplicate()
 				var missing_attributes := required_attributes.filter(func(attribute): return !parser.has_attribute(attribute))
-				assert_eq(missing_attributes, [], "Required attribute(s) missing.")
+				assert_eq(missing_attributes, [], str(tag_name, ":  Required attribute(s) missing ", missing_attributes))
 				
 				# check for unexpected attributes
 				var unexpected_attributes : Array[String] = []
@@ -61,7 +61,7 @@ func assert_is_valid_xml(xml : String)->void:
 					var attribute_name := parser.get_attribute_name(attribute_index)
 					if not attribute_name in RESULT_XML_VALID_TAGS[tag_name]:
 						unexpected_attributes.push_back(attribute_name)
-				assert_eq(unexpected_attributes, [], "Unexpected attribute(s).")
+				assert_eq(unexpected_attributes, [], str(tag_name, " Unexpected attribute(s) ", unexpected_attributes))
 			else:
 				fail_test("%s is not one of the expected tags: %s" % [tag_name, RESULT_XML_VALID_TAGS.keys()])
 				

--- a/test/unit/test_result_exporter.gd
+++ b/test/unit/test_result_exporter.gd
@@ -198,6 +198,33 @@ func test_test_has_text_fields():
 	assert_has(result, 'failing')
 	assert_has(result, 'pending')
 
+func test_test_has_time_field():
+	run_scripts(_test_gut, 'test_simple_2.gd')
+	var re = ResultExporter.new()
+	var result = re.get_results_dictionary(_test_gut)
+	result = result.test_scripts.scripts[export_script('test_simple_2.gd')]
+	result = result.tests
+	assert_has(result.test_pass, 'time_taken')
+	assert_has(result.test_fail, 'time_taken')
+	assert_has(result.test_pending, 'time_taken')
+
+func test_test_time_taken_in_range():
+	run_scripts(_test_gut, 'test_time_taken.gd')
+	await wait_for_signal(_test_gut.end_run, 10)
+	var re = ResultExporter.new()
+	var result = re.get_results_dictionary(_test_gut)
+	result = result.test_scripts.scripts[export_script('test_time_taken.gd')]
+	assert_has(result, 'tests')
+	result = result.tests
+	assert_has(result, 'test_pass_time_taken_about_half_s')
+	assert_has(result, 'test_fail_time_taken_about_half_s')
+	assert_has(result, 'test_pending_time_taken_about_half_s')
+	assert_has(result, 'test_pass_time_taken_about_2s')
+	const TIME_ERROR_INTERVAL := 0.01
+	assert_almost_eq(result.test_pass_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)
+	assert_almost_eq(result.test_fail_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)
+	assert_almost_eq(result.test_pending_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)
+	assert_almost_eq(result.test_pass_time_taken_about_2s.time_taken, 2.0, TIME_ERROR_INTERVAL)
 
 func test_write_file_creates_file():
 	run_scripts(_test_gut, 'test_simple_2.gd')

--- a/test/unit/test_result_exporter.gd
+++ b/test/unit/test_result_exporter.gd
@@ -216,11 +216,7 @@ func test_test_time_taken_in_range():
 	result = result.test_scripts.scripts[export_script('test_time_taken.gd')]
 	assert_has(result, 'tests')
 	result = result.tests
-	assert_has(result, 'test_pass_time_taken_about_half_s')
-	assert_has(result, 'test_fail_time_taken_about_half_s')
-	assert_has(result, 'test_pending_time_taken_about_half_s')
-	assert_has(result, 'test_pass_time_taken_about_2s')
-	const TIME_ERROR_INTERVAL := 0.01
+	const TIME_ERROR_INTERVAL := 0.1
 	assert_almost_eq(result.test_pass_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)
 	assert_almost_eq(result.test_fail_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)
 	assert_almost_eq(result.test_pending_time_taken_about_half_s.time_taken, 0.5, TIME_ERROR_INTERVAL)


### PR DESCRIPTION
I made the changes in a fork to better work with this GitHub test reporter: https://github.com/dorny/test-reporter

* Removed "res://" from reported file paths. This enables you to click on a report in the above tool and take you to the change in Github that caused the failure.
* Reporting Time taken for each test. This fills in the time column in the above tool instead of reporting "null".
* There was a formatting change in collected_test.gd where it was using spaces instead of tabs.  

Output from the test-reporter tool with the changes:

![image](https://github.com/bitwes/Gut/assets/16663122/eced5f1a-926c-411c-9e9c-c88693c1a137)


I'm more than happy to split into different PRs or remove bits that aren't interesting to keep (and of course understand if it's not something wanted at all 😄).

