### PR TITLE
fix: Mocking-Input link

### DIFF
--- a/documentation/docs/Input-Factory.md
+++ b/documentation/docs/Input-Factory.md
@@ -1,6 +1,6 @@
 
 # InputFactory
-This static class is available when extending `GutTest`.  The methods in this class are simple wrappers to make it a little easier to create instances of the various `InputEvent*` classes.  These are used, under the covers, by (Input Sender)[Mocking-Input].
+This static class is available when extending `GutTest`.  The methods in this class are simple wrappers to make it a little easier to create instances of the various `InputEvent*` classes.  These are used, under the covers, by [Input Sender](Mocking-Input).
 
 Usage:
 ```


### PR DESCRIPTION
I fixed **[MD011](https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md)** *no-reversed-links* - Reversed link syntax of **Mocking-Input**.