### PR TITLE
Update gdscript_native_class_names_by_type in GutUtils

### DIFF
--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -54,7 +54,8 @@ static var class_ref_by_name = {} :
 ## on.  It is further populated during a run so that we only have to create
 ## a new instance once to get the class name string.
 static var gdscript_native_class_names_by_type = {
-	Tween:"Tween"
+	Tween:"Tween",
+	CanvasItem:"CanvasItem",
 }
 
 


### PR DESCRIPTION
Currently, running the test test/samples/ via `godot -s gut/gut_cmdln.gd -- -gconfig= -gdir <gut root>/test/samples -gunit_test_name test_assert_is` produces this output:

```
* test_assert_is
    -- passing --
ERROR: Class 'CanvasItem' or its base class cannot be instantiated.
   at: _instantiate_internal (core/object/class_db.cpp:576)
   GDScript backtrace (most recent call first):
       [0] get_native_class_name (res://addons/gut/utils.gd:517)
       [1] type2str (res://addons/gut/strutils.gd:120)
       [2] _str (res://addons/gut/test.gd:143)
       [3] assert_is (res://addons/gut/test.gd:1783)
       [4] test_assert_is (res://test/samples/test_readme_examples.gd:525)
       [5] _run_test (res://addons/gut/gut.gd:615)
       [6] _test_the_scripts (res://addons/gut/gut.gd:818)
       [7] test_scripts (res://addons/gut/gut.gd:1030)
       [8] run_tests (res://addons/gut/gui/GutRunner.gd:198)
       [9] _run_tests (res://addons/gut/cli/gut_cli.gd:238)
       [10] main (res://addons/gut/cli/gut_cli.gd:284)
       [11] _init (res://addons/gut/gut_cmdln.gd:38)
ERROR: Class type: 'CanvasItem' is not instantiable.
   at: _new (modules/gdscript/gdscript.cpp:93)
   GDScript backtrace (most recent call first):
       [0] get_native_class_name (res://addons/gut/utils.gd:517)
       [1] type2str (res://addons/gut/strutils.gd:120)
       [2] _str (res://addons/gut/test.gd:143)
       [3] assert_is (res://addons/gut/test.gd:1783)
       [4] test_assert_is (res://test/samples/test_readme_examples.gd:525)
       [5] _run_test (res://addons/gut/gut.gd:615)
       [6] _test_the_scripts (res://addons/gut/gut.gd:818)
       [7] test_scripts (res://addons/gut/gut.gd:1030)
       [8] run_tests (res://addons/gut/gui/GutRunner.gd:198)
       [9] _run_tests (res://addons/gut/cli/gut_cli.gd:238)
       [10] main (res://addons/gut/cli/gut_cli.gd:284)
       [11] _init (res://addons/gut/gut_cmdln.gd:38)
SCRIPT ERROR: Invalid call. Nonexistent function 'get_class' in base 'Nil'.
          at: get_native_class_name (res://addons/gut/utils.gd:518)
          GDScript backtrace (most recent call first):
              [0] get_native_class_name (res://addons/gut/utils.gd:518)
              [1] type2str (res://addons/gut/strutils.gd:120)
              [2] _str (res://addons/gut/test.gd:143)
              [3] assert_is (res://addons/gut/test.gd:1783)
              [4] test_assert_is (res://test/samples/test_readme_examples.gd:525)
              [5] _run_test (res://addons/gut/gut.gd:615)
              [6] _test_the_scripts (res://addons/gut/gut.gd:818)
              [7] test_scripts (res://addons/gut/gut.gd:1030)
              [8] run_tests (res://addons/gut/gui/GutRunner.gd:198)
              [9] _run_tests (res://addons/gut/cli/gut_cli.gd:238)
              [10] main (res://addons/gut/cli/gut_cli.gd:284)
              [11] _init (res://addons/gut/gut_cmdln.gd:38)
    -- failing --
    [Failed]:  Parameter 2 must be a Class (like Node2D or Label).  You passed <Node2D#78685145119>
      at line 537
    [Failed]:  Expected [<RefCounted#-9223371958119299032>(test_readme_examples.gd/BaseClass)] to extend [():<GDScript#-9223371964041656475>]:
      at line 538
    [Failed]:  Parameter 1 must be an instance of an object.  You passed:  "a"
      at line 539
    [Failed]:  Parameter 1 must be an instance of an object.  You passed:  ARRAY([])
      at line 540
    [Failed]:  Unexpected Errors:
    [1] <engine-0>Parameter "ti->creation_func" is null.
    [2] <engine-0>Parameter "o" is null.
    [3] <engine-2>Invalid call. Nonexistent function 'get_class' in base 'Nil'.
      at line -1
    5 Orphans
        * [<Node2D#77980502021>]
        * [<Label#78014056454>]
        * [<Node#78198605838>(gut.gd)]
        * [<Node2D#78685145119>]
        * [<Node2D#78668367904>]
5 orphans
0/1 passed.
```

While the first four failures are supposed to be here, the fifth "Unexpected Errors" occur because gut attempts to instantiate CanvasItem while getting the string name of the class. By adding the class to the mapping of classes that can't be instantiated to their names in GutUtils, we avoid this error, and the test output becomes:

```
* test_assert_is
    -- passing --
    -- failing --
    [Failed]:  Parameter 2 must be a Class (like Node2D or Label).  You passed <Node2D#78618036251>
      at line 537
    [Failed]:  Expected [<RefCounted#-9223371958186407900>(test_readme_examples.gd/BaseClass)] to extend [():<GDScript#-9223371964008102041>]:
      at line 538
    [Failed]:  Parameter 1 must be an instance of an object.  You passed:  "a"
      at line 539
    [Failed]:  Parameter 1 must be an instance of an object.  You passed:  ARRAY([])
      at line 540
    5 Orphans
        * [<Node2D#78014056455>]
        * [<Label#78047610888>]
        * [<Node#78131496970>(gut.gd)]
        * [<Node2D#78618036251>]
        * [<Node2D#78601259036>]
5 orphans
0/1 passed.
```