### PR TITLE
Bugfix/i578

### DIFF
--- a/test/unit/test_bugs/test_i578.gd
+++ b/test/unit/test_bugs/test_i578.gd
@@ -2,14 +2,23 @@ extends GutTest
 
 class InputSingletonTracker:
 	extends Node
-	var input_frames = []
+	var pressed_frames = []
+	var just_pressed_count = 0
+	var just_released_count = 0
 
 	var _frame_counter = 0
 
 	func _process(delta):
 		_frame_counter += 1
-		if Input.is_anything_pressed():
-			input_frames.append(_frame_counter)
+
+		if(Input.is_action_just_pressed("jump")):
+			just_pressed_count += 1
+
+		if(Input.is_action_just_released("jump")):
+			just_released_count += 1
+
+		if Input.is_action_pressed("jump"):
+			pressed_frames.append(_frame_counter)
 
 class TestInputSingleton:
 	extends "res://addons/gut/test.gd"
@@ -23,6 +32,9 @@ class TestInputSingleton:
 
 	func after_each():
 		_sender.release_all()
+		# Wait for key release to be processed. Otherwise the key release is
+		# leaked to the next test and it detects an extra key release.
+		await wait_frames(1)
 		_sender.clear()
 
 	func test_raw_input_press():
@@ -32,7 +44,7 @@ class TestInputSingleton:
 		await wait_frames(10)
 		Input.action_release("jump")
 
-		assert_gt(r.input_frames.size(), 1, 'input size')
+		assert_gt(r.pressed_frames.size(), 1, 'input size')
 	
 	func test_input_sender_press():
 		var r = add_child_autofree(InputSingletonTracker.new())
@@ -40,4 +52,23 @@ class TestInputSingleton:
 		_sender.action_down("jump").hold_for('10f')
 		await wait_for_signal(_sender.idle, 5)
 
-		assert_gt(r.input_frames.size(), 1, 'input size')
+		print(r.pressed_frames.size())
+		assert_gt(r.pressed_frames.size(), 1, 'input size')
+
+	func test_input_sender_just_pressed():
+		var r = add_child_autofree(InputSingletonTracker.new())
+		
+		_sender.action_down("jump").hold_for("20f")
+		await wait_frames(5)
+
+		assert_eq(r.just_pressed_count, 1, 'just pressed once')
+		assert_eq(r.just_released_count, 0, 'not released yet')
+
+	func test_input_sender_just_released():
+		var r = add_child_autofree(InputSingletonTracker.new())
+		
+		_sender.action_down("jump").hold_for('5f')
+		await wait_for_signal(_sender.idle, 10)
+
+		assert_eq(r.just_pressed_count, 1, 'just pressed once')
+		assert_eq(r.just_released_count, 1, 'released key once')

--- a/test/unit/test_input_sender.gd
+++ b/test/unit/test_input_sender.gd
@@ -65,46 +65,6 @@ class InputTracker:
 		for e in inputs:
 			print(e)
 
-class InputSingletonTracker:
-	extends Node
-	var inputs = []
-	var input_frames = []
-
-	var _frame_counter = 0
-
-	func _process(delta):
-		_frame_counter += 1
-		if Input.is_anything_pressed():
-			input_frames.append(_frame_counter)
-			inputs.append("UNKNOWN_EVENT")
-
-	func print_events():
-		for e in inputs:
-			print(e)
-
-class TestInputSingleton:
-	extends "res://addons/gut/test.gd"
-	var _sender = InputSender.new(Input)
-
-	func before_all():
-		InputMap.add_action("jump")
-
-	func after_all():
-		InputMap.erase_action("jump")
-
-	func test_action_hold_for():
-		var r = add_child_autofree(InputSingletonTracker.new())
-
-		_sender.action_down("jump").hold_for('3f')
-		await wait_for_signal(_sender.idle, 5)
-
-		assert_eq(r.inputs.size(), 2, 'input size')
-		# var jump_pressed = r.inputs[0].action == "jump" and r.inputs[0].pressed
-		# assert_true(jump_pressed, "jump pressed is action 0")
-		# var jummp_released = r.inputs[1].action == "jump" and !(r.inputs[1].pressed)
-		# assert_true(jummp_released, "jump released is action 1")
-	
-
 class TestTheBasics:
 	extends "res://addons/gut/test.gd"
 

--- a/test/unit/test_input_sender.gd
+++ b/test/unit/test_input_sender.gd
@@ -65,6 +65,46 @@ class InputTracker:
 		for e in inputs:
 			print(e)
 
+class InputSingletonTracker:
+	extends Node
+	var inputs = []
+	var input_frames = []
+
+	var _frame_counter = 0
+
+	func _process(delta):
+		_frame_counter += 1
+		if Input.is_anything_pressed():
+			input_frames.append(_frame_counter)
+			inputs.append("UNKNOWN_EVENT")
+
+	func print_events():
+		for e in inputs:
+			print(e)
+
+class TestInputSingleton:
+	extends "res://addons/gut/test.gd"
+	var _sender = InputSender.new(Input)
+
+	func before_all():
+		InputMap.add_action("jump")
+
+	func after_all():
+		InputMap.erase_action("jump")
+
+	func test_action_hold_for():
+		var r = add_child_autofree(InputSingletonTracker.new())
+
+		_sender.action_down("jump").hold_for('3f')
+		await wait_for_signal(_sender.idle, 5)
+
+		assert_eq(r.inputs.size(), 2, 'input size')
+		# var jump_pressed = r.inputs[0].action == "jump" and r.inputs[0].pressed
+		# assert_true(jump_pressed, "jump pressed is action 0")
+		# var jummp_released = r.inputs[1].action == "jump" and !(r.inputs[1].pressed)
+		# assert_true(jummp_released, "jump released is action 1")
+	
+
 class TestTheBasics:
 	extends "res://addons/gut/test.gd"
 


### PR DESCRIPTION
### Context

I found out issue #578 while writing a test. Then found out there was a PR for it #587 that's been on hold for +2 months. I hope it's alright taking the liberty to finish this. Credit for the fix still goes to @lxkarp, since I just added a couple test on top of their branch and code.

The previous PR [asked for more tests](https://github.com/bitwes/Gut/pull/587#pullrequestreview-2015639070) to check the `is_action_just_pressed` and `is_action_just_released` methods worked ok.

### Goal

Close #578 

Add the requested `just_pressed` and `just_released` tests.

### Note on potential issue

I'm not sure if this is expected behavior, but I think some resources are being leaked from one test to the next. I was getting weird results like 1 key pressed and 2 keys released. I think the `InputSender.release_all()` and `InputSender.clear()` weren't being processed before the next test started. So when the second test started, the `InputSender.release_all()` was processed and it detected the key release from the previous test.

I fixed this by waiting for 1 frame after the `InputSender.release_all()` method is called, in the `after_each()` method. If this is expected, maybe it should be documented and added to examples. If it isn't, I can write an issue for it. I'll wait for your feedback before doing anything :slightly_smiling_face: 