### PR TITLE
Wrap failure and pending messages with CDATA

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -7,7 +7,7 @@
     "res://test/integration/"
   ],
   "should_exit": true,
-  "log_level": 3,
+  "log_level": 1,
   "hide_orphans": false,
 
   "should_exit_on_success": false,

--- a/addons/gut/junit_xml_export.gd
+++ b/addons/gut/junit_xml_export.gd
@@ -10,6 +10,10 @@ func indent(s, ind):
 	to_return = to_return.replace("\n", "\n" + ind)
 	return to_return
 
+# Wraps content in CDATA section because it may contain special characters
+# e.g. str(null) becomes <null> and can break XML parsing.
+func wrap_cdata(content):
+	return "<![CDATA[" + str(content) + "]]>"
 
 ## @ignore should be private I think
 func add_attr(name, value):
@@ -22,10 +26,10 @@ func _export_test_result(test):
 	# Right now the pending and failure messages won't fit in the message
 	# attribute because they can span multiple lines and need to be escaped.
 	if(test.status == 'pending'):
-		var skip_tag = str("<skipped message=\"pending\">", test.pending[0], "</skipped>")
+		var skip_tag = str("<skipped message=\"pending\">", wrap_cdata(test.pending[0]), "</skipped>")
 		to_return += skip_tag
 	elif(test.status == 'fail'):
-		var fail_tag = str("<failure message=\"failed\">", test.failing[0], "</failure>")
+		var fail_tag = str("<failure message=\"failed\">", wrap_cdata(test.failing[0]), "</failure>")
 		to_return += fail_tag
 
 	return to_return

--- a/test/integration/test_junit_xml_export.gd
+++ b/test/integration/test_junit_xml_export.gd
@@ -77,6 +77,7 @@ func assert_is_valid_xml(xml : String)->void:
 
 	assert_eq(result, ERR_FILE_EOF, 'Parsing xml should reach EOF')
 
+
 func export_script(name):
 	return str('res://test/resources/exporter_test_files/', name)
 
@@ -96,10 +97,9 @@ func test_no_tests_returns_valid_xml():
 	var re = JunitExporter.new()
 	var result = re.get_results_xml(_test_gut)
 	assert_is_valid_xml(result)
-	print(result)
 
 func test_spot_check():
-	run_scripts(_test_gut, ['test_simple_2.gd', 'test_simple.gd', 'test_with_inner_classes.gd'])
+	run_scripts(_test_gut, ['test_simple_2.gd', 'test_simple.gd', 'test_with_inner_classes.gd', 'test_special_chars_in_test_output.gd'])
 	var re = JunitExporter.new()
 	var result = re.get_results_xml(_test_gut)
 	assert_is_valid_xml(result)
@@ -118,3 +118,9 @@ func test_write_file_creates_file():
 	var result = re.write_file(_test_gut, fname)
 	assert_file_not_empty(fname)
 	gut.file_delete(fname)
+
+func test_xml_is_valid_when_test_skip_message_is_null():
+	run_scripts(_test_gut, ['test_special_chars_in_test_output.gd'])
+	var re = JunitExporter.new()
+	var result = re.get_results_xml(_test_gut)
+	assert_is_valid_xml(result)

--- a/test/resources/exporter_test_files/test_special_chars_in_test_output.gd
+++ b/test/resources/exporter_test_files/test_special_chars_in_test_output.gd
@@ -1,0 +1,25 @@
+extends GutTest
+
+
+func test_pending_with_null_message():
+	pending("The < and > in this message mess up the XML")
+
+func test_failure_message_includes_str_of_null_in_message_1():
+	assert_not_null(null)
+
+func test_failure_message_includes_str_of_null_in_message_2():
+	assert_eq('null', str(null))
+
+func test_failure_message_includes_str_of_null_in_message_3():
+	assert_eq('a', 'b', "The < and > in this message mess up the XML")
+
+class TestSkipWithNullMessage:
+	extends GutTest
+
+	func should_skip():
+		return null
+
+	func test_something_that_is_skipped():
+		assert_true(false, 'hello world')
+
+

--- a/test/unit/test_simple.gd
+++ b/test/unit/test_simple.gd
@@ -16,6 +16,7 @@ func before_all():
 func test_assert_true():
 	assert_true(true, 'this is true')
 
+
 # func test_making_double_of_string():
 # 	var d = double('res://test/resources/doubler_test_objects/double_me.gd')
 # 	assert_not_null(d)


### PR DESCRIPTION
Failure messages and pending messages can include invalid characters which can result in invalid XML.  This wraps the messages in CDATA to prevent that.  

Discovery and fix credited to @ali-wallick 