### PR TITLE
Avoid global `Logger` as this conflicts with a native class in Godot 4.5

### DIFF
--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -99,8 +99,8 @@ static var InputSender = LazyLoader.new("res://addons/gut/input_sender.gd"):
 static var JunitXmlExport = LazyLoader.new('res://addons/gut/junit_xml_export.gd'):
 	get: return JunitXmlExport.get_loaded()
 	set(val): pass
-static var Logger = LazyLoader.new('res://addons/gut/logger.gd') : # everything should use get_logger
-	get: return Logger.get_loaded()
+static var GutLogger = LazyLoader.new('res://addons/gut/logger.gd') : # everything should use get_logger
+	get: return GutLogger.get_loaded()
 	set(val): pass
 static var MethodMaker = LazyLoader.new('res://addons/gut/method_maker.gd'):
 	get: return MethodMaker.get_loaded()
@@ -184,10 +184,10 @@ static var _test_mode = false
 static var _lgr = null
 static func get_logger():
 	if(_test_mode):
-		return Logger.new()
+		return GutLogger.new()
 	else:
 		if(_lgr == null):
-			_lgr = Logger.new()
+			_lgr = GutLogger.new()
 		return _lgr
 
 

--- a/test/integration/test_junit_xml_export.gd
+++ b/test/integration/test_junit_xml_export.gd
@@ -2,7 +2,7 @@ extends GutTest
 
 var Gut = load('res://addons/gut/gut.gd')
 var JunitExporter = GutUtils.JunitXmlExport
-var Logger = GutUtils.Logger
+var GutLogger = GutUtils.GutLogger
 
 var _test_gut = null
 
@@ -18,7 +18,7 @@ const RESULT_XML_VALID_TAGS := {
 func get_a_gut():
 	var g = Gut.new()
 	g.log_level = g.LOG_LEVEL_ALL_ASSERTS
-	g.logger = GutUtils.Logger.new()
+	g.logger = GutUtils.GutLogger.new()
 	g.logger.disable_printer('terminal', true)
 	g.logger.disable_printer('gui', true)
 	g.logger.disable_printer('console', true)

--- a/test/output_tests/test_misc.gd
+++ b/test/output_tests/test_misc.gd
@@ -34,7 +34,7 @@ class TestResultExporter:
 	func get_a_gut():
 		var g = Gut.new()
 		g.log_level = g.LOG_LEVEL_ALL_ASSERTS
-		g.logger = GutUtils.Logger.new()
+		g.logger = GutUtils.GutLogger.new()
 		g.logger.disable_printer('terminal', true)
 		g.logger.disable_printer('gui', true)
 		g.logger.disable_printer('console', true)

--- a/test/output_tests/test_print.gd
+++ b/test/output_tests/test_print.gd
@@ -83,7 +83,7 @@ class TestGuiOutput:
 
 	func before_each():
 		_gui = add_child_autofree(GutUtils.GutScene.instantiate())
-		_logger = GutUtils.Logger.new()
+		_logger = GutUtils.GutLogger.new()
 		_logger._printers.gui = GutUtils.Printers.GutGuiPrinter.new()
 		_logger.disable_printer('gui', false)
 		var printer = _logger.get_printer('gui')
@@ -118,7 +118,7 @@ class TestBasicLoggerOutput:
 
 	var _test_logger = null
 	func before_each():
-		_test_logger = GutUtils.Logger.new()
+		_test_logger = GutUtils.GutLogger.new()
 		_test_logger.set_gut(gut)
 		_test_logger.set_indent_string('|...')
 

--- a/test/resources/tools/gut_test.gd
+++ b/test/resources/tools/gut_test.gd
@@ -20,7 +20,7 @@ var InnerClasses = GutUtils.WarningsManager.load_script_ignoring_all_warnings(IN
 
 var Gut = load('res://addons/gut/gut.gd')
 var Test = load('res://addons/gut/test.gd')
-var Logger = load('res://addons/gut/logger.gd')
+var GutLogger = load('res://addons/gut/logger.gd')
 var Spy = load('res://addons/gut/spy.gd')
 var TestCollector = load('res://addons/gut/test_collector.gd')
 
@@ -83,7 +83,7 @@ func assert_has_logger(obj):
 	if(obj.has_method('get_logger')):
 		assert_not_null(obj.get_logger(), 'Default logger not null.')
 		if(obj.has_method('set_logger')):
-			var l = double(Logger).new()
+			var l = double(GutLogger).new()
 			obj.set_logger(l)
 			assert_eq(obj.get_logger(), l, 'Set/get works')
 
@@ -127,7 +127,7 @@ func get_error_count(obj):
 var new_gut_indent_string = "|   "
 func new_gut(print_sub_tests=false):
 	var g = Gut.new()
-	g.logger = Logger.new()
+	g.logger = GutLogger.new()
 	g.logger.disable_all_printers(true)
 	g.update_loggers()
 
@@ -148,7 +148,7 @@ func new_gut(print_sub_tests=false):
 
 func new_partial_double_gut(print_sub_tests=false):
 	var g = partial_double(Gut).new()
-	g.logger = GutUtils.Logger.new()
+	g.logger = GutUtils.GutLogger.new()
 	g.logger.disable_all_printers(true)
 	g.update_loggers()
 
@@ -169,7 +169,7 @@ func new_partial_double_gut(print_sub_tests=false):
 
 
 func new_no_print_logger(override=!verbose):
-	var to_return = Logger.new()
+	var to_return = GutLogger.new()
 	to_return.disable_all_printers(override)
 	return to_return
 
@@ -185,7 +185,7 @@ func new_wired_test(gut_instance):
 
 # func new_test_double():
 # 	var t = double(GutTest).new()
-# 	var logger = double(GutUtils.Logger).new()
+# 	var logger = double(GutUtils.GutLogger).new()
 # 	stub(t, 'set_logger').to_call_super()
 # 	stub(t, 'get_logger').to_call_super()
 # 	t.set_logger(logger)

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -63,7 +63,7 @@ class TestTheBasics:
 		_doubler.set_stubber(stubber)
 		_doubler.set_gut(gut)
 		_doubler.set_strategy(DOUBLE_STRATEGY.SCRIPT_ONLY)
-		_doubler.set_logger(GutUtils.Logger.new())
+		_doubler.set_logger(GutUtils.GutLogger.new())
 		_doubler.print_source = false
 
 	func test_get_set_stubber():
@@ -428,7 +428,7 @@ class TestDoubleInnerClasses:
 	func before_each():
 		doubler = Doubler.new()
 		doubler.set_stubber(GutUtils.Stubber.new())
-		doubler.set_logger(GutUtils.Logger.new())
+		doubler.set_logger(GutUtils.GutLogger.new())
 
 	func test_when_inner_class_not_registered_it_generates_error():
 		var  Dbl = doubler.double(InnerClasses.InnerA)

--- a/test/unit/test_gut.gd
+++ b/test/unit/test_gut.gd
@@ -57,10 +57,10 @@ class TestProperties:
 		# This is hardcodedd to use the current value to check the default because of the way
 		# that GutUtils and logger works with GutUtils._test_mode = true.  Kinda breaks
 		# the one of the 8 things that this assert checks, but that's fine.
-		assert_property_with_backing_variable(_gut, 'logger', _gut._lgr, GutUtils.Logger.new(), '_lgr')
+		assert_property_with_backing_variable(_gut, 'logger', _gut._lgr, GutUtils.GutLogger.new(), '_lgr')
 
 	func test_setting_logger_sets_gut_for_logger():
-		var new_logger = GutUtils.Logger.new()
+		var new_logger = GutUtils.GutLogger.new()
 		_gut.logger = new_logger
 		assert_eq(new_logger.get_gut(), _gut)
 
@@ -802,7 +802,7 @@ class TestErrorsTreatedAsFailure:
 		_test_gut = add_child_autofree(new_gut())
 
 	func test_logger_calls__fail_for_error_when_error_occurs():
-		var logger = GutUtils.Logger.new()
+		var logger = GutUtils.GutLogger.new()
 		var dgut = double(GutUtils.Gut).new()
 		logger.set_gut(dgut)
 		logger.error('this is an error')

--- a/test/unit/test_gut_config.gd
+++ b/test/unit/test_gut_config.gd
@@ -2,7 +2,7 @@ extends GutInternalTester
 
 func _make_gut_config():
 	var gc = GutUtils.GutConfig.new()
-	gc.logger = GutUtils.Logger.new()
+	gc.logger = GutUtils.GutLogger.new()
 	if(gut.log_level < 2):
 		gc.logger.disable_all_printers(true)
 	return gc

--- a/test/unit/test_logger.gd
+++ b/test/unit/test_logger.gd
@@ -1,7 +1,7 @@
 extends GutInternalTester
 
 func _new_logger():
-	var to_return = Logger.new()
+	var to_return = GutLogger.new()
 	to_return.disable_all_printers(true)
 	return to_return
 

--- a/test/unit/test_orphan_counter.gd
+++ b/test/unit/test_orphan_counter.gd
@@ -12,7 +12,7 @@ func test_can_add_get_counter():
 
 func test_print_singular_orphan():
 	var oc = partial_double(GutUtils.OrphanCounter).new()
-	var d_logger = double(GutUtils.Logger).new()
+	var d_logger = double(GutUtils.GutLogger).new()
 
 	stub(oc, 'orphan_count').to_return(1)
 	oc.add_counter('one')
@@ -25,7 +25,7 @@ func test_print_singular_orphan():
 
 func test_print_plural_orphans():
 	var oc = partial_double(GutUtils.OrphanCounter).new()
-	var d_logger = double(GutUtils.Logger).new()
+	var d_logger = double(GutUtils.GutLogger).new()
 
 	stub(oc, 'orphan_count').to_return(1)
 	oc.add_counter('one')

--- a/test/unit/test_result_exporter.gd
+++ b/test/unit/test_result_exporter.gd
@@ -2,7 +2,7 @@ extends GutTest
 
 var Gut = load('res://addons/gut/gut.gd')
 var ResultExporter = GutUtils.ResultExporter
-var Logger = GutUtils.Logger
+var GutLogger = GutUtils.GutLogger
 
 var _test_gut = null
 
@@ -11,7 +11,7 @@ var _test_gut = null
 func get_a_gut():
 	var g = Gut.new()
 	g.log_level = g.LOG_LEVEL_ALL_ASSERTS
-	g.logger = GutUtils.Logger.new()
+	g.logger = GutUtils.GutLogger.new()
 	g.logger.disable_printer('terminal', true)
 	g.logger.disable_printer('gui', true)
 	g.logger.disable_printer('console', true)

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -60,7 +60,7 @@ class TestMiscTests:
 
 	func test_get_set_logger():
 		assert_ne(gr.test.get_logger(), null)
-		var dlog = double(Logger).new()
+		var dlog = double(GutLogger).new()
 		gr.test.set_logger(dlog)
 		assert_eq(gr.test.get_logger(), dlog)
 


### PR DESCRIPTION
Fixes https://github.com/bitwes/Gut/issues/709

```
ERROR: res://addons/gut/utils.gd:95 - Parse Error: The member "Logger" shadows a native class.
```