### PR TITLE
Remove editor config file warning

### DIFF
--- a/addons/gut/gui/editor_globals.gd
+++ b/addons/gut/gui/editor_globals.gd
@@ -11,9 +11,10 @@ static var editor_run_gut_config_path = 'gut_editor_config.json':
 	get: return temp_directory.path_join(editor_run_gut_config_path)
 	# Should this print a message or something instead?  Probably, but then I'd
 	# be repeating even more code than if this was just a constant.  So I didn't,
-	# even though I wanted to put make the message a easter eggish fun message.
+	# even though I wanted to make the message a easter eggish fun message.
 	# I didn't, so this dumb comment will have to serve as the easter eggish fun.
-	set(v): pass
+	set(v):
+		print("Be sure to document your code.  Never trust comments.")
 
 
 static var editor_run_bbcode_results_path = 'gut_editor.bbcode':

--- a/addons/gut/gut_config.gd
+++ b/addons/gut/gut_config.gd
@@ -51,7 +51,7 @@ var default_options = {
 
 
 var options = default_options.duplicate()
-
+var logger = GutUtils.get_logger()
 
 func _null_copy(h):
 	var new_hash = {}
@@ -61,10 +61,11 @@ func _null_copy(h):
 
 
 func _load_options_from_config_file(file_path, into):
-	# SHORTCIRCUIT
 	if(!FileAccess.file_exists(file_path)):
-		if(file_path != 'res://.gutconfig.json'):
-			print('ERROR:  Config File "', file_path, '" does not exist.')
+		# Default files are ok to be missing.  Maybe this is too deep a place
+		# to implement this, but here it is.
+		if(file_path != 'res://.gutconfig.json' and file_path != GutUtils.EditorGlobals.editor_run_gut_config_path):
+			logger.error(str('Config File "', file_path, '" does not exist.'))
 			return -1
 		else:
 			return 1
@@ -72,7 +73,7 @@ func _load_options_from_config_file(file_path, into):
 	var f = FileAccess.open(file_path, FileAccess.READ)
 	if(f == null):
 		var result = FileAccess.get_open_error()
-		push_error(str("Could not load data ", file_path, ' ', result))
+		logger.error(str("Could not load data ", file_path, ' ', result))
 		return result
 
 	var json = f.get_as_text()
@@ -83,7 +84,7 @@ func _load_options_from_config_file(file_path, into):
 	var results = test_json_conv.get_data()
 	# SHORTCIRCUIT
 	if(results == null):
-		print("\n\n",'!! ERROR parsing file:  ', file_path)
+		logger.error(str("Could not parse file:  ", file_path))
 		return -1
 
 	# Get all the options out of the config file using the option name.  The
@@ -149,7 +150,7 @@ func write_options(path):
 		f.store_string(content)
 		f = null # closes file
 	else:
-		print('ERROR:  could not open file ', path, ' ', result)
+		logger.error(str("Could not open file ", path, ' ', result))
 	return result
 
 

--- a/addons/gut/logger.gd
+++ b/addons/gut/logger.gd
@@ -1,34 +1,3 @@
-# ##############################################################################
-#(G)odot (U)nit (T)est class
-#
-# ##############################################################################
-# The MIT License (MIT)
-# =====================
-#
-# Copyright (c) 2025 Tom "Butch" Wesley
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# ##############################################################################
-# This class wraps around the various printers and supplies formatting for the
-# various message types (error, warning, etc).
-# ##############################################################################
 var types = {
 	debug = 'debug',
 	deprecated = 'deprecated',
@@ -375,3 +344,37 @@ func end_yield():
 
 func get_gui_bbcode():
 	return _printers.gui.get_bbcode()
+
+
+
+# ##############################################################################
+#(G)odot (U)nit (T)est class
+#
+# ##############################################################################
+# The MIT License (MIT)
+# =====================
+#
+# Copyright (c) 2025 Tom "Butch" Wesley
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ##############################################################################
+# This class wraps around the various printers and supplies formatting for the
+# various message types (error, warning, etc).
+# ##############################################################################

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -38,6 +38,7 @@ static var GutScene = load('res://addons/gut/GutScene.tscn')
 static var LazyLoader = load('res://addons/gut/lazy_loader.gd')
 static var VersionNumbers = load("res://addons/gut/version_numbers.gd")
 static var WarningsManager = load("res://addons/gut/warnings_manager.gd")
+static var EditorGlobals = load("res://addons/gut/gui/editor_globals.gd")
 # --------------------------------
 # Lazy loaded scripts.  These scripts are lazy loaded so that they can be
 # declared, but will not load when this script is loaded.  This gives us a

--- a/test/unit/test_gut_config.gd
+++ b/test/unit/test_gut_config.gd
@@ -1,42 +1,69 @@
-extends GutTest
+extends GutInternalTester
 
-var starting_log_level = 99
-func before_all():
-    starting_log_level = gut.log_level
+func _make_gut_config():
+	var gc = GutUtils.GutConfig.new()
+	gc.logger = GutUtils.Logger.new()
+	if(gut.log_level < 2):
+		gc.logger.disable_all_printers(true)
+	return gc
 
-func after_each():
-    gut.log_level = starting_log_level
-    gut.p(str('log level = ', gut.log_level))
-
-func after_all():
-    gut.log_level = starting_log_level
 
 func test_can_make_one():
-    var gc = GutUtils.GutConfig.new()
-    assert_not_null(gc)
+	var gc = GutUtils.GutConfig.new()
+	assert_not_null(gc)
+
 
 func test_double_strategy_defaults_to_include_native():
-    var gc = GutUtils.GutConfig.new()
-    assert_eq(gc.default_options.double_strategy, 'SCRIPT_ONLY')
+	var gc = GutUtils.GutConfig.new()
+	assert_eq(gc.default_options.double_strategy, 'SCRIPT_ONLY')
+
 
 func test_gut_gets_double_strategy_when_applied():
-    var gc = GutUtils.GutConfig.new()
-    var g = autofree(GutUtils.Gut.new())
-    g.log_level = gut.log_level
+	var gc = GutUtils.GutConfig.new()
+	var g = autofree(GutUtils.Gut.new())
+	g.log_level = gut.log_level
 
-    gc.options.double_strategy = GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY
-    gc.apply_options(g)
-    assert_eq(g.double_strategy, gc.options.double_strategy)
+	gc.options.double_strategy = GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY
+	gc.apply_options(g)
+	assert_eq(g.double_strategy, gc.options.double_strategy)
+
 
 func test_gut_gets_default_when_value_invalid():
-    var gc = GutUtils.GutConfig.new()
-    var g = autofree(GutUtils.Gut.new())
-    g.log_level = gut.log_level
+	var gc = GutUtils.GutConfig.new()
+	var g = autofree(GutUtils.Gut.new())
+	g.log_level = gut.log_level
 
-    g.double_strategy = GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY
-    gc.options.double_strategy = 'invalid value'
-    gc.apply_options(g)
-    assert_eq(g.double_strategy, GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY)
+	g.double_strategy = GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY
+	gc.options.double_strategy = 'invalid value'
+	gc.apply_options(g)
+	assert_eq(g.double_strategy, GutUtils.DOUBLE_STRATEGY.SCRIPT_ONLY)
 
-func test_another_thing():
-    assert_true(true)
+
+func test_errors_when_config_file_cannot_be_found():
+	var gc = _make_gut_config()
+	gc.load_options('res://some_file_that_dne.json')
+	assert_errored(gc, 1)
+
+
+func test_does_not_error_when_default_file_missing():
+	var gc = _make_gut_config()
+	gc.load_options('res://.gutconfig.json')
+	assert_errored(gc, 0)
+
+
+func test_does_not_error_when_default_editor_file_missing():
+	var gc = _make_gut_config()
+	gc.load_options(GutUtils.EditorGlobals.editor_run_gut_config_path)
+	assert_errored(gc, 0)
+
+
+func test_errors_when_file_cannot_be_parsed():
+	var gc = _make_gut_config()
+	gc.load_options('res://addons/gut/gut.gd')
+	assert_errored(gc)
+
+
+func test_errors_when_path_cannot_be_written_to():
+	var gc = _make_gut_config()
+	gc.write_options("user://some_path/that_does/not_exist/dot.json")
+	assert_errored(gc)


### PR DESCRIPTION
Changed the warning to only appear when a non-default config path is opened.  Fixes #592.