### PR TITLE
Fix a typo and a grammar mistake in docs

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,7 +2,7 @@
 Documentation is hosted at https://gut.readthedocs.io.
 
 The wiki is generated from three types of files:
-* RST:  This wiki site index (`index.rst`) is the only RST file that manually created.  All other RST files are generated from code comments.
+* RST:  The wiki site index (`index.rst`) is the only manually created RST file.  All other RST files are generated from code comments.
 * Markdown:  The standalone pages of the wiki are all made in Markdown.
 * Documentation Comments:  A modified version of Godot's code is used to generate RST files for GUT scripts and `class_names`.
 

--- a/documentation/docs/index.rst
+++ b/documentation/docs/index.rst
@@ -76,7 +76,7 @@ GUT/Godot Versions
 ----------------------
 There are only two versions of GUT in the Asset Library.  GUT 9 requires Godot 4.  GUT 7 requires Godot 3.4.  GUT will not appear in the Asset Library if your current version of Godot is less than GUT's required version.
 
-The Godot/GUT version list and downlaod links can be found in the repo README https://github.com/bitwes/Gut/blob/main/README.md
+The Godot/GUT version list and download links can be found in the repo README https://github.com/bitwes/Gut/blob/main/README.md
 
 
 Getting Started


### PR DESCRIPTION
* Typo: downlaod => download

* Grammar: "This wiki site index (`index.rst`) is the only RST file that manually created."
  * "that manually created" is missing a verb. I thought to change it to "that is manually created", but then the second "is" seemed repetitive, so I went with "is the only manually created".
  * "This wiki site index"
    * Okay, here I'm slipping over to pedantry, but "This wiki site index" makes it sound like the current file is the site index, which is not true. Hence the change to "The".