### PR TITLE
Added maximum version for v9.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can download/clone earlier versions of GUT using the links below.
 |-|-|-|-|-|-|
 |Main Branch |4.6 (or greater)| |[download](https://github.com/bitwes/Gut/archive/refs/heads/main.zip) | | [wiki](https://gut.readthedocs.io/en/latest/)|
 |[9.6.0](https://github.com/bitwes/Gut/releases/tag/v9.6.0)|4.6|[repo](https://github.com/bitwes/Gut/tree/v9.6.0)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.6.0.zip)|[Asset Library](https://godotengine.org/asset-library/asset/1709)|[wiki](https://gut.readthedocs.io/en/v9.6.0)|
-|[9.5.0](https://github.com/bitwes/Gut/releases/tag/v9.5.0)|4.5|[repo](https://github.com/bitwes/Gut/tree/v9.5.0)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.5.0.zip)||[wiki](https://gut.readthedocs.io/en/v9.5.0/)|
+|[9.5.0](https://github.com/bitwes/Gut/releases/tag/v9.5.0)|4.5 (only)|[repo](https://github.com/bitwes/Gut/tree/v9.5.0)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.5.0.zip)||[wiki](https://gut.readthedocs.io/en/v9.5.0/)|
 |[9.4.0](https://github.com/bitwes/Gut/releases/tag/v9.4.0)|4.3-4.5|[repo](https://github.com/bitwes/Gut/tree/v9.4.0)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.4.0.zip)||[wiki](https://gut.readthedocs.io/en/v9.4.0/)|
 |[9.3.0](https://github.com/bitwes/Gut/releases/tag/v9.3.0)|4.2|[repo](https://github.com/bitwes/Gut/tree/v9.3.0)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.3.0.zip)||[wiki](https://gut.readthedocs.io/en/9.3.1/)|
 |[9.1.1](https://github.com/bitwes/Gut/releases/tag/v9.1.1)|4.1|[repo](https://github.com/bitwes/Gut/tree/v9.1.1)|[download](https://github.com/bitwes/Gut/archive/refs/tags/v9.1.1.zip)|||


### PR DESCRIPTION
I would not be heartbroken if you felt this change was not worth committing, but would have saved me at least a little bit of time. What I tested:

- 9.4.0 -> Works in Godot 4.3, 4.4, and 4.5; explicit errors in 4.6
- 9.5.0 -> Does not load in 4.4 (unsurprising), didn't test in 4.5 as I presumed this working, and does not work in 4.6
- 9.6.0 -> Does not load in 4.4 (unsurprising)

## Big caveat

Edit: I thought of this only after posting the PR, but worth saying: I did not do *exhaustive* testing to ensure *all* aspects of gut are working in 9.4.0 with 4.4 and 4.5. I only found the tests that I already implemented in my repo continued to work without modification. Maybe more testing would be required. Again, no feelings hurt if you close it.

### Context

I'm a plugin developer, and am just now upping the minimum version of the [Godot Road Generator](https://github.com/TheDuckCow/godot-road-generator) to 4.4+, now actively supporting 4.4 - 4.6. For a couple of reasons, awhile go I decided to directly commit gut into repo directly. This was to reduce friction with users contributing (fewer setup steps, since there's no _canonical_ plugin version manager out there), as well as resolving issues I had in the past trying to install gut just-in-time for github action testing (though maybe I'd have more luck if I attempted this again).

I was fingers-tapping-together hoping I could use the 9.4.0 version for all 4.4+, but alas it does not work in 4.6 for reasons I'm sure are out of your control. Anyhow, that's my problem to bear, but the doc change might be nice. I suppose it could be helpful to "cap" any other versions that have maximum support levels, as the table header otherwise implies they work in any version above the listed target.


