### PR TITLE
Font import files: Add disable_embedded_bitmaps

### DIFF
--- a/addons/gut/fonts/AnonymousPro-Bold.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Bold.ttf-9d8fef4d357af5b52cd60af
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-BoldItalic.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-BoldItalic.ttf-4274bf704d3d6b9cd
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-Italic.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Italic.ttf-9989590b02137b799e13d
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-Regular.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Regular.ttf-856c843fd6f89964d2ca
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Bold.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Bold.ttf-1f003c66d63ebed70964e77
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-BoldItalic.ttf.import
+++ b/addons/gut/fonts/CourierPrime-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-BoldItalic.ttf-65ebcc61dd5e1dfa8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Italic.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Italic.ttf-baa9156a73770735a0f72
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Regular.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Regular.ttf-3babe7e4a7a588dfc9a8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Bold.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Bold.ttf-7c7f734103b58a32491a47881
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-BoldItalic.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-BoldItalic.ttf-227406a33e84448e6aa
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Italic.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Italic.ttf-f93abf6c25390c85ad5fb6c
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Regular.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Regular.ttf-f3fcfa01cd671c8da433dd
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48


### PR DESCRIPTION
The Godot editor 4.3 adds this by default.

https://github.com/bitwes/Gut/issues/673