### PR TITLE
fix: make runner take all screen, remove min size

### DIFF
--- a/addons/gut/gui/NormalGui.tscn
+++ b/addons/gut/gui/NormalGui.tscn
@@ -6,7 +6,6 @@
 [ext_resource type="PackedScene" uid="uid://bvrqqgjpyouse" path="res://addons/gut/gui/ResizeHandle.tscn" id="4_2r8a8"]
 
 [node name="Large" type="Panel"]
-custom_minimum_size = Vector2(500, 150)
 offset_right = 632.0
 offset_bottom = 260.0
 theme = ExtResource("1_5hlsm")

--- a/addons/gut/gui/gut_gui.gd
+++ b/addons/gut/gui/gut_gui.gd
@@ -227,6 +227,7 @@ func to_bottom_right():
 
 func align_right():
 	var win_size = get_display_size()
-	self.position.x = win_size.x - self.size.x -5
+	self.position.x = 5
 	self.position.y = 5
 	self.size.y = win_size.y - 10
+	self.size.x = win_size.x - 10


### PR DESCRIPTION
This is a simple fix for #657. It forces the runner to take almost all available space (except a margin of 5 pixels on each side). The result looks like this on a project with a resolution of 384x216:

![image](https://github.com/user-attachments/assets/965bed1d-71c7-4f75-96a0-2a0fd050500a)

But maybe you don't want this to be the default behavior. I was thinking it could also be an option in GUT's settings. Like setting a custom size, or a checkbox to make it fullscreen.