### PR TITLE
fix failing test_optparse.TestValuesDictionary test

### DIFF
--- a/test/unit/test_optparse.gd
+++ b/test/unit/test_optparse.gd
@@ -390,7 +390,7 @@ class TestValuesDictionary:
 	func test_values_contains_positional_arguments_default_value():
 		var op = OptParse.new()
 		op.add_positional("first", 'asdf', 'the first one')
-		op.parse()
+		op.parse([])
 		assert_eq(op.values.first, 'asdf')
 
 	func test_values_contains_positional_arguments_value():


### PR DESCRIPTION
In test_optparse.TestValueDictionary.test_values_contains_positional_arguments_default_value, `op.parse()` is called to see if a positional argument would be filled with its default value when no arguments are given. However, `op.parse()` is called with no arguments instead of an empty list, which actually passes it arguments passed to the godot process. 

Because of this, running the test with `godot -d -s addons/gut/gut_cmdln.gd -gtest test/unit/test_optparse.gd` (with no .gutconfig.json file) fails with `[Failed]:  ["test/unit/test_optparse.gd"] expected to equal ["asdf"]:`.

By passing it an empty list we ensure it tries to parse no arguments, and the test no longer fails when run with the above command.