### PR TITLE
Stub with callables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # 9.2.2
 
 ## Features
+* You can now use callables to `stub`.  Binding arguments adds `when_passed` to the stub.  Less strings, less typing!
+```gdscript
+var dbl = double(MyScript)
+# same as stub(dbl, "some_method").to_return(111)
+stub(dbl.some_method).to_return(111)
+
+# same as stub(dbl, 'some_method').to_return(999).when_passed("a")
+stub(dbl.some_method.bind("a")).to_return(999)
+```
 * @WebF0x GUT can now wait on a `Callable` to return `true` (aka predicate method)  via the new `wait_until`:
 ```
 # Call the function once per frame until it returns 5 or one second has elapsed.

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -28,17 +28,20 @@ var _parameter_override_only = true
 
 const NOT_SET = '|_1_this_is_not_set_1_|'
 
-func _init(target=null,method=null,subpath=null):
+func _init(target=null,method=null):
 	stub_target = target
 	stub_method = method
 
-	if(typeof(target) == TYPE_STRING):
+	if(typeof(target) == TYPE_CALLABLE):
+		stub_target = target.get_object()
+		stub_method = target.get_method()
+		parameters = target.get_bound_arguments()
+	elif(typeof(target) == TYPE_STRING):
 		if(target.is_absolute_path()):
 			stub_target = load(str(target))
 		else:
 			_lgr.warn(str(target, ' is not a valid path'))
-
-	if(stub_target is PackedScene):
+	elif(stub_target is PackedScene):
 		stub_target = GutUtils.get_scene_script_object(stub_target)
 
 	# this is used internally to stub default parameters for everything that is
@@ -47,6 +50,7 @@ func _init(target=null,method=null,subpath=null):
 	if(typeof(method) == TYPE_DICTIONARY):
 		_load_defaults_from_metadata(method)
 
+
 func _load_defaults_from_metadata(meta):
 	stub_method = meta.name
 	var values = meta.default_args.duplicate()
@@ -54,6 +58,7 @@ func _load_defaults_from_metadata(meta):
 		values.push_front(null)
 
 	param_defaults(values)
+
 
 func to_return(val):
 	if(stub_method == '_init'):
@@ -103,10 +108,10 @@ func has_param_override():
 
 
 func is_param_override_only():
-	var to_return = false
+	var ret_val = false
 	if(has_param_override()):
-		to_return = _parameter_override_only
-	return to_return
+		ret_val = _parameter_override_only
+	return ret_val
 
 
 func to_s():

--- a/addons/gut/stub_params.gd
+++ b/addons/gut/stub_params.gd
@@ -28,7 +28,7 @@ var _parameter_override_only = true
 
 const NOT_SET = '|_1_this_is_not_set_1_|'
 
-func _init(target=null,method=null):
+func _init(target=null, method=null, _subpath=null):
 	stub_target = target
 	stub_method = method
 
@@ -36,12 +36,15 @@ func _init(target=null,method=null):
 		stub_target = target.get_object()
 		stub_method = target.get_method()
 		parameters = target.get_bound_arguments()
+		if(parameters.size() == 0):
+			parameters = null
 	elif(typeof(target) == TYPE_STRING):
 		if(target.is_absolute_path()):
 			stub_target = load(str(target))
 		else:
 			_lgr.warn(str(target, ' is not a valid path'))
-	elif(stub_target is PackedScene):
+
+	if(stub_target is PackedScene):
 		stub_target = GutUtils.get_scene_script_object(stub_target)
 
 	# this is used internally to stub default parameters for everything that is

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1440,7 +1440,7 @@ func ignore_method_when_doubling(thing, method_name):
 # Stub something.
 #
 # Parameters
-# 1: the thing to stub, a file path or an instance or a class
+# 1: A callable OR the thing to stub OR a file path OR an instance OR a Script
 # 2: either an inner class subpath or the method name
 # 3: the method name if an inner class subpath was specified
 # NOTE:  right now we cannot stub inner classes at the path level so this should
@@ -1463,6 +1463,8 @@ func stub(thing, p2=null, p3=null):
 
 	var sp = null
 	if(typeof(thing) == TYPE_CALLABLE):
+		if(p2 != null or p3 != null):
+			_lgr.error("Only one parameter expected when using a callable.")
 		sp = GutUtils.StubParams.new(thing)
 	else:
 		sp = GutUtils.StubParams.new(thing, method_name, subpath)

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -1447,9 +1447,10 @@ func ignore_method_when_doubling(thing, method_name):
 #        only be called with two parameters.  I did the work though so I'm going
 #        to leave it but not update the wiki.
 # ------------------------------------------------------------------------------
-func stub(thing, p2, p3=null):
+func stub(thing, p2=null, p3=null):
 	var method_name = p2
 	var subpath = null
+
 	if(p3 != null):
 		subpath = p2
 		method_name = p3
@@ -1460,7 +1461,12 @@ func stub(thing, p2, p3=null):
 			_lgr.error(msg)
 			return GutUtils.StubParams.new()
 
-	var sp = GutUtils.StubParams.new(thing, method_name, subpath)
+	var sp = null
+	if(typeof(thing) == TYPE_CALLABLE):
+		sp = GutUtils.StubParams.new(thing)
+	else:
+		sp = GutUtils.StubParams.new(thing, method_name, subpath)
+
 	gut.get_stubber().add_stub(sp)
 	return sp
 

--- a/documentation/docs/Quick-Start.md
+++ b/documentation/docs/Quick-Start.md
@@ -15,7 +15,7 @@ extends GutTest
 func test_passes():
 	# this test will pass because 1 does equal 1
 	assert_eq(1, 1)
-	
+
 func test_fails():
 	# this test will fail because those strings are not equal
 	assert_eq('hello', 'goodbye')
@@ -120,13 +120,13 @@ var double_foo = double(Foo).new()
 var double_scene = double(MyScene).instantiate()
 ```
 
-You can stub your double to do different things.  Any unstubbed method that is called will generate a warning.
+You can stub your double to do different things.  Unstubbed methods that are called generate log messages.
 ```gdscript
 var double_foo = double(Foo).new()
-stub(double_foo, 'bar').to_return(42)
-stub(double_foo, 'something').to_call_super() # do what method would normally do
-stub(double_foo, 'other_thing').to_return(null).when_passed(1, 2, 'c')
-stub(double_foo, 'method').to_do_nothing()
+stub(double_foo.bar).to_return(42)
+stub(double_foo, "something").to_call_super() # do what method would normally do
+stub(double_foo.other_thing).to_return(77).when_passed(1, 2, 'c')
+stub(double_foo.other_thing.bind(4, 5, 'z')).to_do_nothing()
 ```
 
 You can spy on your doubles with various asserts and helpers.
@@ -158,11 +158,11 @@ Partial doubles have all the same properties of a double except they retain the 
 var double_bar = partial_double(Bar).instance()
 
 # the foo method will do nothing always now
-stub(double_bar, 'foo').to_do_nothing()
+stub(double_ba.foo).to_do_nothing()
 
 # the something method will return 27 when passed 32,
 # but act normally when passed anything else.
-stub(double_bar, 'something').to_return(27).when_passed(32)
+stub(double_bar.something).to_return(27).when_passed(32)
 
 # example of spying
 assert_called(double_bar, 'other_thing')

--- a/documentation/docs/Stubbing.md
+++ b/documentation/docs/Stubbing.md
@@ -1,64 +1,118 @@
 # Stubbing
 
-The `stub` function allows you to set return values for methods for a doubled script or instance.  You can stub any doubled class to return values.  Stubs can be layered to address general and specific situations.
+The `stub` function allows you to define behavior for methods of a Doubled instance.  Stubs can be layered to address general and specific situations.  You can use `stub` to
+* Force a method to do nothing and return a specific value.
+* Call `super`'s version of the method, allowing the double to retain original functionality.
+* Force the method to take no action (useful when using Partial Doubles).
+* Do any of the above only when passed specific values.
 
-You can also use `stub` to set default parameter values and change the parameter count for a method.
+You can also use `stub` to change the signature of a method by
+* Set default parameter values.  All doubles default all parameters on all methods to `null` because GUT can't do anything else yet.  If your method has default values, and it has been stubbed to `call_super`, you may need to specify these values.  See `param_defaults` below.
+* Changing the parameter count (useful in very specific cases, mostly involving `vararg`).
+
+
+All Stubs are cleared between tests.  If you want to stub a method for all your tests do this in `before_each` using `stub(MyScript, "method_name")...`.  You should not stub anything in `before_all`, `after_each`, or `after_all`.
+
+
 
 
 ## Syntax
-```gdscript
-var MyScript = load('res://my_script.gd')
-var inst = double(MyScript).new()
-stub(inst, 'some_method').to_return("I'm stubbed!")
-```
-* `stub(obj, method)`  This stubs the value for a method.  You must chain in a call to one of the "to" methods such as `to_return(...)`.  The first parameter can be a path to a script or a loaded script or an instance of a doubled object.  When you pass in a path or class, then all doubles of that script will have the stub by default.  You can override this by calling `stub` on an instance of a doubled object.
+`stub` creates a stub for a method on a specific instance of a Double or any instance of a Doubled script.  You __must chain in a call__ to one of the "to" methods such as `to_return(...)` to specify what action should be taken when the method is called on a Double.  `stub` can be called numerous ways with different effects
 
-After calling `stub` you must chain one of the following "to" methods after.
-* `.to_return(value)` Stubs the method to return the passed value.
-* `.to_call_super()`  This will cause the method to punch through to the implementation in the super class so it will retain its original functionality.
-* `.to_do_nothing()`  This is the same as calling `.to_return(null)` but it is more readable and shows the intent of what you are doing.
-
-You can optionally chain in the `when_passed` clause as well.
-* `.when_passed(p1, p2, p3....p10)`  This can optionally be called on the result of `stub` in order to stub a value when specific parameters are passed to the method.  It supports up to 10 parameters.  Let me know if you need more.  For example:
-```
-stub('res://script.gd', 'method').to_return(-5).when_passed('minus', 'five')
-```
-
-You can also alter a method's signature with
-* `.param_defaults([])`
-* `.param_count(x)`
-See below for more information about setting parameter default values and changing parameter counts.
-
-## Example
-
-Here is a simple example
-
-Given the `double_this` class:
+### stub(callable)
+This will create a stub for the Double instance and method of the callable.  If the Callable has bound parameters the stub will only be used when the parameters used when calling the method match the bound parameters.  Using bound parameters is the same as using `when_passed`.
 ``` gdscript
-# res://scripts/double_this.gd
-extends Node2D
+var inst = double(MyScript).new()
+stub(inst.some_method).to_return(111)
+stub(inst.some_method.bind("a")).to_return(999)
 
-var foo = -1
-var bar = 10
-
-func returns_seven():
-  return 7
-
-func return_hello(param=1):
-  return 'hello'
-
-class InnerClass:
-  var another_foo = 100
+assert_eq(inst.some_method("not a"), 111)
+assert_eq(inst.some_method("a"), 999)
 ```
-Then, from inside your test script you can do the following to alter the `returns_seven` method to return `500`
+
+### stub(double_instance, method_name)
+This creates a stub for the object and method.  This is the same as `stub(callable)`.  If you wish to stub for specific parameter values, use `when_passed`.
+``` gdscript
+var inst = double(MyScript).new()
+stub(inst, "some_method").to_return(111)
+stub(inst, "some_method").when_passed("a").to_return(999)
+
+assert_eq(inst.some_method("not a"), 111)
+assert_eq(inst.some_method("a"), 999)
+```
+
+### stub(script, method_name) / stub(path_to_script, method_name):
+Creates a stub for `method_name` on all Doubles of a `script`.  This stub will be used if a stub is not added for an instance.  It is best to do this in `before_each`.
+``` gdscript
+func before_each():
+  stub(MyScript, "some_method").to_return(111)
+
+func test_script_level_stubs():
+  var uses_script_stub = double(MyScript).new()
+  var has_instance_stub = double(MyScript).new()
+  stub(has_instance_stub.some_method).to_return(555)
+  stub(has_instance_stub.some_method.bind("a")).to_return(999)
+
+  assert_eq(uses_script_stub.some_method("anything"), 111)
+  assert_eq(uses_script_stub.some_method("a"), 111)
+
+  assert_eq(has_instance_stub.some_method("anything"), 555)
+  assert_eq(has_instance_stub.some_method("a"), 999)
+```
+
+
+
+
+## Stub Actions
+You can stub a method to take the following actions when called.  These actions will be taken based on the best matched stub found for the method.
+
+Chain actions to the end of a call to `stub`
+``` gdscript
+stub(MyScript, "some_method").to_return(9)
+```
+
+### to_return(value)
+This stubs the method to do nothing and return a specific value when called.
+
+
+### to_do_nothing()
+This is the same as `to_return(null)` but has a nice explicit name that is easy to read.  This is mostly used with Partial Doubles to make them not "call super".
 ```gdscript
-var DoubleThis = load('res://scripts/double_this.gd')
+var inst = partial_double(MyScript).new()
+stub(inst._set).to_do_nothing()
 
-func test_something():
-  var inst = double(DoubleThis).new()
-  stub(inst, 'returns_seven').to_return(500)
-  assert_eq(inst.returns_seven(), 500)
+inst.some_property = 9
+assert_ne(inst.some_property, 9)
 ```
+
+### to_call_super()
+This will cause a method to punch through to `super`'s implementation of the method retaining the original functionality of the method.
+```gdscript
+var dbl_inst = double(MyScript).new()
+var inst = double(MyScript).new()
+
+stub(dbl_inst.some_method).to_call_super()
+
+assert_eq(dbl_inst.some_method(), inst.some_method())
+```
+
+
+
+## Stub Qualifiers
+There is only one qualifier, `when_passed`.  See examples above.
+
+
+
+
+## Method Signature
+You alter a method's signature with:
+* `param_defaults([default1, default2, ...])`
+* `param_count(x)`
+
+There are very few cases where you would want to do this.  They are discussed further near the end of this page.
+
+
+
 
 ## Stubbing at the Script level vs Instance level
 The `stub` method is pretty smart about what you pass it.  You can pass it a path, an Object or an instance.  If you pass an instance, it __must__ be an instance of a double.
@@ -73,6 +127,7 @@ var inst = Doubled.new()
 # These two are equivalent, and stub returns_seven for any doubles of
 # DoubleThis to return 500.
 stub('res://scripts/double_this.gd', 'returns_seven').to_return(500)
+# or
 stub(DoubleThis, 'returns_seven').to_return(500)
 assert_eq(inst.returns_seven(), 500)
 
@@ -81,24 +136,35 @@ assert_eq(inst.returns_seven(), 500)
 var stub_again = Doubled.new()
 stub(stub_again, 'returns_seven').to_return('words')
 assert_eq(stub_again.returns_seven(), 'words')
-assert_ne(inst.returns_seven, 'words')
+assert_eq(inst.returns_seven, 500)
 ```
 
+
+
+
 ## Stubbing based off of parameter values
-You can stub a method to return a specific value based on what was passed in.
+You can stub a method to return a specific value based on what was passed to it.
 ```gdscript
 var DoubleThis = load('res://scripts/double_this.gd')
 var Doubled = double(DoubleThis)
-stub(DoubleThis, 'return_hello').to_return('world').when_passed('hello')
-
 var inst = Doubled.new()
-assert_eq(inst.return_hello(), 'hello')
-assert_eq(inst.return_hello('hello'), 'world')
+
+# Script level using when_passed
+stub(DoubleThis, "return_hello").to_return("world").when_passed("hello")
+# Instance level using bound callable
+stub(inst.return_hello.bind("foo")).to_return("bar")
+
+assert_eq(inst.return_hello(), "hello")
+assert_eq(inst.return_hello("hello"), "world")
+assert_eq(inst.return_hello("foo"), "bar")
 ```
 The ordering of `when_passed` and `to_return` does not matter.
 
+
+
+
 ## Stubbing Packed Scenes
-When stubbing doubled scenes, use the path to the scene, __not__ the path to the scene's script.  If you double and stub the script used by the scene, the `instance` you make from `double_scene` will not return values stubbed for the script.  It will only return values stubbed for the scene.
+When stubbing doubled scenes, use the path to the scene, __not__ the path to the scene's script.  If you double and stub the script used by the scene, the `instance` you make from `double` will not return values stubbed for the script.  It will only return values stubbed for the scene.
 
 In order for a scene to be doubled, the scene's script must be able to be instantiated with `new` with zero parameters passed.
 
@@ -119,6 +185,9 @@ func test_illustrate_stubbing_scenes():
 
   assert_eq(doubled_scene.return_hello(), 'world')
 ```
+
+
+
 
 ## Stubbing Method Parameter Defaults
 Godot only provides information about default values for built in methods so Gut doesn't know what any default values are for methods you have created.  Since it can't know, Gut defaults all parameters to `null`.  This can cause issues in specific cases (probably all involving calling super).  You can use `.param_defaults` to specify default values to be used.
@@ -152,6 +221,9 @@ The fix is to add a `param_defaults` stub
 ```
 stub(dbl_foo, 'increment').param_defaults([1])
 ```
+
+
+
 
 ## Stubbing Method Parameter Count
 <u>__Changing the number of parameters must be done before `double` is called__</u>
@@ -189,6 +261,8 @@ func test_issue_246_rpc_id_varargs_with_defaults():
 You cannot make a method have less parameters, only more.
 
 
+
+
 ## Stubbing Accessors
 It is not possible to stub the accessors for properties if you do not use a secondary method for the accessors.  This means that doubles retain the functionality of the accessors, and it cannot be changed.
 ``` gdscript
@@ -214,9 +288,3 @@ func _get_my_property():
 func _set_my_property(val):
   my_property = val
 ```
-
-
-
-
-
-

--- a/test/integration/test_stub_in_before_each.gd
+++ b/test/integration/test_stub_in_before_each.gd
@@ -1,0 +1,12 @@
+extends GutInternalTester
+
+
+func before_each():
+	stub(DoubleMe, 'get_value').to_return(999)
+
+
+func test_that_it_is_stubbed():
+	var inst = double(DoubleMe).new()
+	assert_eq(inst.get_value(), 999)
+
+

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -220,6 +220,7 @@ class TestTestsSmartDoubleMethod:
 		assert_errored(_test, 1)
 
 
+
 class TestPartialDoubleMethod:
 	extends GutInternalTester
 
@@ -433,6 +434,12 @@ class TestStub:
 		var dbl = _test.double(DoubleMe).new()
 		_test.stub(dbl, 'foo').to_do_nothing()
 		assert_errored(_test, 1)
+
+	func test_can_stub_double_method_with_callable():
+		var d = _test.double(DoubleMe).new()
+		_test.stub(d.has_one_param).to_return(5)
+		assert_eq(_gut.get_stubber().get_return(d, 'has_one_param'), 5)
+
 
 
 # class TestSingletonDoubling:

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -408,7 +408,7 @@ class TestStub:
 	var _gut = null
 	var _test = null
 
-	func before_all():
+	func before_each():
 		_gut = Gut.new()
 		_gut.logger = GutUtils.Logger.new()
 		_test = Test.new()
@@ -435,10 +435,21 @@ class TestStub:
 		_test.stub(dbl, 'foo').to_do_nothing()
 		assert_errored(_test, 1)
 
+
 	func test_can_stub_double_method_with_callable():
 		var d = _test.double(DoubleMe).new()
 		_test.stub(d.has_one_param).to_return(5)
 		assert_eq(_gut.get_stubber().get_return(d, 'has_one_param'), 5)
+
+	func test_errors_or_p2_when_using_callable():
+		var d = _test.double(DoubleMe).new()
+		_test.stub(d.has_one_param, 'asdf').to_return(5)
+		assert_errored(_test, 1)
+
+	func test_errors_or_p3_when_using_callable():
+		var d = _test.double(DoubleMe).new()
+		_test.stub(d.has_one_param, null, 'asdf').to_return(5)
+		assert_errored(_test, 1)
 
 
 

--- a/test/unit/test_stub_params.gd
+++ b/test/unit/test_stub_params.gd
@@ -219,4 +219,8 @@ func test_can_create_from_bound_callable():
 	var sp = StubParamsClass.new(self.assert_true.bind(false))
 	assert_eq(sp.parameters, [false])
 
+func test_when_callable_is_not_bound_parameters_is_null():
+	var sp = StubParamsClass.new(self.assert_false)
+	assert_eq(sp.parameters, null)
+
 

--- a/test/unit/test_stub_params.gd
+++ b/test/unit/test_stub_params.gd
@@ -207,3 +207,16 @@ func test__draw_polyline_colors__method_meta_4():
 
 
 
+# ------------------------------------------------------------------------------
+# Test creating from Callable
+# ------------------------------------------------------------------------------
+func test_can_create_from_callable():
+	var sp = StubParamsClass.new(self.assert_true)
+	assert_eq(sp.stub_target, self, 'target')
+	assert_eq(sp.stub_method, 'assert_true', 'method')
+
+func test_can_create_from_bound_callable():
+	var sp = StubParamsClass.new(self.assert_true.bind(false))
+	assert_eq(sp.parameters, [false])
+
+


### PR DESCRIPTION
You can now use callables to `stub`.  Binding arguments adds `when_passed` to the stub.  Less strings, less typing!
```gdscript
var dbl = double(MyScript)
# same as stub(dbl, "some_method").to_return(111)
stub(dbl.some_method).to_return(111)

# same as stub(dbl, 'some_method').to_return(999).when_passed("a")
stub(dbl.some_method.bind("a")).to_return(999)
```