### PR TITLE
Avoid error message when opening text files

### DIFF
--- a/addons/gut/editor_caret_context_notifier.gd
+++ b/addons/gut/editor_caret_context_notifier.gd
@@ -178,6 +178,8 @@ var _scripts_that_have_been_warned_about = []
 var _we_have_warned_enough = false
 var _max_warnings = 5
 func is_test_script(script):
+	if script is not Script:
+		return false
 	var base = script.get_base_script()
 	if(base == null and script.get_script_method_list().size() == 0 and _could_be_test_script(script)):
 		if(OS.is_stdout_verbose() or (!_scripts_that_have_been_warned_about.has(script.resource_path) and !_we_have_warned_enough)):


### PR DESCRIPTION
Whenever a text file, like a README, is opened in the editor, a message is shown saying: "Attempt to call function 'get_base_script' in base 'null instance' on a null instance."

What this PR does, is checking if it is actually a script before checking if it is a test script