### PR TITLE
Fixed typos in error messages.

### DIFF
--- a/addons/gut/gui/GutRunner.gd
+++ b/addons/gut/gui/GutRunner.gd
@@ -157,7 +157,7 @@ func run_tests(show_gui=true):
 	_setup_gui(show_gui)
 
 	if(gut_config.options.dirs.size() + gut_config.options.tests.size() == 0):
-		var err_text = "You do not have any directories configrued, so GUT doesn't know where to find the tests.  Tell GUT where to find the tests and GUT shall run the tests."
+		var err_text = "You do not have any directories configured, so GUT doesn't know where to find the tests.  Tell GUT where to find the tests and GUT shall run the tests."
 		lgr.error(err_text)
 		push_error(err_text)
 		_end_run(EXIT_ERROR)

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -216,7 +216,7 @@ func _fail_if_parameters_not_array(parameters):
 	var invalid = parameters != null and typeof(parameters) != TYPE_ARRAY
 	if(invalid):
 		_lgr.error('The "parameters" parameter must be an array of expected parameter values.')
-		_fail('Cannot compare paramter values because an array was not passed.')
+		_fail('Cannot compare parameter values because an array was not passed.')
 	return invalid
 
 
@@ -1235,7 +1235,7 @@ func yield_to(obj, signal_name, max_wait, msg=''):
 # ------------------------------------------------------------------------------
 func wait_frames(frames, msg=''):
 	if(frames <= 0):
-		var text = str('yeild_frames:  frames must be > 0, you passed  ', frames, '.  0 frames waited.')
+		var text = str('wait_frames:  frames must be > 0, you passed  ', frames, '.  0 frames waited.')
 		_lgr.error(text)
 		frames = 1
 


### PR DESCRIPTION
I was hit with the "configrued" error message, so I decided to go and review the other messages. I found three small things to fix.