### PR TITLE
Check if object emitting signal exist before disconnecting

### DIFF
--- a/addons/gut/awaiter.gd
+++ b/addons/gut/awaiter.gd
@@ -76,7 +76,9 @@ func _end_wait():
 	elif(_wait_process_frames > 0):
 		_did_last_wait_timeout = _elapsed_frames >= _wait_process_frames
 
-	if(_signal_to_wait_on != null and _signal_to_wait_on.get_object() != null and _signal_to_wait_on.is_connected(_signal_callback)):
+	if(_signal_to_wait_on != null and \
+	   is_instance_valid(_signal_to_wait_on.get_object()) and \
+	   _signal_to_wait_on.is_connected(_signal_callback)):
 		_signal_to_wait_on.disconnect(_signal_callback)
 
 	_wait_process_frames = 0


### PR DESCRIPTION
If object emitting the signal was freed immediately after emitting the signal, Godot logged internal error.

Reproduction example:

```gdscript
extends CardsGutTest

class NodeWithSignal extends Node:
	signal test_signal

func test_error():
	var node := NodeWithSignal.new()
	get_tree().create_timer(0.1).timeout.connect(func():
		node.test_signal.emit()
		node.queue_free()
	)
	assert_true(await wait_for_signal(node.test_signal, 1))
```

Stacktrace:
```
E 0:00:10:137   awaiter.gd:79 @ _end_wait(): Parameter "obj" is null.
  <C++ Source>  core/variant/callable.cpp:557 @ is_connected()
  <Stack Trace> awaiter.gd:79 @ _end_wait()
                awaiter.gd:37 @ _on_tree_process_frame()
```