### PR TITLE
Refactor wait methods

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -7,7 +7,7 @@
     "res://test/integration/"
   ],
   "should_exit": true,
-  "log_level": 3,
+  "log_level": 1,
   "hide_orphans": false,
 
   "should_exit_on_success": false,

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -7,7 +7,7 @@
     "res://test/integration/"
   ],
   "should_exit": true,
-  "log_level": 1,
+  "log_level": 3,
   "hide_orphans": false,
 
   "should_exit_on_success": false,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * I192 in just under 5 years I moved the two lines of code up some to finally fix this.
 * I666 Using a doubled scene as the value of a property with type `PackedScene` could cause errors.
 
+
+
+
 # 9.3.1
 A small collection of bug fixes and documentation.  GUT can now generate documentation from code comments.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # 9.4.0
 
+## Potentially Breaking Changes
+* The deprecated `wait_frames` and the new `wait_idle_frames`, `wait_physics_frames` now count frames when the `SceneTree.process_frame` and `SceneTree.physics_frame` signals are emitted.  This may cause some of your awaits to wait a frame too long/short.  This approach is more reliable as it occurs before the `_process` or `_physics_process` is called on anything in the tree.  This means that tree order will not matter and all objects will have finished `_process`/`_physics_process` by the time the await ends.
+
+
 ## Features
 * Utilized the adapted Godot tools that generate HTML from code comments, moving some documentation to code comments.  This makes more documentation easily accessible from the editor and cuts down on some duplicate documentation.
-* `wait_process_frames` added.  This counts frames in `_process` instead of `_physics_process`.  `wait_frames` has been renamed (deprecated) to `wait_physics_frames`.
+* `wait_idle_frames` added.  This counts frames idle/process frames instead of `_physics_process`.  `wait_frames` has been renamed (deprecated) to `wait_physics_frames`.
 * New `class_name`s:
   * `GutInputFactory` for `res://addons/gut/gut_input_factory.gd` static class.
 
@@ -16,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * I666 Using a doubled scene as the value of a property with type `PackedScene` could cause errors.
 
 
+## Deprecations
+* `wait_frames` has been deprecated in lieu of the more specific `wait_physics_frames` and `wait_idle_frames`.
 
 
 # 9.3.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Features
 * Utilized the adapted Godot tools that generate HTML from code comments, moving some documentation to code comments.  This makes more documentation easily accessible from the editor and cuts down on some duplicate documentation.
+* `wait_process_frames` added.  This counts frames in `_process` instead of `_physics_process`.  `wait_frames` has been renamed (deprecated) to `wait_physics_frames`.
 * New `class_name`s:
   * `GutInputFactory` for `res://addons/gut/gut_input_factory.gd` static class.
+
 
 ## Bug Fixes
 * I192 in just under 5 years I moved the two lines of code up some to finally fix this.

--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -30,11 +30,11 @@ await yield_to(signaler, 'the_signal_name', 5, 'optional message')
 await yield_for(1.5, 'optional message')
 await yield_frames(30, 'optional message')
 ```
-* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_frames`, and `wait_for_signal`.
+* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_process_frames`, `wait_physics_frames`, and `wait_for_signal`.
 ```gdscript
 await wait_for_signal(signaler.the_signal, 5, 'optional message') # wait for signal or 5 seconds
 await wait_seconds(1.5, 'optional message')
-await wait_frames(30, 'optional message')
+await wait_physics_frames(30, 'optional message')
 ```
 * Doubling no longer supports paths to a script or scene.  Load the script or scene first and pass that to `double`.  See the "Doubling Changes" section for more details.
 * Doubling Inner Classes now requires you to call `register_inner_classes` first.  See the "Doubling Changes" sedtion for more details.

--- a/GODOT_4_README.md
+++ b/GODOT_4_README.md
@@ -30,7 +30,7 @@ await yield_to(signaler, 'the_signal_name', 5, 'optional message')
 await yield_for(1.5, 'optional message')
 await yield_frames(30, 'optional message')
 ```
-* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_process_frames`, `wait_physics_frames`, and `wait_for_signal`.
+* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_idle_frames`, `wait_physics_frames`, and `wait_for_signal`.
 ```gdscript
 await wait_for_signal(signaler.the_signal, 5, 'optional message') # wait for signal or 5 seconds
 await wait_seconds(1.5, 'optional message')

--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -83,6 +83,7 @@ func _signal_callback(
 	# signal_watcher doesn't get the signal in time if we don't do this.
 	_wait_physics_frames = 2
 
+
 func wait_seconds(x):
 	_did_last_wait_timeout = false
 	_wait_time = x
@@ -99,7 +100,6 @@ func wait_physics_frames(x):
 	_did_last_wait_timeout = false
 	_wait_physics_frames = x
 	wait_started.emit()
-
 
 
 func wait_for_signal(the_signal, max_time):

--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -22,6 +22,9 @@ var _elapsed_frames := 0
 
 
 func _process(_delta: float) -> void:
+	# TODO:  The `process_frame` signal on SceneTree fires before _process
+	# is called (same for physics_frame).  It might be more consistent to
+	# connect to that signal and increment then.
 	if(_wait_process_frames > 0):
 		_elapsed_frames += 1
 		if(_elapsed_frames >= _wait_process_frames):

--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -4,7 +4,7 @@ signal timeout
 signal wait_started
 
 var _wait_time := 0.0
-var _wait_idle_frames := 0
+var _wait_process_frames := 0
 var _wait_physics_frames := 0
 var _signal_to_wait_on = null
 
@@ -22,9 +22,9 @@ var _elapsed_frames := 0
 
 
 func _process(_delta: float) -> void:
-	if(_wait_idle_frames > 0):
+	if(_wait_process_frames > 0):
 		_elapsed_frames += 1
-		if(_elapsed_frames >= _wait_idle_frames):
+		if(_elapsed_frames >= _wait_process_frames):
 			_end_wait()
 
 
@@ -55,13 +55,13 @@ func _end_wait():
 		_did_last_wait_timeout = _elapsed_time >= _wait_time
 	elif(_wait_physics_frames > 0):
 		_did_last_wait_timeout = _elapsed_frames >= _wait_physics_frames
-	elif(_wait_idle_frames > 0):
-		_did_last_wait_timeout = _elapsed_frames >= _wait_idle_frames
+	elif(_wait_process_frames > 0):
+		_did_last_wait_timeout = _elapsed_frames >= _wait_process_frames
 
 	if(_signal_to_wait_on != null and _signal_to_wait_on.is_connected(_signal_callback)):
 		_signal_to_wait_on.disconnect(_signal_callback)
 
-	_wait_idle_frames = 0
+	_wait_process_frames = 0
 	_wait_time = 0.0
 	_wait_physics_frames = 0
 	_signal_to_wait_on = null
@@ -90,9 +90,9 @@ func wait_seconds(x):
 	wait_started.emit()
 
 
-func wait_idle_frames(x):
+func wait_process_frames(x):
 	_did_last_wait_timeout = false
-	_wait_idle_frames = x
+	_wait_process_frames = x
 	wait_started.emit()
 
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2028,37 +2028,56 @@ func wait_for_signal(sig : Signal, max_wait, msg=''):
 ## @deprecated
 ## Use wait_physics_frames or wait_process_frames
 ## See [wiki]Awaiting[/wiki]
-func wait_frames(frames, msg=''):
+func wait_frames(frames : int, msg=''):
 	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  " +
 		"wait_process_frames has also been added which is counted in _process.")
 	return wait_physics_frames(frames, msg)
 
 
-## Use this with await to pause execution for a number of physics frames
-## (counted in _physics_process).
+## This returns a signal that is emitted after [code]x[/code] physics frames have
+## elpased.  You can await this method directly to pause execution for [code]x[/code]
+## physics frames.  The frames are counted prior to _physics_process being called
+## on any node (when [signal SceneTree.physics_frame] is emitted).  This means the
+## signal is emitted after [code]x[/code] frames and just before the x + 1 frame starts.
+## [codeblock]
+## await wait_physics_frames(10)
+## [/codeblock]
 ## See [wiki]Awaiting[/wiki]
-func wait_physics_frames(frames, msg=''):
-	if(frames <= 0):
-		var text = str('wait_physics_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
+func wait_physics_frames(x :int , msg=''):
+	if(x <= 0):
+		var text = str('wait_physics_frames:  frames must be > 0, you passed  ', x, '.  1 frames waited.')
 		_lgr.error(text)
-		frames = 1
+		x = 1
 
-	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
-	_awaiter.wait_physics_frames(frames)
+	_lgr.yield_msg(str('-- Awaiting ', x, ' frame(s) -- ', msg))
+	_awaiter.wait_physics_frames(x)
 	return _awaiter.timeout
 
 
-## Use this with await to pause execution for a number of idle/process frames
-## (counted in _process(delta))
-## See [wiki]Awaiting[/wiki]
-func wait_process_frames(frames, msg=''):
-	if(frames <= 0):
-		var text = str('wait_process_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
-		_lgr.error(text)
-		frames = 1
+## Alias for [method GutTest.wait_process_frames]
+func wait_idle_frames(x : int, msg=''):
+	wait_process_frames(x, msg)
 
-	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
-	_awaiter.wait_process_frames(frames)
+
+## This returns a signal that is emitted after [code]x[/code] process/idle frames have
+## elpased.  You can await this method directly to pause execution for [code]x[/code]
+## process/idle frames.  The frames are counted prior to _process being called
+## on any node (when [signal SceneTree.process_frame] is emitted).  This means the
+## signal is emitted after [code]x[/code] frames and just before the x + 1 frame starts.
+## [codeblock]
+## await wait_process_frames(10)
+## # wait_idle_frames is an alias of wait_process_frames
+## await wait_idle_frames(10)
+## [/codeblock]
+## See [wiki]Awaiting[/wiki]
+func wait_process_frames(x : int, msg=''):
+	if(x <= 0):
+		var text = str('wait_process_frames:  frames must be > 0, you passed  ', x, '.  1 frames waited.')
+		_lgr.error(text)
+		x = 1
+
+	_lgr.yield_msg(str('-- Awaiting ', x, ' frame(s) -- ', msg))
+	_awaiter.wait_process_frames(x)
 	return _awaiter.timeout
 
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2056,7 +2056,7 @@ func wait_physics_frames(x :int , msg=''):
 
 ## Alias for [method GutTest.wait_process_frames]
 func wait_idle_frames(x : int, msg=''):
-	wait_process_frames(x, msg)
+	return wait_process_frames(x, msg)
 
 
 ## This returns a signal that is emitted after [code]x[/code] process/idle frames have

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2025,14 +2025,18 @@ func wait_for_signal(sig : Signal, max_wait, msg=''):
 	return !_awaiter.did_last_wait_timeout
 
 
-## Use with await to wait a number of frames.  The optional message will be
-## printed[br]
+## @deprecated
+## Use wait_physics_frames or wait_process_frames
 ## See [wiki]Awaiting[/wiki]
 func wait_frames(frames, msg=''):
-	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  wait_process_frames has also been added which is counted in _process.")
+	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  " +
+		"wait_process_frames has also been added which is counted in _process.")
 	return wait_physics_frames(frames, msg)
 
 
+## Use this with await to pause execution for a number of physics frames
+## (counted in _physics_process).
+## See [wiki]Awaiting[/wiki]
 func wait_physics_frames(frames, msg=''):
 	if(frames <= 0):
 		var text = str('wait_physics_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
@@ -2044,6 +2048,9 @@ func wait_physics_frames(frames, msg=''):
 	return _awaiter.timeout
 
 
+## Use this with await to pause execution for a number of idle/process frames
+## (counted in _process(delta))
+## See [wiki]Awaiting[/wiki]
 func wait_process_frames(frames, msg=''):
 	if(frames <= 0):
 		var text = str('wait_process_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
@@ -2053,7 +2060,6 @@ func wait_process_frames(frames, msg=''):
 	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
 	_awaiter.wait_process_frames(frames)
 	return _awaiter.timeout
-
 
 
 ## Use with await to wait for the passed in callable to return true or a maximum

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2049,7 +2049,7 @@ func wait_physics_frames(x :int , msg=''):
 		_lgr.error(text)
 		x = 1
 
-	_lgr.yield_msg(str('-- Awaiting ', x, ' frame(s) -- ', msg))
+	_lgr.yield_msg(str('-- Awaiting ', x, ' physics frame(s) -- ', msg))
 	_awaiter.wait_physics_frames(x)
 	return _awaiter.timeout
 
@@ -2076,7 +2076,7 @@ func wait_process_frames(x : int, msg=''):
 		_lgr.error(text)
 		x = 1
 
-	_lgr.yield_msg(str('-- Awaiting ', x, ' frame(s) -- ', msg))
+	_lgr.yield_msg(str('-- Awaiting ', x, ' idle frame(s) -- ', msg))
 	_awaiter.wait_process_frames(x)
 	return _awaiter.timeout
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2029,7 +2029,7 @@ func wait_for_signal(sig : Signal, max_wait, msg=''):
 ## printed[br]
 ## See [wiki]Awaiting[/wiki]
 func wait_frames(frames, msg=''):
-	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  wait_idle_frames has also been added which is counted in _process.")
+	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  wait_process_frames has also been added which is counted in _process.")
 	return wait_physics_frames(frames, msg)
 
 
@@ -2044,14 +2044,14 @@ func wait_physics_frames(frames, msg=''):
 	return _awaiter.timeout
 
 
-func wait_idle_frames(frames, msg=''):
+func wait_process_frames(frames, msg=''):
 	if(frames <= 0):
-		var text = str('wait_idle_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
+		var text = str('wait_process_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
 		_lgr.error(text)
 		frames = 1
 
 	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
-	_awaiter.wait_idle_frames(frames)
+	_awaiter.wait_process_frames(frames)
 	return _awaiter.timeout
 
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2029,14 +2029,31 @@ func wait_for_signal(sig : Signal, max_wait, msg=''):
 ## printed[br]
 ## See [wiki]Awaiting[/wiki]
 func wait_frames(frames, msg=''):
+	_lgr.deprecated("wait_frames has been replaced with wait_physics_frames which is counted in _physics_process.  wait_idle_frames has also been added which is counted in _process.")
+	return wait_physics_frames(frames, msg)
+
+
+func wait_physics_frames(frames, msg=''):
 	if(frames <= 0):
-		var text = str('wait_frames:  frames must be > 0, you passed  ', frames, '.  0 frames waited.')
+		var text = str('wait_physics_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
 		_lgr.error(text)
 		frames = 1
 
 	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
-	_awaiter.wait_frames(frames)
+	_awaiter.wait_physics_frames(frames)
 	return _awaiter.timeout
+
+
+func wait_idle_frames(frames, msg=''):
+	if(frames <= 0):
+		var text = str('wait_idle_frames:  frames must be > 0, you passed  ', frames, '.  1 frames waited.')
+		_lgr.error(text)
+		frames = 1
+
+	_lgr.yield_msg(str('-- Awaiting ', frames, ' frame(s) -- ', msg))
+	_awaiter.wait_idle_frames(frames)
+	return _awaiter.timeout
+
 
 
 ## Use with await to wait for the passed in callable to return true or a maximum

--- a/documentation/docs/Awaiting.md
+++ b/documentation/docs/Awaiting.md
@@ -3,7 +3,8 @@ If you aren't sure about coroutines and using `await`, [Godot explains it pretty
 
 You can use `await` with any of the following methods to pause execution for a duration or until something occurs.  You can find more information about each method below, and in the `GutTest` documentation.
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-seconds">wait_seconds</a>:  Waits x seconds.
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_frames</a>:  Waits x frames (physics frames).
+ * <a href="class_ref/class_guttest.html#class-guttest-method-wait-process-frames">wait_process_frames</a>:  Waits x process frames(_process(delta)).
+ * <a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">wait_physics_frames</a>:  Waits x physics frames(_physics_process(delta)).
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">wait_for_signal</a>:  Waits until a signal is emitted, or a maximum amount of time.
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-until">wait_until</a>:   Waits until a `Callable` returns `true` or a maximum amount of time.
  * `pause_before_teardown`:  can be called in a test to pause execution at the end of a test, before moving on to the next test or ending the run.
@@ -26,23 +27,31 @@ await wait_seconds(2.8)
 await wait_secondes(.25, "waiting for a short period")
 ```
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_frames</a>
+## <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_physics_frames</a>
 ``` gdscript
-wait_frames(frames, msg=''):
+wait_physics_frames(frames, msg=''):
 ```
 
-This is just like `wait_seconds` but instead of counting seconds it counts frames.  Due to order of operations, this may wait +/- 1 frames, but sholdn't ever be 0.  This can be very useful if you use `call_deferred` in any of the objects under test, or need to wait a frame or two for `_process` to run.
+This is just like `wait_seconds` but instead of counting seconds it counts physics frames.  Due to order of operations, this may wait +/- 1 frames, but sholdn't ever be 0.  This can be very useful if you use `call_deferred` in any of the objects under test, or need to wait a frame or two for `_process` to run.
 
 The internal frame counter is incremented in `_process_physics`.
 
 The optional `msg` parameter is logged so you know why test execution is paused.
 ``` gdscript
 # wait 2 frames before continue test execution
-await wait_frames(2)
+await wait_physics_frames(2)
 
 # wait's some frames and includes optional message
-await wait_frames(20) # waiting some frames.
+await wait_physics_frames(20) # waiting some frames.
 ```
+
+## <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_process_frames</a>
+``` gdscript
+wait_process_frames(frames, msg=''):
+```
+
+This is just like `wait_physics_frames` except frames are counted in `_process` instead of `_physics_process`.
+
 
 ## <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">wait_for_signal</a>
 ``` gdscript

--- a/documentation/docs/Awaiting.md
+++ b/documentation/docs/Awaiting.md
@@ -1,18 +1,19 @@
 # Awaiting
-If you aren't sure about coroutines and using `await`, [Godot explains it pretty well](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#awaiting-for-signals-or-coroutines).  GUT supports coroutines, so you can `await` at anytime in your tests.  GUT also provides some handy methods to make awaiting in your tests a little easier.
+If you aren't sure about coroutines and using `await`, [Godot explains it pretty well](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#awaiting-signals-or-coroutines).  GUT supports coroutines, so you can `await` at anytime in your tests.  GUT also provides some handy methods to make awaiting in your tests a little easier.
 
 You can use `await` with any of the following methods to pause execution for a duration or until something occurs.  You can find more information about each method below, and in the `GutTest` documentation.
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-seconds">wait_seconds</a>:  Waits x seconds.
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-idle-frames">wait_idle_frames</a>:  Waits x process frames(_process(delta)).
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">wait_physics_frames</a>:  Waits x physics frames(_physics_process(delta)).
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">wait_for_signal</a>:  Waits until a signal is emitted, or a maximum amount of time.
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-until">wait_until</a>:   Waits until a `Callable` returns `true` or a maximum amount of time.
+ * `wait_seconds`:  Waits x seconds.
+ * `wait_idle_frames`:  Waits x process frames(_process(delta)).
+ * `wait_physics_frames`:  Waits x physics frames(_physics_process(delta)).
+ * `wait_for_signal`:  Waits until a signal is emitted, or a maximum amount of time.
+ * `wait_until`:   Waits until a `Callable` returns `true` or a maximum amount of time.
  * `pause_before_teardown`:  can be called in a test to pause execution at the end of a test, before moving on to the next test or ending the run.
 
 Calling `await` without using one of GUT's "wait" methods is discouraged.  When you use these methods, GUT provides output to indicate that execution is paused.  If you don't use them it can look like your tests have stopped running.
 
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-seconds">wait_seconds</a>
+## wait_seconds
+<a href="class_ref/class_guttest.html#class-guttest-method-wait-seconds">GutTest.wait_seconds</a>
 ``` gdscript
 wait_seconds(time, msg=''):
 ```
@@ -27,33 +28,45 @@ await wait_seconds(2.8)
 await wait_secondes(.25, "waiting for a short period")
 ```
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">wait_physics_frames</a>
+## wait_physics_frames
+<a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">GutTest.wait_physics_frames</a>
 ``` gdscript
 wait_physics_frames(frames, msg=''):
 ```
-
-This is just like `wait_seconds` but instead of counting seconds it counts physics frames.  Due to order of operations, this may wait +/- 1 frames, but sholdn't ever be 0.  This can be very useful if you use `call_deferred` in any of the objects under test, or need to wait a frame or two for `_process` to run.
-
-The internal frame counter is incremented in `_process_physics`.
+This returns a signal that is emitted after `x` physics frames have
+elpased.  You can await this method directly to pause execution for `x`
+physics frames.  The frames are counted prior to _physics_process being called
+on any node (when [signal SceneTree.physics_frame] is emitted).  This means the
+signal is emitted after `x` frames and just before the x + 1 frame starts.
+```
+await wait_physics_frames(10)
+```
 
 The optional `msg` parameter is logged so you know why test execution is paused.
 ``` gdscript
 # wait 2 frames before continue test execution
 await wait_physics_frames(2)
 
-# wait's some frames and includes optional message
-await wait_physics_frames(20) # waiting some frames.
+# waits some frames and includes optional message
+await wait_physics_frames(20, 'waiting some frames.')
 ```
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-idle-frames">wait_idle_frames</a>
-``` gdscript
-wait_idle_frames(frames, msg=''):
+## wait_idle_frames
+<a href="class_ref/class_guttest.html#class-guttest-method-wait-idle-frames">GutTest.wait_idle_frames</a>
+```gdscript
+await wait_idle_frames(10)
+# wait_process_frames is an alias of wait_idle_frames
+await wait_process_frames(10)
 ```
+This returns a signal that is emitted after `x` process/idle frames have
+elpased.  You can await this method directly to pause execution for `x`
+process/idle frames.  The frames are counted prior to _process being called
+on any node (when [signal SceneTree.process_frame] is emitted).  This means the
+signal is emitted after `x` frames and just before the x + 1 frame starts.
 
-This is just like `wait_physics_frames` except frames are counted in `_process` instead of `_physics_process`.
 
-
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">wait_for_signal</a>
+## wait_for_signal
+ <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">GutTest.wait_for_signal</a>
 ``` gdscript
 wait_for_signal(sig, max_wait, msg=''):
 ```
@@ -77,7 +90,8 @@ assert_true(await wait_for_signal(my_object.my_signal, 2),
 ```
 
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-until">wait_until</a>
+## wait_until
+<a href="class_ref/class_guttest.html#class-guttest-method-wait-until">GutTest.wait_until</a>
 ``` gdscript
 wait_until(callable, max_wait, p3='', p4=''):
 ```
@@ -106,4 +120,6 @@ assert_true(await wait_until(everything_is_ok, 10, 1),
 ```
 
 ## pause_before_teardown
+<a href="class_ref/class_guttest.html#class-guttest-method-pause-before-teardown">GutTest.pause_before_teardown</a>
+
 Sometimes, as you are developing your tests you may want to verify something before the any of the teardown methods are called or just look at things a bit.  If you call `pause_before_teardown()` anywhere in your test then GUT will pause execution until you press the "Continue" button in the GUT GUI.  You can also specify an option to ignore all calls to `pause_before_teardown` through the GUT Panel, command line, or `.gutconfig` in case you get lazy and don't want to remove them.  You should always remove them, but I know you won't because I didn't, so I made that an option.

--- a/documentation/docs/Awaiting.md
+++ b/documentation/docs/Awaiting.md
@@ -3,7 +3,7 @@ If you aren't sure about coroutines and using `await`, [Godot explains it pretty
 
 You can use `await` with any of the following methods to pause execution for a duration or until something occurs.  You can find more information about each method below, and in the `GutTest` documentation.
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-seconds">wait_seconds</a>:  Waits x seconds.
- * <a href="class_ref/class_guttest.html#class-guttest-method-wait-process-frames">wait_process_frames</a>:  Waits x process frames(_process(delta)).
+ * <a href="class_ref/class_guttest.html#class-guttest-method-wait-idle-frames">wait_idle_frames</a>:  Waits x process frames(_process(delta)).
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">wait_physics_frames</a>:  Waits x physics frames(_physics_process(delta)).
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-for-signal">wait_for_signal</a>:  Waits until a signal is emitted, or a maximum amount of time.
  * <a href="class_ref/class_guttest.html#class-guttest-method-wait-until">wait_until</a>:   Waits until a `Callable` returns `true` or a maximum amount of time.
@@ -27,7 +27,7 @@ await wait_seconds(2.8)
 await wait_secondes(.25, "waiting for a short period")
 ```
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_physics_frames</a>
+## <a href="class_ref/class_guttest.html#class-guttest-method-wait-physics-frames">wait_physics_frames</a>
 ``` gdscript
 wait_physics_frames(frames, msg=''):
 ```
@@ -45,9 +45,9 @@ await wait_physics_frames(2)
 await wait_physics_frames(20) # waiting some frames.
 ```
 
-## <a href="class_ref/class_guttest.html#class-guttest-method-wait-frames">wait_process_frames</a>
+## <a href="class_ref/class_guttest.html#class-guttest-method-wait-idle-frames">wait_idle_frames</a>
 ``` gdscript
-wait_process_frames(frames, msg=''):
+wait_idle_frames(frames, msg=''):
 ```
 
 This is just like `wait_physics_frames` except frames are counted in `_process` instead of `_physics_process`.

--- a/documentation/docs/New-For-Godot-4.md
+++ b/documentation/docs/New-For-Godot-4.md
@@ -22,7 +22,7 @@ await yield_to(signaler, 'the_signal_name', 5, 'optional message')
 await yield_for(1.5, 'optional message')
 await yield_frames(30, 'optional message')
 ```
-* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_process_frames`, `wait_physics_frames`, and `wait_for_signal`.
+* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_idle_frames`, `wait_physics_frames`, and `wait_for_signal`.
 ```gdscript
 await wait_for_signal(signaler.the_signal, 5, 'optional message') # wait for signal or 5 seconds
 await wait_seconds(1.5, 'optional message')

--- a/documentation/docs/New-For-Godot-4.md
+++ b/documentation/docs/New-For-Godot-4.md
@@ -3,7 +3,7 @@ These are changes to Godot that affect how GUT is used/implemented.  There is mo
 
 * `setget` has been replaced with a completely new syntax.  More info at [#380](https://github.com/bitwes/Gut/issues/380).  Examples of the new way and the new `assert_property` method below.
 * `connect` has been significantly altered.  The signal related asserts will likely change to use `Callable` parameters instead of strings.  It is possible to use strings, so this may remain in some form.  More info in [#383](https://github.com/bitwes/Gut/issues/383).
-* `yield` has been replaced with `await`.  `yield_to`, `yield_for`, and `yield_frames` have been deprecated, the new methods are `wait_seconds`, `wait_frames` and `wait_for_signal`.  There are examples below and more info at [#382](https://github.com/bitwes/Gut/issues/382).
+* `yield` has been replaced with `await`.  `yield_to`, `yield_for`, and `yield_frames` have been deprecated, the new methods are below.
 * Arrays are pass by reference now.
 * Dictionaries are compared by value now.
 * `File` and `Directory` have been replaced with `FileAccess` and `DirAccess`.
@@ -22,11 +22,11 @@ await yield_to(signaler, 'the_signal_name', 5, 'optional message')
 await yield_for(1.5, 'optional message')
 await yield_frames(30, 'optional message')
 ```
-* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_frames`, and `wait_for_signal`.
+* The replacement methods for the various `yield_` methods are `wait_seconds`, `wait_process_frames`, `wait_physics_frames`, and `wait_for_signal`.
 ```gdscript
 await wait_for_signal(signaler.the_signal, 5, 'optional message') # wait for signal or 5 seconds
 await wait_seconds(1.5, 'optional message')
-await wait_frames(30, 'optional message')
+await wait_physics_frames(30, 'optional message')
 ```
 * Doubling no longer supports paths to a script or scene.  Load the script or scene first and pass that to `double`.  See the "Doubling Changes" section for more details.
 * Doubling Inner Classes now requires you to call `register_inner_classes` first.  See the "Doubling Changes" section for more details.

--- a/documentation/docs/Quick-Start.md
+++ b/documentation/docs/Quick-Start.md
@@ -204,9 +204,13 @@ You can `await` to a signal or an amount of time, whichever comes first with `wa
 var my_obj = load('res://my_obj.gd').new()
 await wait_for_signal(my_obj.some_signal, 3)
 ```
-You can also `await` for a number of frames using `wait_frames`.  It's best to wait at least 2 frames as waiting one frame can be flaky.
+You can also `await` for a number of physics frames using `wait_physics_frames`.  It's best to wait at least 2 frames as waiting one frame can be flaky.
+```gdscript
+await wait_physics_frames(5)
 ```
-await wait_frames(5)
+Or a number of idle/process frames using `wait_process_frames`.
+```gdscript
+await wait_process_frames(10)
 ```
 
 ## Leak Testing and Memory Management

--- a/documentation/docs/class_ref/class_guttest.rst
+++ b/documentation/docs/class_ref/class_guttest.rst
@@ -241,7 +241,9 @@ Methods
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_for_signal<class_GutTest_method_wait_for_signal>`\ (\ sig\: `Signal <https://docs.godotengine.org/en/stable/classes/class_signal.html>`_, max_wait, msg = ""\ )                                                                                       |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_frames<class_GutTest_method_wait_frames>`\ (\ frames, msg = ""\ )                                                                                                                                                                                     |
+   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_physics_frames<class_GutTest_method_wait_physics_frames>`\ (\ frames, msg = ""\ )                                                                                                                                                                     |
+   +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_process_frames<class_GutTest_method_wait_process_frames>`\ (\ frames, msg = ""\ )                                                                                                                                                                     |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_seconds<class_GutTest_method_wait_seconds>`\ (\ time, msg = ""\ )                                                                                                                                                                                     |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -263,6 +265,8 @@ Methods
    | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_scene<class_GutTest_method_double_scene>`\ (\ path, strategy = null\ )                                                     |
    +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
    | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_script<class_GutTest_method_double_script>`\ (\ path, strategy = null\ )                                                   |
+   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_frames<class_GutTest_method_wait_frames>`\ (\ frames, msg = ""\ )                                                            |
    +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
    | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_for<class_GutTest_method_yield_for>`\ (\ time, msg = ""\ )                                                                  |
    +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -1956,9 +1960,33 @@ See `Awaiting <../Awaiting.html>`__
 
 `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_frames>`
 
-Use with await to wait a number of frames.  The optional message will be printed
+**Deprecated:** This method may be changed or removed in future versions.
 
-See `Awaiting <../Awaiting.html>`__
+Use wait_physics_frames or wait_process_frames See `Awaiting <../Awaiting.html>`__
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_GutTest_method_wait_physics_frames:
+
+.. rst-class:: classref-method
+
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_physics_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_physics_frames>`
+
+Use this with await to pause execution for a number of physics frames (counted in _physics_process). See `Awaiting <../Awaiting.html>`__
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_GutTest_method_wait_process_frames:
+
+.. rst-class:: classref-method
+
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_process_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_process_frames>`
+
+Use this with await to pause execution for a number of idle/process frames (counted in _process(delta)) See `Awaiting <../Awaiting.html>`__
 
 .. rst-class:: classref-item-separator
 

--- a/documentation/docs/class_ref/class_guttest.rst
+++ b/documentation/docs/class_ref/class_guttest.rst
@@ -241,9 +241,11 @@ Methods
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_for_signal<class_GutTest_method_wait_for_signal>`\ (\ sig\: `Signal <https://docs.godotengine.org/en/stable/classes/class_signal.html>`_, max_wait, msg = ""\ )                                                                                       |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_physics_frames<class_GutTest_method_wait_physics_frames>`\ (\ frames, msg = ""\ )                                                                                                                                                                     |
+   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_idle_frames<class_GutTest_method_wait_idle_frames>`\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ )                                                                                                       |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_process_frames<class_GutTest_method_wait_process_frames>`\ (\ frames, msg = ""\ )                                                                                                                                                                     |
+   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_physics_frames<class_GutTest_method_wait_physics_frames>`\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ )                                                                                                 |
+   +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_process_frames<class_GutTest_method_wait_process_frames>`\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ )                                                                                                 |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_seconds<class_GutTest_method_wait_seconds>`\ (\ time, msg = ""\ )                                                                                                                                                                                     |
    +--------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -255,25 +257,25 @@ Methods
 .. table::
    :widths: auto
 
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | |void|                                                                         | :ref:`assert_call_count<class_GutTest_method_assert_call_count>`\ (\ inst, method_name, expected_count, parameters = null\ )            |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | |void|                                                                         | :ref:`assert_setget<class_GutTest_method_assert_setget>`\ (\ instance, name_property, const_or_setter = null, getter = "__not_set__"\ ) |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_inner<class_GutTest_method_double_inner>`\ (\ path, subpath, strategy = null\ )                                            |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_scene<class_GutTest_method_double_scene>`\ (\ path, strategy = null\ )                                                     |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_script<class_GutTest_method_double_script>`\ (\ path, strategy = null\ )                                                   |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_frames<class_GutTest_method_wait_frames>`\ (\ frames, msg = ""\ )                                                            |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_for<class_GutTest_method_yield_for>`\ (\ time, msg = ""\ )                                                                  |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_frames<class_GutTest_method_yield_frames>`\ (\ frames, msg = ""\ )                                                          |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_to<class_GutTest_method_yield_to>`\ (\ obj, signal_name, max_wait, msg = ""\ )                                              |
-   +------------+--------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | |void|                                                                         | :ref:`assert_call_count<class_GutTest_method_assert_call_count>`\ (\ inst, method_name, expected_count, parameters = null\ )                          |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | |void|                                                                         | :ref:`assert_setget<class_GutTest_method_assert_setget>`\ (\ instance, name_property, const_or_setter = null, getter = "__not_set__"\ )               |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_inner<class_GutTest_method_double_inner>`\ (\ path, subpath, strategy = null\ )                                                          |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_scene<class_GutTest_method_double_scene>`\ (\ path, strategy = null\ )                                                                   |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`double_script<class_GutTest_method_double_script>`\ (\ path, strategy = null\ )                                                                 |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`wait_frames<class_GutTest_method_wait_frames>`\ (\ frames\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ ) |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_for<class_GutTest_method_yield_for>`\ (\ time, msg = ""\ )                                                                                |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_frames<class_GutTest_method_yield_frames>`\ (\ frames, msg = ""\ )                                                                        |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Deprecated | `Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ | :ref:`yield_to<class_GutTest_method_yield_to>`\ (\ obj, signal_name, max_wait, msg = ""\ )                                                            |
+   +------------+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. table::
    :widths: auto
@@ -1958,7 +1960,7 @@ See `Awaiting <../Awaiting.html>`__
 
 .. rst-class:: classref-method
 
-`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_frames>`
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_frames**\ (\ frames\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_frames>`
 
 **Deprecated:** This method may be changed or removed in future versions.
 
@@ -1972,9 +1974,27 @@ Use wait_physics_frames or wait_process_frames See `Awaiting <../Awaiting.html>`
 
 .. rst-class:: classref-method
 
-`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_physics_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_physics_frames>`
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_physics_frames**\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_physics_frames>`
 
-Use this with await to pause execution for a number of physics frames (counted in _physics_process). See `Awaiting <../Awaiting.html>`__
+This returns a signal that is emitted after ``x`` physics frames have elpased.  You can await this method directly to pause execution for ``x`` physics frames.  The frames are counted prior to _physics_process being called on any node (when :ref:`SceneTree.physics_frame<class_SceneTree_signal_physics_frame>` is emitted).  This means the signal is emitted after ``x`` frames and just before the x + 1 frame starts.
+
+::
+
+    await wait_physics_frames(10)
+
+See `Awaiting <../Awaiting.html>`__
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_GutTest_method_wait_idle_frames:
+
+.. rst-class:: classref-method
+
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_idle_frames**\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_idle_frames>`
+
+Alias for :ref:`wait_process_frames<class_GutTest_method_wait_process_frames>`
 
 .. rst-class:: classref-item-separator
 
@@ -1984,9 +2004,17 @@ Use this with await to pause execution for a number of physics frames (counted i
 
 .. rst-class:: classref-method
 
-`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_process_frames**\ (\ frames, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_process_frames>`
+`Variant <https://docs.godotengine.org/en/stable/classes/class_variant.html>`_ **wait_process_frames**\ (\ x\: `int <https://docs.godotengine.org/en/stable/classes/class_int.html>`_, msg = ""\ ) :ref:`🔗<class_GutTest_method_wait_process_frames>`
 
-Use this with await to pause execution for a number of idle/process frames (counted in _process(delta)) See `Awaiting <../Awaiting.html>`__
+This returns a signal that is emitted after ``x`` process/idle frames have elpased.  You can await this method directly to pause execution for ``x`` process/idle frames.  The frames are counted prior to _process being called on any node (when :ref:`SceneTree.process_frame<class_SceneTree_signal_process_frame>` is emitted).  This means the signal is emitted after ``x`` frames and just before the x + 1 frame starts.
+
+::
+
+    await wait_process_frames(10)
+    # wait_idle_frames is an alias of wait_process_frames
+    await wait_idle_frames(10)
+
+See `Awaiting <../Awaiting.html>`__
 
 .. rst-class:: classref-item-separator
 

--- a/test/integration/test_everything_together.gd
+++ b/test/integration/test_everything_together.gd
@@ -54,8 +54,8 @@ class TestMemoryMgmt:
 	func test_GutTest_with_waits():
 		var t = GutTest.new()
 		add_child(t)
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		t.free()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_no_new_orphans()
 

--- a/test/output_tests/test_print.gd
+++ b/test/output_tests/test_print.gd
@@ -92,7 +92,7 @@ class TestGuiOutput:
 
 	func test_embedded_bbcode():
 		_logger.log('[u]this should not be underlined')
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		# assert_string_contains(_gui.get_textbox().text, '[u]this should')
 		pass_test('Check output, cannot get bbcode out of RTL')
 		pause_before_teardown()

--- a/test/unit/test_awaiter.gd
+++ b/test/unit/test_awaiter.gd
@@ -86,11 +86,11 @@ func test_wait_for_resets_did_last_wait_timeout():
 
 
 
-func test_wait_idle_frames_counts_frames_in_process(_x = run_x_times(10)):
+func test_wait_process_frames_counts_frames_in_process(_x = run_x_times(10)):
 	var a = add_child_autoqfree(Awaiter.new())
 	watch_signals(a)
 	a.set_physics_process(false)
-	a.wait_idle_frames(10)
+	a.wait_process_frames(10)
 	var c = add_child_autoqfree(Counter.new())
 	await wait_for_signal(a.timeout, 10)
 	assert_almost_eq(c.idle_frames, 11, 2, 'waited enough frames')
@@ -136,9 +136,9 @@ func test_wait_physics_frames_sets_did_last_wait_timeout_to_true():
 	await a.timeout
 	assert_true(a.did_last_wait_timeout)
 
-func test_wait_idle_frames_sets_did_last_wait_timeout_to_true():
+func test_wait_process_frames_sets_did_last_wait_timeout_to_true():
 	var a = add_child_autoqfree(Awaiter.new())
-	a.wait_idle_frames(10)
+	a.wait_process_frames(10)
 	await a.timeout
 	assert_true(a.did_last_wait_timeout)
 
@@ -150,11 +150,11 @@ func test_wait_physics_frames_resets_did_last_wait_timeout():
 	a.wait_physics_frames(50)
 	assert_false(a.did_last_wait_timeout)
 
-func test_wait_idle_frames_resets_did_last_wait_timeout():
+func test_wait_process_frames_resets_did_last_wait_timeout():
 	var a = add_child_autoqfree(Awaiter.new())
-	a.wait_idle_frames(10)
+	a.wait_process_frames(10)
 	await a.timeout
-	a.wait_idle_frames(50)
+	a.wait_process_frames(50)
 	assert_false(a.did_last_wait_timeout)
 
 

--- a/test/unit/test_bugs/test_i288_wait_times.gd
+++ b/test/unit/test_bugs/test_i288_wait_times.gd
@@ -26,33 +26,33 @@ func after_all():
 
 func test_yield1():
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 func test_yield2():
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 func test_yield3():
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 func test_yield4():
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 func test_yield5():
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 var yield_params = [1, 2, 3, 4, 5, 6, 7, 8]
 func test_parameterized(p=use_parameters(yield_params)):
 	_max_acceptable_time += 20
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	pass_test('no test')
 
 

--- a/test/unit/test_bugs/test_i578.gd
+++ b/test/unit/test_bugs/test_i578.gd
@@ -51,7 +51,7 @@ class TestInputSingleton:
 	func before_all():
 		_sender.release_all()
 		_sender.clear()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		InputMap.add_action("jump")
 
 
@@ -63,7 +63,7 @@ class TestInputSingleton:
 		_sender.release_all()
 		# Wait for key release to be processed. Otherwise the key release is
 		# leaked to the next test and it detects an extra key release.
-		await wait_frames(1)
+		await wait_physics_frames(1)
 		_sender.clear()
 
 
@@ -71,7 +71,7 @@ class TestInputSingleton:
 		var r = add_child_autofree(InputSingletonTracker.new())
 
 		Input.action_press("jump")
-		await wait_frames(2)
+		await wait_physics_frames(2)
 		Input.action_release("jump")
 
 		# see inner-test-class note
@@ -89,7 +89,7 @@ class TestInputSingleton:
 		var r = add_child_autofree(InputSingletonTracker.new())
 
 		_sender.action_down("jump").hold_for("20f")
-		await wait_frames(5)
+		await wait_physics_frames(5)
 
 		assert_eq(r.just_pressed_count, 1, 'just pressed once')
 		assert_eq(r.just_released_count, 0, 'not released yet')

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -286,7 +286,7 @@ class TestMisc:
 	func test_gut_does_not_make_orphans_when_freed_before_in_tree():
 		var g = new_gut()
 		g.free()
-		await wait_frames(2)
+		await wait_physics_frames(2)
 		assert_no_new_orphans()
 
 
@@ -662,7 +662,7 @@ class TestEverythingElse:
 		gr.test_gut.test_scripts()
 		assert_eq(gr.test_gut.get_test_count(), 0, 'test should not be run')
 		assert_errored(gr.test_gut, -1)
-	
+
 	func test_awaiting_in_the_pre_hook_script():
 		var pre_run_script = load("res://test/resources/awaiting_pre_run_script.gd")
 		gr.test_gut.pre_run_script = "res://test/resources/awaiting_pre_run_script.gd"
@@ -670,7 +670,7 @@ class TestEverythingElse:
 		gr.test_gut.test_scripts()
 		await wait_for_signal(gr.test_gut.start_run, 3, "It should take exactly 1 second.")
 		assert_true(gr.test_gut.get_pre_run_script_instance().awaited, "Pre-run script awaited.")
-	
+
 	func test_awaiting_in_the_post_hook_script():
 		var pre_run_script = load("res://test/resources/awaiting_post_run_script.gd")
 		gr.test_gut.post_run_script = "res://test/resources/awaiting_post_run_script.gd"

--- a/test/unit/test_gut_config_gui.gd
+++ b/test/unit/test_gut_config_gui.gd
@@ -21,7 +21,7 @@ func test_free_makes_no_orphans():
 	var ctrl = add_child_autofree(HBoxContainer.new())
 	var gcc = GutConfigGui.new(ctrl)
 	gcc = null
-	await wait_frames(1)
+	await wait_physics_frames(1)
 	assert_no_new_orphans()
 
 func test_double_strategy_is_script_only():

--- a/test/unit/test_gut_runner.gd
+++ b/test/unit/test_gut_runner.gd
@@ -44,7 +44,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_not_called(gr, 'quit')
 
 	func test_quits_with_exit_code_0_when_should_exit_and_everything_ok():
@@ -53,7 +53,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [0])
 
 	func test_quits_with_exit_code_0_when_exit_on_success_and_everything_ok():
@@ -62,7 +62,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [0])
 
 	func test_sets_exit_code_from_post_run_hook():
@@ -75,7 +75,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [456])
 
 
@@ -86,7 +86,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [1])
 
 
@@ -101,7 +101,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [456])
 
 
@@ -112,7 +112,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_not_called(gr, 'quit')
 
 
@@ -123,7 +123,7 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [0])
 
 
@@ -134,5 +134,5 @@ class TestQuit:
 		add_child_autofree(gr)
 
 		gr.run_tests()
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_called(gr, 'quit', [1])

--- a/test/unit/test_illustrate_input_and_button_event_issue.gd
+++ b/test/unit/test_illustrate_input_and_button_event_issue.gd
@@ -82,7 +82,7 @@ func test_illustrate():
 
 	# If we use get_tree().root when calling illustrate, then all the signal
 	# asserts in other tests will fail and I have no idea why.
-	await wait_frames(10)
+	await wait_physics_frames(10)
 	await illustrate(btn)
 	assert_called(btn, '_on_button_up')
 	assert_signal_emitted(btn, 'button_down')

--- a/test/unit/test_input_sender.gd
+++ b/test/unit/test_input_sender.gd
@@ -128,7 +128,7 @@ class TestTheBasics:
 		assert_gt(parent_item.get_child_count(), 0, 'just making sure there is something to free')
 		# could not find a way to trigger this by unreferencing
 		sender._notification(NOTIFICATION_PREDELETE)
-		await wait_frames(5)
+		await wait_physics_frames(5)
 		assert_freed(parent_item, 'sender item node parent')
 
 

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -67,7 +67,7 @@ class TestMiscTests:
 	func test_when_leaves_tree_awaiter_is_freed():
 		add_child(gr.test)
 		remove_child(gr.test)
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_freed(gr.test._awaiter, 'awaiter')
 
 
@@ -1448,7 +1448,7 @@ class TestReplaceNode:
 	func after_each():
 		# Things get queue_free in these tests and show up as orphans when they
 		# actually aren't, so wait for them to free.
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		super.after_each()
 
 	func test_can_replace_node():
@@ -1477,7 +1477,7 @@ class TestReplaceNode:
 		var old = _arena.get_sword()
 		gr.test.replace_node(_arena, 'Player1/Sword', replacement)
 		# object is freed using queue_free, so we have to wait for it to go away
-		await wait_frames(20)
+		await wait_physics_frames(20)
 		assert_true(GutUtils.is_freed(old))
 
 	func test_replaced_node_retains_groups():
@@ -1697,7 +1697,7 @@ class TestMemoryMgmt:
 		assert_eq(n.get_parent(), self, 'added as child')
 		gut.get_autofree().free_all()
 		assert_not_freed(n, 'node') # should not be freed until we wait
-		await wait_frames(10)
+		await wait_physics_frames(10)
 		assert_freed(n, 'node')
 		assert_no_new_orphans()
 

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -58,7 +58,7 @@ class TestYeOldYieldMethods:
 		await yield_frames(30)
 		assert_between(counter.physics_frames, 29, 31)
 
-	func test_wait_to_ends_when_signal_emitted():
+	func test_wait_to_ends_when_signal_emitted(_x = run_x_times(5)):
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		signaler.emit_after(.5)
 		await yield_to(signaler, 'the_signal', 10)
@@ -100,7 +100,14 @@ class TestTheNewWaitMethods:
 		await wait_process_frames(30)
 		assert_between(counter.idle_frames, 29, 31)
 
-	func test_wait_to_ends_when_signal_emitted():
+	func test_wait_for_signal_does_not_wait_too_long(_x = run_x_times(5)):
+		var signaler = add_child_autoqfree(TimedSignaler.new())
+		signaler.emit_after(.5)
+		await wait_for_signal(signaler.the_signal, 10)
+		assert_between(counter.physics_time, .48, .52)
+
+
+	func test_wait_for_signal_ends_when_signal_emitted():
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		signaler.emit_after(.5)
 		await wait_for_signal(signaler.the_signal, 10)

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -100,6 +100,11 @@ class TestTheNewWaitMethods:
 		await wait_process_frames(30)
 		assert_between(counter.idle_frames, 29, 31)
 
+	func test_wait_idle_frames_waits_for_x_frames():
+		await wait_idle_frames(30)
+		assert_between(counter.idle_frames, 29, 31)
+
+
 	func test_wait_for_signal_does_not_wait_too_long(_x = run_x_times(5)):
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		signaler.emit_after(.5)

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -14,7 +14,7 @@ class TimedSignaler:
 		_timer.one_shot = true
 
 	func _on_timer_timeout():
-		print(self, " emitting the_signal")
+		# print(self, " emitting the_signal")
 		the_signal.emit()
 
 	func emit_after(time):

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -25,12 +25,19 @@ class TimedSignaler:
 class Counter:
 	extends Node
 
-	var time = 0.0
-	var frames = 0
+	var idle_time = 0.0
+	var idle_frames = 0
+
+	var physics_time = 0.0
+	var physics_frames = 0
 
 	func _physics_process(delta):
-		time += delta
-		frames += 1
+		physics_time += delta
+		physics_frames += 1
+
+	func _process(delta):
+		idle_time += delta
+		idle_frames += 1
 
 
 class PredicateMethods:
@@ -49,51 +56,61 @@ class TestYeOldYieldMethods:
 
 	func test_wait_frames_waits_for_x_frames():
 		await yield_frames(30)
-		assert_between(counter.frames, 29, 31)
+		assert_between(counter.physics_frames, 29, 31)
 
 	func test_wait_to_ends_when_signal_emitted():
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		signaler.emit_after(.5)
 		await yield_to(signaler, 'the_signal', 10)
-		assert_between(counter.time, .48, .52)
+		assert_between(counter.physics_time, .48, .52)
 
 	func test_wait_to_ends_at_max_wait_if_signal_not_emitted():
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		await yield_to(signaler, 'the_signal', 1)
-		assert_between(counter.time, .9, 1.1)
+		assert_between(counter.physics_time, .9, 1.1)
 
 	func test_wait_for_waits_for_x_seconds():
 		await wait_seconds(.5)
-		assert_between(counter.time, .49, .52)
+		assert_between(counter.physics_time, .49, .52)
 
 
 
 class TestTheNewWaitMethods:
-	extends GutTest
+	extends GutInternalTester
 
 	var counter = null
 	func before_each():
 		counter = add_child_autoqfree(Counter.new())
 
+	func test_wait_frames_is_deprecated():
+		var t = GutTest.new()
+		t._awaiter = autofree(double(load('res://addons/gut/awaiter.gd')).new())
+		t.wait_frames(5)
+		assert_deprecated(t)
+
 	func test_wait_for_waits_for_x_seconds():
 		await wait_seconds(.5)
-		assert_between(counter.time, .49, .52)
+		assert_between(counter.physics_time, .49, .52)
 
-	func test_wait_frames_waits_for_x_frames():
-		await wait_frames(30)
-		assert_between(counter.frames, 29, 31)
+	func test_wait_physics_frames_waits_for_x_frames():
+		await wait_physics_frames(30)
+		assert_between(counter.physics_frames, 29, 31)
+
+	func test_wait_idle_frames_waits_for_x_frames():
+		await wait_idle_frames(30)
+		assert_between(counter.idle_frames, 29, 31)
 
 	func test_wait_to_ends_when_signal_emitted():
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		signaler.emit_after(.5)
 		await wait_for_signal(signaler.the_signal, 10)
-		assert_almost_eq(counter.time, .5, .05)
+		assert_almost_eq(counter.physics_time, .5, .05)
 		assert_false(did_wait_timeout(), 'did_wait_timeout')
 
 	func test_wait_to_ends_at_max_wait_if_signal_not_emitted():
 		var signaler = add_child_autoqfree(TimedSignaler.new())
 		await wait_for_signal(signaler.the_signal, 1)
-		assert_between(counter.time, .9, 1.1)
+		assert_between(counter.physics_time, .9, 1.1)
 		assert_true(did_wait_timeout(), 'did_wait_timeout')
 
 	func test_wait_for_signal_returns_true_when_signal_emitted():
@@ -111,10 +128,10 @@ class TestTheNewWaitMethods:
 
 	func test_wait_until_waits_ends_when_method_returns_true():
 		var all_is_good = func():
-			return counter.time > .25
+			return counter.physics_time > .25
 
 		await wait_until(all_is_good, .5)
-		assert_almost_eq(counter.time, .25, .05)
+		assert_almost_eq(counter.physics_time, .25, .05)
 		assert_false(did_wait_timeout(), 'did_wait_timeout')
 
 	func test_wait_until_times_out():
@@ -122,12 +139,12 @@ class TestTheNewWaitMethods:
 			return false
 
 		await wait_until(all_is_good, .5)
-		assert_almost_eq(counter.time, .5, .05)
+		assert_almost_eq(counter.physics_time, .5, .05)
 		assert_true(did_wait_timeout(), 'did_wait_timeout')
 
 	func test_wait_until_returns_true_when_it_finishes():
 		var all_is_good = func():
-			return counter.time > .25
+			return counter.physics_time > .25
 
 		var result = await wait_until(all_is_good, .5)
 		assert_true(result)

--- a/test/unit/test_test_await_methods.gd
+++ b/test/unit/test_test_await_methods.gd
@@ -96,8 +96,8 @@ class TestTheNewWaitMethods:
 		await wait_physics_frames(30)
 		assert_between(counter.physics_frames, 29, 31)
 
-	func test_wait_idle_frames_waits_for_x_frames():
-		await wait_idle_frames(30)
+	func test_wait_process_frames_waits_for_x_frames():
+		await wait_process_frames(30)
 		assert_between(counter.idle_frames, 29, 31)
 
 	func test_wait_to_ends_when_signal_emitted():


### PR DESCRIPTION
Implements #675

* deprecates `GutTest.wait_frames`
* adds `GutTest.wait_physics_frames` to replace `wait_frames`
* adds `GutTest.wait_process_frames`