### PR TITLE
I598 skipping scripts

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -10,7 +10,7 @@
   "hide_orphans": true,
   "should_exit": true,
   "ignore_pause": true,
-  "log_level": 0,
+  "log_level": 3,
   "double_strategy": "script_only",
   "inner_class": "",
   "disable_colors": false,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,35 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# Next Version
+# 9.2.2
 
 ## Features
 * @mphe GUT now automatically enables the "Exclude Addons" option when running tests.  This means you don't have to keep enabling/disabling this option if GUT does not conform to your warning/error settings.
 * @plink-plonk-will Elapsed time is now included in the XML export.
 * __Issue__ #612 `InputSender` now sets the `button_mask` property for generated mouse motion events when mouse buttons have been pressed but not released prior to a motion event.
+* __Issue__ #598 Added the virtual method `should_skip_script` to `GutTest`.  If you impelement this method and return `true` or a `String`, then GUT will skip the script.  Skipped scripts are marked as "risky" in the final counts.  This can be useful when skipping scripts that should not be run under certiain circumstances such as:
+    * You are porting tests from 3.x to 4.x and you don't want to comment everything out.
+    * Skipping tests that should not be run when in `headless` mode.
+    ``` gdscript
+    func should_skip_script():
+        if DisplayServer.get_name() == "headless":
+            return "Skip Input tests when running headless"
+    ```
+    * If you have tests that would normally cause the debugger to break on an error, you can skip the script if the debugger is enabled so that the run is not interrupted.
+    ``` gdscript
+    func should_skip_script():
+        return EngineDebugger.is_active()
+    ```
+
 
 ## Bug Fixes
 * __Issue__ #601 doubles now get a resource path that makes Godot ignore them when "Exclude Addons" is enabled (res://adddons/gut/not_a_real_file/...).
+
+
+## Deprecations
+* The optional `GutTest` script variable `skip_script` has been deprecated.  Use the new `should_skip_script` method instead.
+
+
 
 
 # 9.2.1

--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -24,10 +24,6 @@ These are changes to Godot that affect how GUT is used/implemented.  There is mo
 * To aid refactoring, `assert_property` and `assert_property_with_backing_variable` will warn if any "public accessors" are found for the property ('get_' and 'set_' methods).
 * `assert_property` now requires an instance instead of also working with a loaded objects.
 * Doubling strategy flags have been renamed to `INCLUDE_NATIVE` (was `FULL`) and `SCRIPT_ONLY` (was `PARTIAL`).  The default is `SCRIPT_ONLY`.  I wanted something more descriptive and less likely to be confused with partial doubles.
-* Added support for a `skip_script` test-script variable.  This can be added to any test-script or inner-class causing GUT to skip running tests in that script.  The script will be included in the "risky" count and appear in the summary as skipped.  This was done to help porting tests to 4.0 but might stick around as a permanent feature.
-```gdscript
-var skip_script = 'The reason for skipping.  This will be printed in the output.'
-```
 * The various `yield_` methods have been deprecated but are still supported to make conversions easier.  The new syntax for `yield_to`, `yield_for`, or `yield_frames` is:
 ```gdscript
 await yield_to(signaler, 'the_signal_name', 5, 'optional message')

--- a/addons/gut/collected_script.gd
+++ b/addons/gut/collected_script.gd
@@ -33,179 +33,179 @@ var was_run = false
 
 
 var name = '' :
-    get: return path
-    set(val):pass
+	get: return path
+	set(val):pass
 
 
 func _init(logger=null):
-    _lgr = logger
+	_lgr = logger
 
 
 func get_new():
-    return load_script().new()
+	return load_script().new()
 
 
 func load_script():
-    var to_return = load(path)
+	var to_return = load(path)
 
-    if(inner_class_name != null and inner_class_name != ''):
-        # If we wanted to do inner classes in inner classses
-        # then this would have to become some kind of loop or recursive
-        # call to go all the way down the chain or this class would
-        # have to change to hold onto the loaded class instead of
-        # just path information.
-        to_return = to_return.get(inner_class_name)
+	if(inner_class_name != null and inner_class_name != ''):
+		# If we wanted to do inner classes in inner classses
+		# then this would have to become some kind of loop or recursive
+		# call to go all the way down the chain or this class would
+		# have to change to hold onto the loaded class instead of
+		# just path information.
+		to_return = to_return.get(inner_class_name)
 
-    return to_return
+	return to_return
 
 # script.gd.InnerClass
 func get_filename_and_inner():
-    var to_return = get_filename()
-    if(inner_class_name != ''):
-        to_return += '.' + String(inner_class_name)
-    return to_return
+	var to_return = get_filename()
+	if(inner_class_name != ''):
+		to_return += '.' + String(inner_class_name)
+	return to_return
 
 
 # res://foo/bar.gd.FooBar
 func get_full_name():
-    var to_return = path
-    if(inner_class_name != ''):
-        to_return += '.' + String(inner_class_name)
-    return to_return
+	var to_return = path
+	if(inner_class_name != ''):
+		to_return += '.' + String(inner_class_name)
+	return to_return
 
 
 func get_filename():
-    return path.get_file()
+	return path.get_file()
 
 
 func has_inner_class():
-    return inner_class_name != ''
+	return inner_class_name != ''
 
 
 # Note:  although this no longer needs to export the inner_class names since
 #        they are pulled from metadata now, it is easier to leave that in
 #        so we don't have to cut the export down to unique script names.
 func export_to(config_file, section):
-    config_file.set_value(section, 'path', path)
-    config_file.set_value(section, 'inner_class', inner_class_name)
-    var names = []
-    for i in range(tests.size()):
-        names.append(tests[i].name)
-    config_file.set_value(section, 'tests', names)
+	config_file.set_value(section, 'path', path)
+	config_file.set_value(section, 'inner_class', inner_class_name)
+	var names = []
+	for i in range(tests.size()):
+		names.append(tests[i].name)
+	config_file.set_value(section, 'tests', names)
 
 
 func _remap_path(source_path):
-    var to_return = source_path
-    if(!FileAccess.file_exists(source_path)):
-        _lgr.debug('Checking for remap for:  ' + source_path)
-        var remap_path = source_path.get_basename() + '.gd.remap'
-        if(FileAccess.file_exists(remap_path)):
-            var cf = ConfigFile.new()
-            cf.load(remap_path)
-            to_return = cf.get_value('remap', 'path')
-        else:
-            _lgr.warn('Could not find remap file ' + remap_path)
-    return to_return
+	var to_return = source_path
+	if(!FileAccess.file_exists(source_path)):
+		_lgr.debug('Checking for remap for:  ' + source_path)
+		var remap_path = source_path.get_basename() + '.gd.remap'
+		if(FileAccess.file_exists(remap_path)):
+			var cf = ConfigFile.new()
+			cf.load(remap_path)
+			to_return = cf.get_value('remap', 'path')
+		else:
+			_lgr.warn('Could not find remap file ' + remap_path)
+	return to_return
 
 
 func import_from(config_file, section):
-    path = config_file.get_value(section, 'path')
-    path = _remap_path(path)
-    # Null is an acceptable value, but you can't pass null as a default to
-    # get_value since it thinks you didn't send a default...then it spits
-    # out red text.  This works around that.
-    var inner_name = config_file.get_value(section, 'inner_class', 'Placeholder')
-    if(inner_name != 'Placeholder'):
-        inner_class_name = inner_name
-    else: # just being explicit
-        inner_class_name = StringName("")
+	path = config_file.get_value(section, 'path')
+	path = _remap_path(path)
+	# Null is an acceptable value, but you can't pass null as a default to
+	# get_value since it thinks you didn't send a default...then it spits
+	# out red text.  This works around that.
+	var inner_name = config_file.get_value(section, 'inner_class', 'Placeholder')
+	if(inner_name != 'Placeholder'):
+		inner_class_name = inner_name
+	else: # just being explicit
+		inner_class_name = StringName("")
 
 
-func get_test_named(name):
-    return GutUtils.search_array(tests, 'name', name)
+func get_test_named(test_name):
+	return GutUtils.search_array(tests, 'name', test_name)
 
 
 func mark_tests_to_skip_with_suffix(suffix):
-    for single_test in tests:
-        single_test.should_skip = single_test.name.ends_with(suffix)
+	for single_test in tests:
+		single_test.should_skip = single_test.name.ends_with(suffix)
 
 
 func get_ran_test_count():
-    var count = 0
-    for t in tests:
-        if(t.was_run):
-            count += 1
-    return count
+	var count = 0
+	for t in tests:
+		if(t.was_run):
+			count += 1
+	return count
 
 
 func get_assert_count():
-    var count = 0
-    for t in tests:
-        count += t.pass_texts.size()
-        count += t.fail_texts.size()
-    for t in setup_teardown_tests:
-        count += t.pass_texts.size()
-        count += t.fail_texts.size()
-    return count
+	var count = 0
+	for t in tests:
+		count += t.pass_texts.size()
+		count += t.fail_texts.size()
+	for t in setup_teardown_tests:
+		count += t.pass_texts.size()
+		count += t.fail_texts.size()
+	return count
 
 
 func get_pass_count():
-    var count = 0
-    for t in tests:
-        count += t.pass_texts.size()
-    for t in setup_teardown_tests:
-        count += t.pass_texts.size()
-    return count
+	var count = 0
+	for t in tests:
+		count += t.pass_texts.size()
+	for t in setup_teardown_tests:
+		count += t.pass_texts.size()
+	return count
 
 
 func get_fail_count():
-    var count = 0
-    for t in tests:
-        count += t.fail_texts.size()
-    for t in setup_teardown_tests:
-        count += t.fail_texts.size()
-    return count
+	var count = 0
+	for t in tests:
+		count += t.fail_texts.size()
+	for t in setup_teardown_tests:
+		count += t.fail_texts.size()
+	return count
 
 
 func get_pending_count():
-    var count = 0
-    for t in tests:
-        count += t.pending_texts.size()
-    return count
+	var count = 0
+	for t in tests:
+		count += t.pending_texts.size()
+	return count
 
 
 func get_passing_test_count():
-    var count = 0
-    for t in tests:
-        if(t.is_passing()):
-            count += 1
-    return count
+	var count = 0
+	for t in tests:
+		if(t.is_passing()):
+			count += 1
+	return count
 
 
 func get_failing_test_count():
-    var count = 0
-    for t in tests:
-        if(t.is_failing()):
-            count += 1
-    return count
+	var count = 0
+	for t in tests:
+		if(t.is_failing()):
+			count += 1
+	return count
 
 
 func get_risky_count():
-    var count = 0
-    if(was_skipped):
-        count = 1
-    else:
-        for t in tests:
-            if(t.is_risky()):
-                count += 1
-    return count
+	var count = 0
+	if(was_skipped):
+		count = 1
+	else:
+		for t in tests:
+			if(t.is_risky()):
+				count += 1
+	return count
 
 
 func to_s():
-    var to_return = path
-    if(inner_class_name != null):
-        to_return += str('.', inner_class_name)
-    to_return += "\n"
-    for i in range(tests.size()):
-        to_return += str('  ', tests[i].to_s())
-    return to_return
+	var to_return = path
+	if(inner_class_name != null):
+		to_return += str('.', inner_class_name)
+	to_return += "\n"
+	for i in range(tests.size()):
+		to_return += str('  ', tests[i].to_s())
+	return to_return

--- a/addons/gut/collected_script.gd
+++ b/addons/gut/collected_script.gd
@@ -125,11 +125,6 @@ func get_test_named(test_name):
 	return GutUtils.search_array(tests, 'name', test_name)
 
 
-func mark_tests_to_skip_with_suffix(suffix):
-	for single_test in tests:
-		single_test.should_skip = single_test.name.ends_with(suffix)
-
-
 func get_ran_test_count():
 	var count = 0
 	for t in tests:

--- a/addons/gut/collected_test.gd
+++ b/addons/gut/collected_test.gd
@@ -31,7 +31,7 @@ var line_number = -1
 
 # Set internally by Gut using whatever reason Gut wants to use to set this.
 # Gut will skip these marked true and the test will be listed as risky.
-var should_skip = false
+var should_skip = false  # -- Currently not used by GUT don't believe ^
 
 var pass_texts = []
 var fail_texts = []

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -668,7 +668,7 @@ func _should_skip_script(test_script, collected_script):
 		if(typeof(skip_value) == TYPE_BOOL):
 			should_skip = skip_value
 			if(skip_value):
-				skip_message = 'TRUE was returned'
+				skip_message = 'script marked to skip'
 		elif(typeof(skip_value) == TYPE_STRING):
 			should_skip = true
 			skip_message = skip_value

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -751,19 +751,10 @@ func _test_the_scripts(indexes=[]):
 			await _call_before_all(test_script, coll_script)
 
 		# Each test in the script
-		var skip_suffix = '_skip__'
-		coll_script.mark_tests_to_skip_with_suffix(skip_suffix)
-
 		for i in range(coll_script.tests.size()):
 			_stubber.clear()
 			_spy.clear()
 			_current_test = coll_script.tests[i]
-
-			# ------------------
-			# SHORTCIRCUI
-			if(_current_test.should_skip):
-				continue
-			# ------------------
 
 			if((_unit_test_name != '' and _current_test.name.find(_unit_test_name) > -1) or
 				(_unit_test_name == '')):

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -254,19 +254,22 @@ func _create_obj_from_type(type):
 # Virtual Methods
 # #######################
 
-# alias for prerun_setup
+func should_skip_script():
+	return false
+
+
 func before_all():
 	pass
 
-# alias for setup
+
 func before_each():
 	pass
 
-# alias for postrun_teardown
+
 func after_all():
 	pass
 
-# alias for teardown
+
 func after_each():
 	pass
 

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -106,6 +106,9 @@ func add_script(path):
 
 	# SHORTCIRCUIT
 	if(!FileAccess.file_exists(path)):
+		# This check was added so tests could create dynmaic scripts and add
+		# them to be run through gut.  This helps cut down on creating test
+		# scripts to be used in test/resources.
 		if(ResourceLoader.has_cached(path)):
 			_lgr.info("Using cached version of " + path)
 		else:

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -106,8 +106,11 @@ func add_script(path):
 
 	# SHORTCIRCUIT
 	if(!FileAccess.file_exists(path)):
-		_lgr.error('Could not find script:  ' + path)
-		return
+		if(ResourceLoader.has_cached(path)):
+			_lgr.info("Using cached version of " + path)
+		else:
+			_lgr.error('Could not find script:  ' + path)
+			return
 
 	var ts = CollectedScript.new(_lgr)
 	ts.path = path

--- a/documentation/docs/Asserts-and-Methods.md
+++ b/documentation/docs/Asserts-and-Methods.md
@@ -4,6 +4,38 @@ These are all the methods, bells, whistles and blinky lights you get when you ex
 
 Most sample code listed for the methods can be found here in [test_readme_examples.gd](https://github.com/bitwes/Gut/blob/master/test/samples/test_readme_examples.gd)
 
+## Setup/Teardown
+Implement these virtual methods in your test script to run code at key points during the execution of the test script.
+
+### before_all
+This method is run prior to to running any test.  This is a great place to perform one time setup for the script.
+``` gdscript
+var _foo = null
+func before_all():
+	_foo = Foo.instantiate()
+```
+
+### before_each
+This method is called right before each test.
+``` gdscript
+func before_each():
+	_foo.reset()
+```
+
+### after_each
+This method is run after each test.
+``` gdscript
+func after_each():
+	pass # could not think of a fun thing to go here.
+```
+
+### after_all
+This is called after all tests have been executed.  This is a good place to clean up after yourself.
+``` gdscript
+func after_all():
+	_foo.queue_free()
+```
+
 
 ## Assertions
 
@@ -1395,6 +1427,22 @@ Performs a deep comparison between two arrays or dictionaries.  A `CompareResult
 `set_double_strategy(strategy)`
 
 See [Double Strategy](Double-Strategy)
+
+
+### should_skip_script
+This virtual method is run after the script has been prepped for execution, but before `before_all` is executed.  If you implement this method and return `true` or a `String` (the string is displayed in the log) then GUT will stop executing the script and mark it as risky.  You might want to do this because:
+* You are porting tests from 3.x to 4.x and you don't want to comment everything out.
+* Skipping tests that should not be run when in `headless` mode such as input testing that does not work in headless.
+``` gdscript
+func should_skip_script():
+	if DisplayServer.get_name() == "headless":
+		return "Skip Input tests when running headless"
+```
+* If you have tests that would normally cause the debugger to break on an error, you can skip the script if the debugger is enabled so that the run is not interrupted.
+``` gdscript
+func should_skip_script():
+	return EngineDebugger.is_active()
+```
 
 
 

--- a/documentation/docs/New-For-Godot-4.md
+++ b/documentation/docs/New-For-Godot-4.md
@@ -16,10 +16,6 @@ These are changes to Godot that affect how GUT is used/implemented.  There is mo
 * To aid refactoring, `assert_property` and `assert_property_with_backing_variable` will warn if any "public accessors" are found for the property ('get_' and 'set_' methods).
 * `assert_property` now requires an instance instead of also working with a loaded objects.
 * Doubling strategy flags have been renamed to `INCLUDE_NATIVE` (was `FULL`) and `SCRIPT_ONLY` (was `PARTIAL`).  The default is `SCRIPT_ONLY`.  I wanted something more descriptive and less likely to be confused with partial doubles.
-* Added support for a `skip_script` test-script variable.  This can be added to any test-script or inner-class causing GUT to skip running tests in that script.  The script will be included in the "risky" count and appear in the summary as skipped.  This was done to help porting tests to 4.0 but might stick around as a permanent feature.
-```gdscript
-var skip_script = 'The reason for skipping.  This will be printed in the output.'
-```
 * The various `yield_` methods have been deprecated but are still supported to make conversions easier.  The new syntax for `yield_to`, `yield_for`, or `yield_frames` is:
 ```gdscript
 await yield_to(signaler, 'the_signal_name', 5, 'optional message')

--- a/test/gut_test.gd
+++ b/test/gut_test.gd
@@ -3,19 +3,19 @@ class_name GutInternalTester
 extends GutTest
 
 const DOUBLE_ME_PATH = 'res://test/resources/doubler_test_objects/double_me.gd'
-var DoubleMe = load(DOUBLE_ME_PATH)
+var DoubleMe = GutUtils.WarningsManager.load_script_ignoring_all_warnings(DOUBLE_ME_PATH)
 
 const DOUBLE_ME_SCENE_PATH = 'res://test/resources/doubler_test_objects/double_me_scene.tscn'
-var DoubleMeScene = load(DOUBLE_ME_SCENE_PATH)
+var DoubleMeScene = GutUtils.WarningsManager.load_script_ignoring_all_warnings(DOUBLE_ME_SCENE_PATH)
 
 const DOUBLE_EXTENDS_NODE2D = 'res://test/resources/doubler_test_objects/double_extends_node2d.gd'
-var DoubleExtendsNode2D = load(DOUBLE_EXTENDS_NODE2D)
+var DoubleExtendsNode2D = GutUtils.WarningsManager.load_script_ignoring_all_warnings(DOUBLE_EXTENDS_NODE2D)
 
 const DOUBLE_EXTENDS_WINDOW_DIALOG = 'res://test/resources/doubler_test_objects/double_extends_window_dialog.gd'
-var DoubleExtendsWindowDialog = load(DOUBLE_EXTENDS_WINDOW_DIALOG)
+var DoubleExtendsWindowDialog = GutUtils.WarningsManager.load_script_ignoring_all_warnings(DOUBLE_EXTENDS_WINDOW_DIALOG)
 
 const INNER_CLASSES_PATH = 'res://test/resources/doubler_test_objects/inner_classes.gd'
-var InnerClasses = load(INNER_CLASSES_PATH)
+var InnerClasses = GutUtils.WarningsManager.load_script_ignoring_all_warnings(INNER_CLASSES_PATH)
 
 var Gut = load('res://addons/gut/gut.gd')
 var Test = load('res://addons/gut/test.gd')

--- a/test/integration/test_gut_skip_scripts.gd
+++ b/test/integration/test_gut_skip_scripts.gd
@@ -1,0 +1,126 @@
+extends GutInternalTester
+
+
+var _src_base = """
+extends GutTest
+"""
+var _src_passing_test = """
+func test_is_passing():
+	assert_true(true)
+"""
+var _src_failing_test = """
+func test_is_failing():
+	assert_eq(1, '1')
+"""
+var _src_skip_script_var_string_val = """
+var skip_script = 'skip me, thanks'
+"""
+var _src_skip_script_var_null_val = """
+var skip_script = null
+"""
+var _src_should_skip_script_method_ret_true = """
+func should_skip_script():
+	return true
+"""
+var _src_should_skip_script_method_ret_false = """
+func should_skip_script():
+	return false
+"""
+var _src_should_skip_script_method_ret_string = """
+func should_skip_script():
+	return 'skip me'
+"""
+
+func _run_test_source(src):
+	var g = new_gut(true)
+	add_child_autofree(g)
+
+	var dyn = GutUtils.create_script_from_source(src)
+	g.get_test_collector().add_script(dyn.resource_path)
+	g.run_tests()
+
+	var s = GutUtils.Summary.new()
+	return s.get_totals(g)
+
+
+func test_can_compose_and_run_a_script():
+	var src = _src_base +\
+		_src_passing_test +\
+		_src_failing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 2)
+
+
+func test_using_skip_script_variable_is_deprecated():
+	var src = _src_base + \
+		_src_skip_script_var_string_val + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.deprecated, 1, 'Should be one deprecation.')
+
+
+func test_when_skip_script_var_is_string_script_is_skipped():
+	var src = _src_base + \
+		_src_skip_script_var_string_val + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 0, 'no tests should be ran')
+	assert_eq(t.risky, 1, 'Should be marked as risky due to skip')
+
+
+func test_when_skip_script_var_is_null_the_script_is_ran():
+	var src = _src_base + \
+		_src_skip_script_var_null_val + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 1, 'the one test should be ran')
+	assert_eq(t.risky, 0, 'not marked risky just for having var')
+
+func test_should_skip_script_method_returns_false_by_default():
+	var test = autofree(GutTest.new())
+	assert_false(test.should_skip_script())
+
+
+func test_when_should_skip_script_returns_false_script_is_run():
+	var src = _src_base + \
+		_src_should_skip_script_method_ret_false + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 1, 'no tests should be ran')
+	assert_eq(t.risky, 0, 'Should be marked as risky due to skip')
+
+
+
+func test_when_should_skip_script_returns_true_script_is_skipped():
+	var src = _src_base + \
+		_src_should_skip_script_method_ret_true + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 0, 'no tests should be ran')
+	assert_eq(t.risky, 1, 'Should be marked as risky due to skip')
+
+
+func test_when_should_skip_script_returns_string_script_is_skipped():
+	var src = _src_base + \
+		_src_should_skip_script_method_ret_string + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.tests, 0, 'no tests should be ran')
+	assert_eq(t.risky, 1, 'Should be marked as risky due to skip')
+
+
+func test_using_should_skip_script_method_is_not_deprecated():
+	var src = _src_base + \
+		_src_should_skip_script_method_ret_true + \
+		_src_passing_test
+	var t = _run_test_source(src)
+
+	assert_eq(t.deprecated, 0, 'nothing is deprecated')
+

--- a/test/integration/test_more_input_ideas.gd
+++ b/test/integration/test_more_input_ideas.gd
@@ -1,10 +1,7 @@
 extends GutTest
 
-var skip_script = 'takes too long and these shouldnt even be here'
-
 class SuperButton:
 	extends Button
-
 
 	func p(s1='', s2='', s3='', s4='', s5='', s6=''):
 		print(s1, s2, s3, s4, s5, s6)
@@ -38,6 +35,9 @@ class DraggableButton:
 			_mouse_down = event.pressed
 		elif(event is InputEventMouseMotion and _mouse_down):
 			position += event.relative
+
+func should_skip_script():
+	return 'takes too long and these shouldnt even be here'
 
 
 func _print_emitted_signals(thing):

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -791,7 +791,8 @@ class TestAccessorAsserts:
 class TestAssertExports:
 	extends BaseTestClass
 
-	var skip_script = 'Not implemented in 4.0'
+	func should_skip_script():
+		return 'Not implemented in 4.0'
 
 	class NoProperty:
 		func _unused():

--- a/test/unit/test_test_collector.gd
+++ b/test/unit/test_test_collector.gd
@@ -130,7 +130,8 @@ class TestTestsWithParameters:
 class TestExportImport:
 	extends GutInternalTester
 
-	var skip_script = 'Not implemented in 4.0'
+	func should_skip_script():
+		return 'Not implemented in 4.0'
 
 	var SCRIPTS_ROOT = 'res://test/resources/parsing_and_loading_samples/'
 	var EXPORT_FILE = 'user://exported_tests.cfg'


### PR DESCRIPTION
Added the virtual method `should_skip_script` to `GutTest`.  If you impelement this method and return `true` or a `String`, then GUT will skip the script.  Skipped scripts are marked as "risky" in the final counts.  This can be useful when skipping scripts that should not be run under certiain circumstances such as:
* You are porting tests from 3.x to 4.x and you don't want to comment everything out.
* Skipping tests that should not be run when in `headless` mode.
    ``` gdscript
    func should_skip_script():
        if DisplayServer.get_name() == "headless":
            return "Skip Input tests when running headless"
    ```
* If you have tests that would normally cause the debugger to break on an error, you can skip the script if the debugger is enabled so that the run is not interrupted.
    ``` gdscript
    func should_skip_script():
        return EngineDebugger.is_active()
    ```