### PR TITLE
Fix failing test in test/samples/test_readme_examples.gd

### DIFF
--- a/test/samples/test_readme_examples.gd
+++ b/test/samples/test_readme_examples.gd
@@ -342,7 +342,7 @@ func test_illustrate_yield():
 	# While the yield happens, the node should move
 	await yield_for(2)
 	assert_gt(moving_node.get_position().x, 0)
-	assert_between(moving_node.get_position().x, 3.9, 4, 'it should move almost 4 whatevers at speed 2')
+	assert_between(moving_node.get_position().x, 3.9, 4.1, 'it should move almost 4 whatevers at speed 2')
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Running the test `test/samples/test_readme_examples.gd` using `godot -d -s addons/gut/gut_cmdln.gd -- -gconfig= -gtest=./test/samples/test_readme_examples.gd` currently outputs the following and drops you into debug mode:

```
    [ERROR]:  Doubling using the path to a script or scene is no longer supported.  Load the script or scene and pass that to double instead.

SCRIPT ERROR: Invalid call. Nonexistent function 'new' in base 'Nil'.
          at: test_assert_called (res://test/samples/test_readme_examples.gd:546)
          GDScript backtrace (most recent call first):
              [0] test_assert_called (res://test/samples/test_readme_examples.gd:546)
              [1] _run_test (res://addons/gut/gut.gd:615)
              [2] _test_the_scripts (res://addons/gut/gut.gd:818)

Debugger Break, Reason: 'Invalid call. Nonexistent function 'new' in base 'Nil'.'
*Frame 0 - res://test/samples/test_readme_examples.gd:546 in function 'test_assert_called'
Enter "help" for assistance.
debug>
```

This is because there are three tests in that file that attempt to create a double using the string path to the script to double and not the actual script object itself. Simply wrapping each access in a `load` call allows the tests to work as intended.

Since this test script was titled "test_readme_examples", I assumed that it mirrored some documentation somewhere in the repository that should probably be updated as well, but after a little bit of grepping and browsing the git history I couldn't find what I was looking for, so I just wanted to ask if there is/was anything this was related to that ought to be changed as well.