### PR TITLE
Fix docs typo

### DIFF
--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -69,7 +69,7 @@ If you pass a string then an error message will be printed and `double` will ret
 ### Doubling Inner Classes
 The `double` method no longer supports strings for the path of the base script or a string of the name of the Inner Class.  You must call `register_inner_classes` then pass the Inner Class to `double`.  You only have to do this once, so it is best to call it in `before_all` or a pre-hook script.  Registering multiple times does nothing.  Failing to call `register_inner_classes` will result in a GUT error and a runtime error.
 ```gdscript
-# Given that SomeScript contains the class InnerClass that you wish to to double:
+# Given that SomeScript contains the class InnerClass that you wish to double:
 var SomeScript = load('res://some_script.gd')
 
 func before_all():

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@
 # GUT 9.3.1 (Godot 4.2)
 GUT (Godot Unit Test) is a unit testing framework for the [Godot Engine](https://godotengine.org/).  It allows you to write tests for your gdscript in gdscript.
 
-GUT versions 9.x are for Godot 4.x
-GUT versions below 9.0.0 (currently 7.4.2) are for Godot 3.x
+GUT versions 9.x are for Godot 4.x.
+GUT versions below 9.0.0 (currently 7.4.2) are for Godot 3.x.
 
 
 # Features
 * Godot 4.0
-* [Simple install](https://gut.readthedocs.io/en/latest/Install.html) via the Asset Library.
-* A plethora of [asserts and utility methods](https://gut.readthedocs.io/en/latest/Asserts-and-Methods.html) to help make your tests simple and concise.
-* Support for [Inner Test Classes](https://gut.readthedocs.io/en/latest/Inner-Test-Classes.html) to give your tests some extra context and maintainability.
+* [Simple install](https://gut.readthedocs.io/en/latest/Install.html) via the Asset Library
+* A plethora of [asserts and utility methods](https://gut.readthedocs.io/en/latest/Asserts-and-Methods.html) to help make your tests simple and concise
+* Support for [Inner Test Classes](https://gut.readthedocs.io/en/latest/Inner-Test-Classes.html) to give your tests some extra context and maintainability
 * Doubling:  [Full](https://gut.readthedocs.io/en/latest/Doubles.html) and [Partial](https://gut.readthedocs.io/en/latest/Partial-Doubles.html), [Stubbing](https://gut.readthedocs.io/en/latest/Stubbing.html), [Spies](https://gut.readthedocs.io/en/latest/Spies.html)
 * Command Line Interface [(CLI)](https://gut.readthedocs.io/en/latest/Command-Line.html)
 * [Parameterized Tests](https://gut.readthedocs.io/en/latest/Parameterized-Tests.html)
-* [Export results](https://gut.readthedocs.io/en/latest/Export-Test-Results.html) in standard JUnit XML format.
+* [Export results](https://gut.readthedocs.io/en/latest/Export-Test-Results.html) in standard JUnit XML format
 
 More info can be found in the [wiki](https://github.com/bitwes/Gut/wiki).
 
@@ -47,7 +47,7 @@ Run your tests directly from the VSCode Editor.  Search VSCode extensions for "g
 
 
 # License
-Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`
+Gut is provided under the MIT license.  License is in `addons/gut/LICENSE.md`.
 
 
 ## [Tutorials](https://github.com/bitwes/Gut/wiki/Tutorials.html)

--- a/addons/gut/input_factory.gd
+++ b/addons/gut/input_factory.gd
@@ -1,5 +1,5 @@
 class_name GutInputFactory
-## Static class full of helper methods to make InputEvent instances
+## Static class full of helper methods to make InputEvent instances.
 ##
 ## This thing makes InputEvents.  Enjoy.
 
@@ -26,7 +26,7 @@ static func _to_scancode(which):
 	return key_code
 
 
-## Creates a new button with the properties given
+## Creates a new button with the given propoerties.
 static func new_mouse_button_event(position, global_position, pressed, button_index) -> InputEventMouseButton:
 	var event = InputEventMouseButton.new()
 	event.position = position

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -471,7 +471,7 @@ func set_double_strategy(double_strategy):
 ## [br]
 ## Sometimes you get lazy, and you don't remove calls to
 ## [code skip-lint]pause_before_teardown[/code] after you are done with them.  You can
-## tell GUT to ignore calls to to this method through the panel or
+## tell GUT to ignore calls to this method through the panel or
 ## the command line.  Setting this in your `.gutconfig.json` file is recommended
 ## for CI/CD Pipelines.
 func pause_before_teardown():

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -89,6 +89,7 @@ The class reference documentation generation toolkit wrapper script requires:
 Before generating class reference:
 * The project must have been opened in the editor or you have run an import (`godot --import`).  No xml files will be generated if not.
 * You must have created the docker image already, per the directions above.
+* The environment variable "GODOT" must be set to the godot executable.
 
 
 ## Execution

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -89,7 +89,7 @@ The class reference documentation generation toolkit wrapper script requires:
 Before generating class reference:
 * The project must have been opened in the editor or you have run an import (`godot --import`).  No xml files will be generated if not.
 * You must have created the docker image already, per the directions above.
-* The environment variable "GODOT" must be set to the godot executable.
+* The environment variable `GODOT` must be set to the godot executable.
 
 
 ## Execution

--- a/documentation/docs/Contributing.md
+++ b/documentation/docs/Contributing.md
@@ -30,7 +30,7 @@ If you don't see an existing directory that matches your needs then you can crea
 
 
 ### Running GUT Tests
-Due to the nature of using the tool to test the tool, there are some are pending or risky.  These ar ebeing cleaned up, but there might be some.  You should run all the tests once before developing to see see which currently exist.
+Due to the nature of using GUT to test GUT, some tests may not work as intended.  These are being cleaned up, but there may still be some left in the codebase.  You should run all the tests once before developing to see which tests are currently in use.
 
 Here's some common errors:
 

--- a/documentation/docs/Doubles.md
+++ b/documentation/docs/Doubles.md
@@ -52,7 +52,7 @@ Inner Classes cannot be automatically detected and therefore must be registered 
 
 ```gdscript
 # Given that SomeScript contains the class InnerClass that
-# you wish to to double:
+# you wish to double:
 var SomeScript = load('res://some_script.gd')
 
 func before_all():

--- a/documentation/docs/Memory-Management.md
+++ b/documentation/docs/Memory-Management.md
@@ -22,7 +22,7 @@ Quick Example:
 ``` gdscript
 func test_something():
   # add_child_autofree will add the result of SuperNeatNode.new to the tree,
-  # mark to to be freed after the test, and return the instance created by
+  # mark it to be freed after the test, and return the instance created by
   # SuperNeatNode.new().
   var my_node = add_child_autofree(SuperNeatNode.new())
   assert_not_null(my_node)

--- a/documentation/docs/New-For-Godot-4.md
+++ b/documentation/docs/New-For-Godot-4.md
@@ -61,7 +61,7 @@ If you pass a string then an error message will be printed and `double` will ret
 ### Doubling Inner Classes
 The `double` method no longer supports strings for the path of the base script or a string of the name of the Inner Class.  You must call `register_inner_classes` then pass the Inner Class to `double`.  You only have to do this once, so it is best to call it in `before_all` or a pre-hook script.  Registering multiple times does nothing.  Failing to call `register_inner_classes` will result in a GUT error and a runtime error.
 ```gdscript
-# Given that SomeScript contains the class InnerClass that you wish to to double:
+# Given that SomeScript contains the class InnerClass that you wish to double:
 var SomeScript = load('res://some_script.gd')
 
 func before_all():

--- a/documentation/docs/class_ref/class_gutinputfactory.rst
+++ b/documentation/docs/class_ref/class_gutinputfactory.rst
@@ -10,7 +10,7 @@ GutInputFactory
 
 **Inherits:** `RefCounted <https://docs.godotengine.org/en/stable/classes/class_refcounted.html>`_
 
-Static class full of helper methods to make InputEvent instances
+Static class full of helper methods to make InputEvent instances.
 
 .. rst-class:: classref-introduction-group
 
@@ -68,7 +68,7 @@ Method Descriptions
 
 `InputEventMouseButton <https://docs.godotengine.org/en/stable/classes/class_inputeventmousebutton.html>`_ **new_mouse_button_event**\ (\ position, global_position, pressed, button_index\ ) |static| :ref:`🔗<class_GutInputFactory_method_new_mouse_button_event>`
 
-Creates a new button with the properties given
+Creates a new button with the given propoerties.
 
 .. rst-class:: classref-item-separator
 

--- a/documentation/docs/class_ref/class_guttest.rst
+++ b/documentation/docs/class_ref/class_guttest.rst
@@ -586,7 +586,7 @@ Sets the double strategy for all tests in the script.  This should usually be do
 
 This method will cause Gut to pause before it moves on to the next test. This is useful for debugging, for instance if you want to investigate the screen or anything else after a test has finished executing. 
 
-Sometimes you get lazy, and you don't remove calls to ``pause_before_teardown`` after you are done with them.  You can tell GUT to ignore calls to to this method through the panel or the command line.  Setting this in your `.gutconfig.json` file is recommended for CI/CD Pipelines.
+Sometimes you get lazy, and you don't remove calls to ``pause_before_teardown`` after you are done with them.  You can tell GUT to ignore calls to this method through the panel or the command line.  Setting this in your `.gutconfig.json` file is recommended for CI/CD Pipelines.
 
 .. rst-class:: classref-item-separator
 

--- a/documentation/generate_rst.sh
+++ b/documentation/generate_rst.sh
@@ -44,11 +44,11 @@ function generate_xml(){
     # using gtimeout (which is mac version of timeout from coreutils) and then
     # kill it (-k 1s).
     case $OSTYPE in
-        linux-gnu)
-            timeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
-        ;;
-        darwin)
+        "darwin"*)
             gtimeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
+        ;;
+        *)
+            timeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
         ;;
     esac
 

--- a/documentation/generate_rst.sh
+++ b/documentation/generate_rst.sh
@@ -43,7 +43,14 @@ function generate_xml(){
     # soon (fixed merged after 4.3).  So we wait 2 seconds +1 seconds (-k 1s)
     # using gtimeout (which is mac version of timeout from coreutils) and then
     # kill it (-k 1s).
-    gtimeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
+    case $OSTYPE in
+        linux-gnu)
+            timeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
+        ;;
+        darwin)
+            gtimeout -k 1s 2s $GODOT --doctool $the_dir --no-docbase --gdscript-docs $scripts_dir
+        ;;
+    esac
 
     printdir $the_dir
 }


### PR DESCRIPTION
Just a few typos here and there, and one clarification of a sentence I thought was a little confusing to read.

I also added a small bit to the `generate_rst.sh` file so that I could build it on my linux machine (otherwise it would use the mac version of a command that I don't have here).