### PR TITLE
fixed issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Bug Fixes
 * I192 in just under 5 years I moved the two lines of code up some to finally fix this.
+* I666 Using a doubled scene as the value of a property with type `PackedScene` could cause errors.
 
 # 9.3.1
 A small collection of bug fixes and documentation.  GUT can now generate documentation from code comments.

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -1,45 +1,6 @@
-# ------------------------------------------------------------------------------
-# A stroke of genius if I do say so.  This allows for doubling a scene without
-# having  to write any files.  By overloading the "instantiate" method  we can
-# make whatever we want.
-# ------------------------------------------------------------------------------
-class PackedSceneDouble:
-	extends PackedScene
-	var _script =  null
-	var _scene = null
-
-	func set_script_obj(obj):
-		_script = obj
-
-	@warning_ignore("native_method_override")
-	func instantiate(edit_state=0):
-		var inst = _scene.instantiate(edit_state)
-		var export_props = []
-		var script_export_flag = (PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE)
-
-		if(_script !=  null):
-			if(inst.get_script() != null):
-				# Get all the exported props and values so we can set them again
-				for prop in inst.get_property_list():
-					var is_export = prop.usage & (script_export_flag) == script_export_flag
-					if(is_export):
-						export_props.append([prop.name, inst.get(prop.name)])
-
-			inst.set_script(_script)
-			for exported_value in export_props:
-				inst.set(exported_value[0], exported_value[1])
-
-		return inst
-
-	func load_scene(path):
-		_scene = load(path)
+extends RefCounted
 
 
-
-
-# ------------------------------------------------------------------------------
-# START Doubler
-# ------------------------------------------------------------------------------
 var _base_script_text = GutUtils.get_file_as_text('res://addons/gut/double_templates/script_template.txt')
 var _script_collector = GutUtils.ScriptCollector.new()
 # used by tests for debugging purposes.
@@ -222,21 +183,27 @@ func _stub_method_default_values(which, parsed, strategy):
 			_stubber.stub_defaults_from_meta(parsed.script_path, method.meta)
 
 
-
 func _double_scene_and_script(scene, strategy, partial):
-	var to_return = PackedSceneDouble.new()
-	to_return.load_scene(scene.get_path())
-
+	var dbl_bundle = scene._bundled.duplicate(true)
 	var script_obj = GutUtils.get_scene_script_object(scene)
+	# I'm not sure if the script object for the root node of a packed scene is
+	# always the first entry in "variants" so this tries to find it.
+	var script_index = dbl_bundle["variants"].find(script_obj)
+	var script_dbl = null
+
 	if(script_obj != null):
-		var script_dbl = null
 		if(partial):
 			script_dbl = _partial_double(script_obj, strategy, scene.get_path())
 		else:
 			script_dbl = _double(script_obj, strategy, scene.get_path())
-		to_return.set_script_obj(script_dbl)
 
-	return to_return
+	if(script_index != -1):
+		dbl_bundle["variants"][script_index] = script_dbl
+
+	var doubled_scene = PackedScene.new()
+	doubled_scene._set_bundled_scene(dbl_bundle)
+
+	return doubled_scene
 
 
 func _get_inst_id_ref_str(inst):
@@ -299,12 +266,14 @@ func partial_double(obj, strategy=_strategy):
 func double_scene(scene, strategy=_strategy):
 	return _double_scene_and_script(scene, strategy, false)
 
+
 func partial_double_scene(scene, strategy=_strategy):
 	return _double_scene_and_script(scene, strategy, true)
 
 
 func double_gdnative(which):
 	return _double(which, GutUtils.DOUBLE_STRATEGY.INCLUDE_NATIVE)
+
 
 func partial_double_gdnative(which):
 	return _partial_double(which, GutUtils.DOUBLE_STRATEGY.INCLUDE_NATIVE)

--- a/test/resources/simple_scene.gd
+++ b/test/resources/simple_scene.gd
@@ -1,0 +1,13 @@
+extends Node2D
+## This is just a simple script for a simple scene.
+
+@export var this_is_different_in_scene := "default"
+@export var exported_string := 'This is an exported string'
+var public_string := 'this is a public string'
+
+
+func foo():
+	return "bar"
+
+func bar():
+	return "foo"

--- a/test/resources/simple_scene.tscn
+++ b/test/resources/simple_scene.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://cft5q1uqr1cic"]
+
+[ext_resource type="Script" path="res://test/resources/simple_scene.gd" id="1_83uy2"]
+[ext_resource type="Texture2D" uid="uid://biw60gwe1vv6w" path="res://images/gut_logo_256x256.png" id="1_epxcm"]
+
+[node name="SimpleScene" type="Node2D"]
+script = ExtResource("1_83uy2")
+this_is_different_in_scene = "not the default value"
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("1_epxcm")

--- a/test/unit/test_bugs/test_issue_SOTB.gd
+++ b/test/unit/test_bugs/test_issue_SOTB.gd
@@ -1,0 +1,61 @@
+extends GutTest
+
+
+var SimpleScene = load("res://test/resources/simple_scene.tscn")
+var SimpleSceneScript = load("res://test/resources/simple_scene.gd")
+
+class TheSpawner:
+	@export var spawn_resource : SpawnResource
+
+	func spawn():
+		var inst = spawn_resource.scene.instantiate()
+		inst.foo()
+		return inst
+
+
+class SpawnResource:
+	extends Resource
+
+	# The bug is that if this has a type of PackedScene it would error when
+	# you tried to use a doubled scene for this value.
+	@export var scene : PackedScene = null
+
+	func foo():
+		return "bar"
+
+
+
+func before_all():
+	register_inner_classes(get_script())
+
+
+func test_are_we_sure_scenes_can_be_doubled():
+	var DoubleSimpleScene = double(SimpleScene)
+	var inst = DoubleSimpleScene.instantiate()
+
+	assert_not_null(inst)
+	assert_has_method(inst, "foo")
+
+
+func test_can_use_a_double_of_a_scene_as_the_value_of_a_PackedScene_variable():
+	var DoubleSimpleScene = double(SimpleScene)
+	var res = SpawnResource.new()
+	res.scene = DoubleSimpleScene
+
+	var spawner = TheSpawner.new()
+	spawner.spawn_resource = res
+
+	var spawned = spawner.spawn()
+	assert_not_null(spawned)
+
+
+func test_can_use_a_double_of_a_scene_as_the_value_of_a_PackedScene_variable2():
+	var DoubleSimpleScene = double(SimpleScene)
+	var res = SpawnResource.new()
+	res.scene = DoubleSimpleScene
+
+	var spawner = TheSpawner.new()
+	spawner.spawn_resource = res
+
+	var spawned = spawner.spawn()
+	assert_ne(spawned.this_is_different_in_scene, "default")


### PR DESCRIPTION
Fixes #666 

Originally doubled scenes were created with super cool and witty programming.  Godot is getting better (worse?) at not calling overridden methods and would not call my super cool and witty code when a variable had a type of `PackedScene`.  This is probably because it knew enough to not call the method in the script since it had a type.  The new approach for creating a doubled scene is a lot more straight forward and gets around the issues the witty code was causing.