### PR TITLE
Automatically enable `exclude_addons` option when running tests

### DIFF
--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -56,6 +56,17 @@ var options = default_options.duplicate()
 var json = JSON.new()
 
 
+func _init() -> void:
+	# Ensure the exclude_addons option in the project settings is enabled when running GUT.
+	# This is important, because GUT will throw errors if this option is disabled, e.g. due to
+	# overriding native methods.
+	# When working on addons it is usually desired to disable exclude_addons in order to get proper
+	# code diagnostics.
+	# This however makes it tedious to run GUT because the option has to be manually disabled before
+	# running tests.
+	if not Engine.is_editor_hint():
+		ProjectSettings.set("debug/gdscript/warnings/exclude_addons", true)
+
 func _null_copy(h):
 	var new_hash = {}
 	for key in h:


### PR DESCRIPTION
GUT will throw errors if `exclude_addons` option is disabled, e.g. due to overriding native methods.
When working on addons it is usually desired to disable `exclude_addons` in order to get proper code diagnostics.
This however makes it tedious to run GUT because the option has to be manually disabled before running tests and manually enabled again afterwards to get diagnostics.
To workaround this issue, this commit automatically enables the `exclude_addons` option when running tests, so regardless of the project settings in the editor, GUT will always run as intended.