### PR TITLE
Add instructions for installing gut as a git submodule

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -3,7 +3,7 @@ Documentation is hosted at https://gut.readthedocs.io.
 
 The wiki is generated from three types of files:
 * RST:  This wiki site index (`index.rst`) is the only RST file that manually created.  All other RST files are generated from code comments.
-* Markdown:  The standalone pages of th wiki are all made in Markdown.
+* Markdown:  The standalone pages of the wiki are all made in Markdown.
 * Documentation Comments:  A modified version of Godot's code is used to generate RST files for GUT scripts and `class_names`.
 
 

--- a/documentation/docs/Install.md
+++ b/documentation/docs/Install.md
@@ -12,7 +12,6 @@ GUT is a Godot Plugin.  You can download it directly or install it from the Asse
 
 Finish the install by following the instructions in [Setup](#setup) below.
 
-
 ## Download and install
 Download the zip from the [releases](https://github.com/bitwes/gut/releases) or from the [Godot Asset Library](https://godotengine.org/asset-library/asset/54).
 
@@ -20,6 +19,16 @@ Extract the zip and place the `gut` directory into your `addons` directory in yo
 
 Finish the install by following the instructions in Setup below.
 
+## Installing as git submodule
+Because GUT is developed in the `res://addons/gut` directory of this project, resources in this repository are referenced as `res://addons/gut/...`. If this repository is installed as a git submodule in `res://addons`, those paths are now invalid, as the path to them would now be `res://addons/gut/addons/gut/...`.
+
+In order to install GUT as a git submodule, then, you can use a single symlink to keep all the resource paths in GUT valid. Follow these steps:
+1. Add GUT as a git submodule (`git submodule add https://github.com/bitwes/Gut.git <submodule location>`).
+2. Symlink GUT's source to your project's addons (`ln -s <submodule location>/addons/gut addons/gut`).
+
+Godot (as of version 4.4) will detect that the submodule contains a Godot project and will give a warning noting that it will not attempt to parse this folder (which also means that the submodule will not show up in Godot's file tree). However, because the symlink you've created goes into GUT's source and skips the project file, Godot will parse GUT's source and you can use it like normal.
+
+If you'd prefer not to see this warning, you can manually tell Godot not to parse the submodule by placing the submodule in a directory and adding an empty file named `.gdignore` in that directory.
 
 ## Setup
 ### Activate


### PR DESCRIPTION
In [506](https://github.com/bitwes/Gut/issues/506) it is discussed how to make it easier to use gut as a git submodule in projects. It seems the conclusion is that a single symlink does the trick, but this has not yet been added to the actual documentation. This PR adds instructions and explanations for this method to the installation section of the documentation.