### PR TITLE
there is now a blurb printed for before_all/after_all failures

### DIFF
--- a/addons/gut/logger.gd
+++ b/addons/gut/logger.gd
@@ -47,6 +47,7 @@ var _logs = {
 	types.debug: [],
 	types.deprecated: [],
 	types.expected_error: [],
+	types.failed: [],
 }
 
 var _printers = {

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -7,7 +7,6 @@
 script = ExtResource("1")
 
 [node name="RunTestsButton" type="Button" parent="."]
-anchors_preset = -1
 offset_left = 11.0
 offset_top = 19.0
 offset_right = 194.0

--- a/test/unit/test_bugs/test_i288_wait_times.gd
+++ b/test/unit/test_bugs/test_i288_wait_times.gd
@@ -22,37 +22,37 @@ func before_all():
 
 func after_all():
 	var total_time = Time.get_ticks_msec() - _start_time
-	assert_lt(total_time, _max_acceptable_time)
+	assert_lt(total_time, _max_acceptable_time, 'Flakey on full runs')
 
 func test_yield1():
 	_max_acceptable_time += 20
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 func test_yield2():
 	_max_acceptable_time += 20
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 func test_yield3():
 	_max_acceptable_time += 20
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 func test_yield4():
 	_max_acceptable_time += 20
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 func test_yield5():
 	_max_acceptable_time += 20
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 var yield_params = [1, 2, 3, 4, 5, 6, 7, 8]
 func test_parameterized(p=use_parameters(yield_params)):
 	_max_acceptable_time += 30
-	await wait_physics_frames(1)
+	await wait_idle_frames(1)
 	pass_test('no test')
 
 

--- a/test/unit/test_illustrate_input_and_button_event_issue.gd
+++ b/test/unit/test_illustrate_input_and_button_event_issue.gd
@@ -46,11 +46,6 @@ class PrintEventsButton:
 func before_all():
 	register_inner_classes(load('res://test/unit/test_illustrate_input_and_button_event_issue.gd'))
 
-func test_something():
-	var btn = autofree(PrintEventsButton.new())
-	btn.print_has_method('_input')
-	btn._input(InputEventMouseButton.new())
-
 
 func illustrate(btn):
 	var button_down = InputEventMouseButton.new()


### PR DESCRIPTION
Fixes #730

The script is listed in the summary when a test fails in `before_all` or `after_all`.  You still have to go look for it because the failure message does not appear, but it's better than it was.  The final line of the run will also indicate if an assert has failed in a `before_all`/`after_all` method if no tests in the run fail.