### PR TITLE
fix: register_inner_classes can handle cyclic dependencies

### DIFF
--- a/addons/gut/inner_class_registry.gd
+++ b/addons/gut/inner_class_registry.gd
@@ -19,13 +19,7 @@ func _register_inners(base_path, obj, prev_inner = ''):
 		var key = consts[const_idx]
 		var thing = const_map[key]
 
-		if(typeof(thing) == TYPE_OBJECT):
-			if (
-				thing.resource_path == base_path
-				or thing in _registry
-			):
-				const_idx += 1
-				continue
+		if(typeof(thing) == TYPE_OBJECT and thing.resource_path == ''):
 			var cur_inner = str(prev_inner, ".", key)
 			_registry[thing] = _create_reg_entry(base_path, cur_inner)
 			_register_inners(base_path, thing, cur_inner)

--- a/addons/gut/inner_class_registry.gd
+++ b/addons/gut/inner_class_registry.gd
@@ -20,6 +20,12 @@ func _register_inners(base_path, obj, prev_inner = ''):
 		var thing = const_map[key]
 
 		if(typeof(thing) == TYPE_OBJECT):
+			if (
+				thing.resource_path == base_path
+				or thing in _registry
+			):
+				const_idx += 1
+				continue
 			var cur_inner = str(prev_inner, ".", key)
 			_registry[thing] = _create_reg_entry(base_path, cur_inner)
 			_register_inners(base_path, thing, cur_inner)

--- a/addons/gut/script_parser.gd
+++ b/addons/gut/script_parser.gd
@@ -119,7 +119,7 @@ class ParsedScript:
 
 			_script_path = to_load.resource_path
 			if(inner_class != null):
-				_subpath = _find_subpath(to_load, inner_class, {})
+				_subpath = _find_subpath(to_load, inner_class)
 
 			if(inner_class == null):
 				_resource = to_load
@@ -173,10 +173,7 @@ class ParsedScript:
 				_methods_by_name[m.name] = parsed_method
 
 
-	func _find_subpath(parent_script, inner, seen):
-		if parent_script in seen:
-			return
-		seen[parent_script] = parent_script
+	func _find_subpath(parent_script, inner):
 		var const_map = parent_script.get_script_constant_map()
 		var consts = const_map.keys()
 		var const_idx = 0
@@ -191,7 +188,7 @@ class ParsedScript:
 					found = true
 					to_return = key
 				else:
-					to_return = _find_subpath(const_val, inner, seen)
+					to_return = _find_subpath(const_val, inner)
 					if(to_return != null):
 						to_return = str(key, '.', to_return)
 						found = true

--- a/addons/gut/script_parser.gd
+++ b/addons/gut/script_parser.gd
@@ -119,7 +119,7 @@ class ParsedScript:
 
 			_script_path = to_load.resource_path
 			if(inner_class != null):
-				_subpath = _find_subpath(to_load, inner_class)
+				_subpath = _find_subpath(to_load, inner_class, {})
 
 			if(inner_class == null):
 				_resource = to_load
@@ -173,7 +173,10 @@ class ParsedScript:
 				_methods_by_name[m.name] = parsed_method
 
 
-	func _find_subpath(parent_script, inner):
+	func _find_subpath(parent_script, inner, seen):
+		if parent_script in seen:
+			return
+		seen[parent_script] = parent_script
 		var const_map = parent_script.get_script_constant_map()
 		var consts = const_map.keys()
 		var const_idx = 0
@@ -188,7 +191,7 @@ class ParsedScript:
 					found = true
 					to_return = key
 				else:
-					to_return = _find_subpath(const_val, inner)
+					to_return = _find_subpath(const_val, inner, seen)
 					if(to_return != null):
 						to_return = str(key, '.', to_return)
 						found = true

--- a/test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd
+++ b/test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd
@@ -1,0 +1,8 @@
+const b_ref := preload('res://test/resources/parsing_and_loading_samples/cyclic_ref_class_b.gd')
+
+class CyclicRefAInnerClass:
+	var foo = 'bar'
+
+	class CyclicRfAInnerInnerClass:
+		var bar = 'foo'
+

--- a/test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd.uid
+++ b/test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd.uid
@@ -1,0 +1,1 @@
+uid://be5q6d3e8y4d

--- a/test/resources/parsing_and_loading_samples/cyclic_ref_class_b.gd
+++ b/test/resources/parsing_and_loading_samples/cyclic_ref_class_b.gd
@@ -1,0 +1,5 @@
+const a_ref := preload('res://test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd')
+
+class CyclicRefBInnerClass:
+	var foo = 'bar'
+

--- a/test/resources/parsing_and_loading_samples/cyclic_ref_class_b.gd.uid
+++ b/test/resources/parsing_and_loading_samples/cyclic_ref_class_b.gd.uid
@@ -1,0 +1,1 @@
+uid://dir5mfqrjbigl

--- a/test/unit/test_inner_class_registry.gd
+++ b/test/unit/test_inner_class_registry.gd
@@ -2,6 +2,7 @@ extends GutTest
 
 const INNER_CLASSES_PATH = 'res://test/resources/doubler_test_objects/inner_classes.gd'
 var InnerClasses = load(INNER_CLASSES_PATH)
+var CyclicRefA = load('res://test/resources/parsing_and_loading_samples/cyclic_ref_class_a.gd')
 
 func test_can_make_one():
 	var reg = GutUtils.InnerClassRegistry.new()
@@ -56,3 +57,14 @@ func test_get_base_resource_returns_null_when_not_registered():
 	var reg = GutUtils.InnerClassRegistry.new()
 	var resource = reg.get_base_resource(InnerClasses.InnerCA)
 	assert_eq(resource, null)
+
+func test_does_not_spin_out_of_control_with_const_cyclic_refs():
+	var reg = GutUtils.InnerClassRegistry.new()
+	reg.register(CyclicRefA)
+	pass_test('we got here')
+
+func test_does_not_contain_a_ref_to_external_classes():
+	var reg = GutUtils.InnerClassRegistry.new()
+	reg.register(CyclicRefA)
+	var result = reg.get_base_path(CyclicRefA.b_ref)
+	assert_null(result)


### PR DESCRIPTION
If you have the following:
```gdscript
# script A
const B := preload("res://b.gd")

# script B
const A := preload("res://a.gd")
```
Calling `register_inner_classes` on `A` results in a stack overflow. 