### PR TITLE
add _to_string to blacklist

### DIFF
--- a/addons/gut/script_parser.gd
+++ b/addons/gut/script_parser.gd
@@ -3,6 +3,7 @@
 const BLACKLIST = [
 	'get_script',
 	'has_method',
+	'_to_string',
 ]
 
 

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -259,6 +259,9 @@ func _get_bad_method_message(inst, method_name, what_you_cant_do):
 		to_return = str("You cannot ", what_you_cant_do, " [", method_name, "] because the method does not exist.  ",
 			"This can happen if the method is virtual and not overloaded (i.e. _ready) ",
 			"or you have mistyped the name of the method.")
+	elif(GutUtils.ScriptCollector.BLACKLIST.has(method_name)):
+		to_return = str("Method '", method_name, "' cannot be stubbed because it ",
+			"is excluded by GUT when creating doubles.")
 	elif(!inst.__gutdbl_values.doubled_methods.has(method_name)):
 		to_return = str("You cannot ", what_you_cant_do, " [", method_name, "] because ",
 			_str(inst), ' does not overload it or it was ignored with ',

--- a/test/integration/test_test_stubber_doubler.gd
+++ b/test/integration/test_test_stubber_doubler.gd
@@ -1,6 +1,31 @@
 extends GutInternalTester
 
 
+class OverrideToString:
+	extends Node
+
+	func _to_string() -> String:
+		return "this has been overriden"
+
+	func foo():
+		pass
+
+
+func before_all():
+	register_inner_classes(get_script())
+
+func test_doubling_class_that_overrides_to_string_does_not_error():
+	var obj = double(OverrideToString).new()
+	obj.foo()
+	assert_engine_error_count(0)
+
+func test_error_generated_when_attempting_to_stub_blacklisted_method():
+	var obj = double(OverrideToString).new()
+	stub(obj._to_string).to_return('hello')
+	assert_tracked_gut_error()
+
+
+
 
 class TestDoubleCreation:
 	extends GutInternalTester
@@ -480,6 +505,7 @@ class TestStub:
 	extends GutInternalTester
 	var _gut = null
 	var _test = null
+
 
 	func before_each():
 		_gut = new_gut(verbose)


### PR DESCRIPTION
Fixes #797 
 _to_string is now excluded when creating doubles.  Added a new error message if you attempt to stub a blacklisted method