### PR TITLE
fix error calling get_base_script on null instance for non-script files

### DIFF
--- a/addons/gut/editor_caret_context_notifier.gd
+++ b/addons/gut/editor_caret_context_notifier.gd
@@ -124,12 +124,17 @@ func _make_info(editor, script, test_script_flag):
 # Events
 # -------------
 
-# Fired whenever the script changes.  This does not fire if you select something
-# other than a script from the tree.  So if you click a help file and then
-# back to the same file, then this will fire for the same script
+# Fired whenever the script changes.  This does not fire for help files.  If
+# you click a help file and then back to the same file, then this will fire
+# for the same script
+#
+# This does fire for some non-script files such as .cfg, .json and .md files,
+# but the passed in value will be null.
 #
 # This can fire multiple times for the same script when a script is opened.
 func _on_editor_script_changed(script):
+	if(script == null):
+		return
 	_last_line = -1
 	_current_script = script
 	_current_editor_base = _current_script_editor.get_current_editor()


### PR DESCRIPTION
fixes #764

Opening non-script files within the editor calls _on_editor_script_changed with null as its argument, leading to some errors printed to console when e.g. opening json files or if such files are open already when starting the editor.

as I'm not familiar with the code base please check if more values need to be reset when null is passed here (or if this is already sufficient).

thanks!