### PR TITLE
Fix #618

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -836,9 +836,12 @@ func assert_not_typeof(object, type, text=''):
 # The match_case flag determines case sensitivity.
 # ------------------------------------------------------------------------------
 func assert_string_contains(text, search, match_case=true):
-	var empty_search = 'Expected text and search strings to be non-empty. You passed \'%s\' and \'%s\'.'
+	const empty_search = 'Expected text and search strings to be non-empty. You passed \'%s\' and \'%s\'.'
+	const non_strings = 'Expected text and search to both be strings.  You passed \'%s\' and \'%s\'.'
 	var disp = 'Expected \'%s\' to contain \'%s\', match_case=%s' % [text, search, match_case]
-	if(text == '' or search == ''):
+	if(typeof(text) != TYPE_STRING or typeof(search) != TYPE_STRING):
+		_fail(non_strings % [text, search])
+	elif(text == '' or search == ''):
 		_fail(empty_search % [text, search])
 	elif(match_case):
 		if(text.find(search) == -1):

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -836,13 +836,13 @@ func assert_not_typeof(object, type, text=''):
 # The match_case flag determines case sensitivity.
 # ------------------------------------------------------------------------------
 func assert_string_contains(text, search, match_case=true):
-	const empty_search = 'Expected text and search strings to be non-empty. You passed \'%s\' and \'%s\'.'
-	const non_strings = 'Expected text and search to both be strings.  You passed \'%s\' and \'%s\'.'
+	const empty_search = 'Expected text and search strings to be non-empty. You passed %s and %s.'
+	const non_strings = 'Expected text and search to both be strings.  You passed %s and %s.'
 	var disp = 'Expected \'%s\' to contain \'%s\', match_case=%s' % [text, search, match_case]
 	if(typeof(text) != TYPE_STRING or typeof(search) != TYPE_STRING):
-		_fail(non_strings % [text, search])
+		_fail(non_strings % [_str(text), _str(search)])
 	elif(text == '' or search == ''):
-		_fail(empty_search % [text, search])
+		_fail(empty_search % [_str(text), _str(search)])
 	elif(match_case):
 		if(text.find(search) == -1):
 			_fail(disp)

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1233,33 +1233,48 @@ class TestAssertTypeOf:
 
 
 # ------------------------------------------------------------------------------
-# TODO rename tests since they are now in an inner class.  See NOTE at top about naming.
-class TestStringContains:
+class TestAssertStringContains:
 	extends BaseTestClass
 
-	func test__assert_string_contains__fails_when_text_is_empty():
+	func test_fails_when_text_is_empty():
 		gr.test.assert_string_contains('', 'walrus')
 		assert_fail(gr.test)
 
-	func test__assert_string_contains__fails_when_search_string_is_empty():
+	func test_fails_when_search_string_is_empty():
 		gr.test.assert_string_contains('This is a test.', '')
 		assert_fail(gr.test)
 
-	func test__assert_string_contains__fails_when_case_sensitive_search_not_found():
+	func test_fails_when_case_sensitive_search_not_found():
 		gr.test.assert_string_contains('This is a test.', 'TeSt', true)
 		assert_fail(gr.test)
 
-	func test__assert_string_contains__fails_when_case_insensitive_search_not_found():
+	func test_fails_when_case_insensitive_search_not_found():
 		gr.test.assert_string_contains('This is a test.', 'penguin', false)
 		assert_fail(gr.test)
 
-	func test__assert_string_contains__passes_when_case_sensitive_search_is_found():
+	func test_passes_when_case_sensitive_search_is_found():
 		gr.test.assert_string_contains('This is a test.', 'is a ', true)
 		assert_pass(gr.test)
 
-	func test__assert_string_contains__passes_when_case_insensitive_search_is_found():
+	func test_passes_when_case_insensitive_search_is_found():
 		gr.test.assert_string_contains('This is a test.', 'this ', false)
 		assert_pass(gr.test)
+
+	func test_fails_when_text_is_null():
+		gr.test.assert_string_contains(null, 'whatever', false)
+		assert_fail(gr.test)
+
+	func test_fails_when_search_is_null():
+		gr.test.assert_string_contains('hello', null, false)
+		assert_fail(gr.test)
+
+	func test_fails_when_text_is_number():
+		gr.test.assert_string_contains(123, '2', false)
+		assert_fail(gr.test)
+
+	func test_fails_when_search_is_number():
+		gr.test.assert_string_contains('2', 123, false)
+		assert_fail(gr.test)
 
 
 # ------------------------------------------------------------------------------

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1238,19 +1238,19 @@ class TestAssertStringContains:
 
 	func test_fails_when_text_is_empty():
 		gr.test.assert_string_contains('', 'walrus')
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search strings to be non-empty. You passed "" and "walrus".')
 
 	func test_fails_when_search_string_is_empty():
 		gr.test.assert_string_contains('This is a test.', '')
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search strings to be non-empty. You passed "This is a test." and "".')
 
 	func test_fails_when_case_sensitive_search_not_found():
 		gr.test.assert_string_contains('This is a test.', 'TeSt', true)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected \'This is a test.\' to contain \'TeSt\', match_case=true')
 
 	func test_fails_when_case_insensitive_search_not_found():
 		gr.test.assert_string_contains('This is a test.', 'penguin', false)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected \'This is a test.\' to contain \'penguin\', match_case=false')
 
 	func test_passes_when_case_sensitive_search_is_found():
 		gr.test.assert_string_contains('This is a test.', 'is a ', true)
@@ -1262,19 +1262,19 @@ class TestAssertStringContains:
 
 	func test_fails_when_text_is_null():
 		gr.test.assert_string_contains(null, 'whatever', false)
-		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'<null>\' and \'whatever\'.')
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed <null> and "whatever".')
 
 	func test_fails_when_search_is_null():
 		gr.test.assert_string_contains('hello', null, false)
-		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'hello\' and \'<null>\'.')
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed "hello" and <null>.')
 
-	func test_fails_when_text_is_number():
+	func test_fails_when_text_is_int():
 		gr.test.assert_string_contains(123, '2', false)
-		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'123\' and \'2\'.')
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed 123 and "2".')
 
-	func test_fails_when_search_is_number():
+	func test_fails_when_search_is_int():
 		gr.test.assert_string_contains('2', 123, false)
-		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'2\' and \'123\'.')
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed "2" and 123.')
 
 
 # ------------------------------------------------------------------------------

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -1262,19 +1262,19 @@ class TestAssertStringContains:
 
 	func test_fails_when_text_is_null():
 		gr.test.assert_string_contains(null, 'whatever', false)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'<null>\' and \'whatever\'.')
 
 	func test_fails_when_search_is_null():
 		gr.test.assert_string_contains('hello', null, false)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'hello\' and \'<null>\'.')
 
 	func test_fails_when_text_is_number():
 		gr.test.assert_string_contains(123, '2', false)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'123\' and \'2\'.')
 
 	func test_fails_when_search_is_number():
 		gr.test.assert_string_contains('2', 123, false)
-		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, 'Expected text and search to both be strings.  You passed \'2\' and \'123\'.')
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR attempts to fix issue #618 .  This appears to fix the original issue, but there are two concerns I have that I need your opinion on.

Concerns:
1. The message is not entirely clear in the case of when someone passes a number - in fact it looks like it should have worked because of the formatting (see below).  Should I go through the trouble of improving the formatting?  There's a nice method here from user Jengamon that would be useful but I don't know if this project can just incorporate code like that, or maybe if something already exists here.  https://forum.godotengine.org/t/is-there-a-corresponding-type-function-in-gdscript/31815/4
2. Should we automatically convert `text` to a string if it's not null?  Maybe that's more aligned with GDScript as a dynamically typed language? I lean towards no, but I can see the argument that testing if "2" appears in the number `123` should be true.  I am more strongly against doing it the other way (testing if the number 2 appears in the string "123") because that feels more like a defective test.


Example errors which I think are fine:
```
Expected text and search to both be strings.  You passed '<null>' and 'whatever'.
Expected text and search to both be strings.  You passed 'hello' and '<null>'.
```

Example errors with which I have concerns:
```
Expected text and search to both be strings.  You passed '123' and '2'.
Expected text and search to both be strings.  You passed '2' and '123'.
```