### PR TITLE
Add missing terminal quote in doc comment

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2307,7 +2307,7 @@ func assert_engine_error(text, msg=''):
 ## [codeblock]
 ## func test_with_push_error():
 ##     push_error("This is an error")
-##     assert_push_error(1, 'This test should have caused a push_error)
+##     assert_push_error(1, 'This test should have caused a push_error')
 ## [/codeblock]
 ## See [wiki]Error-Tracking[/wiki].
 func assert_push_error_count(count : int, msg:=''):


### PR DESCRIPTION
Because of missing terminal quote, docs are rendered incorrectly:

<img width="866" height="313" alt="image" src="https://github.com/user-attachments/assets/781e8dbd-bf29-4805-bc2a-769d558ed782" />
