### PR TITLE
Improve static typing support

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -1,4 +1,5 @@
 extends 'res://addons/gut/gut_to_move.gd'
+class_name GutMain
 
 # ##############################################################################
 #
@@ -916,7 +917,7 @@ func _get_files(path, prefix, suffix):
 # public
 #
 #########################
-func get_elapsed_time():
+func get_elapsed_time() -> float:
 	var to_return = 0.0
 	if(_start_time != 0.0):
 		to_return = Time.get_ticks_msec() - _start_time

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -46,7 +46,7 @@ var _compare = _utils.Comparator.new()
 # Need a reference to the instance that is running the tests.  This
 # is set by the gut class when it runs the tests.  This gets you
 # access to the asserts in the tests you write.
-var gut = null
+var gut: GutMain = null
 
 var _disable_strict_datatype_checks = false
 # Holds all the text for a test's fail/pass.  This is used for testing purposes


### PR DESCRIPTION
I enabled various warnings in `debug/gdscript` related to enforcing static typing, e.g. `unsafe_property_access` or `unsafe_method_access`.
I also treat some of them as errors.

I've just wrote a unit test and immediately ran into errors because Gut doesn't seem to make much use of static typing.
This patch gives the `gut` object a `class_name` and adds an explicit return type to the `get_elapsed_time` function.

I'm not sure if `GutContext` is a sensible name for this class, I'm open for suggestions.

This patch just contains fixes for the parts that immediately caused errors in my workflow.
There might be more PRs to come in the future if I run into trouble again :)