### PR TITLE
I824 orphans after all

### DIFF
--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -650,6 +650,18 @@ func get_current_test_orphans():
 	return _orphan_counter.get_orphan_ids(sname, tname)
 
 
+
+	var to_return = 0
+	if(get_current_test_object().collected_script != null):
+		var sname = get_current_test_object().collected_script.get_ref().get_filename_and_inner()
+		var tname = get_current_test_object().name
+		to_return = _orphan_counter.record_orphans(sname, tname)
+	else:
+		to_return = _orphan_counter.record_orphans(null)
+
+	return to_return
+
+
 # ------------------------------------------------------------------------------
 # Calls before_all on the passed in test script and takes care of settings so all
 # logger output appears indented and with a proper heading

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -644,18 +644,12 @@ func _run_test(script_inst, test_name, param_index = -1):
 
 
 func get_current_test_orphans():
-	var sname = get_current_test_object().collected_script.get_ref().get_filename_and_inner()
-	var tname = get_current_test_object().name
-	_orphan_counter.record_orphans(sname, tname)
-	return _orphan_counter.get_orphan_ids(sname, tname)
-
-
-
 	var to_return = 0
 	if(get_current_test_object().collected_script != null):
 		var sname = get_current_test_object().collected_script.get_ref().get_filename_and_inner()
 		var tname = get_current_test_object().name
-		to_return = _orphan_counter.record_orphans(sname, tname)
+		_orphan_counter.record_orphans(sname, tname)
+		to_return = _orphan_counter.get_orphan_ids(sname, tname)
 	else:
 		to_return = _orphan_counter.record_orphans(null)
 

--- a/addons/gut/gut.gd
+++ b/addons/gut/gut.gd
@@ -644,14 +644,16 @@ func _run_test(script_inst, test_name, param_index = -1):
 
 
 func get_current_test_orphans():
-	var to_return = 0
-	if(get_current_test_object().collected_script != null):
-		var sname = get_current_test_object().collected_script.get_ref().get_filename_and_inner()
-		var tname = get_current_test_object().name
-		_orphan_counter.record_orphans(sname, tname)
-		to_return = _orphan_counter.get_orphan_ids(sname, tname)
-	else:
-		to_return = _orphan_counter.record_orphans(null)
+	var to_return = []
+	var ct = get_current_test_object()
+	if(ct.collected_script != null):
+		var sname = ct.collected_script.get_ref().get_filename_and_inner()
+		if(ct.name == &'after_all' or ct.name == &'before_all'):
+			_orphan_counter.record_orphans(sname)
+			to_return = _orphan_counter.get_orphan_ids(sname)
+			to_return.append_array(_orphan_counter.get_orphan_ids(ct.collected_script.get_ref().get_full_name()))
+		else:
+			to_return = _orphan_counter.record_orphans(sname, ct.name)
 
 	return to_return
 
@@ -669,6 +671,7 @@ func _call_before_all(test_script, collected_script):
 
 	collected_script.setup_teardown_tests.append(before_all_test_obj)
 	_current_test = before_all_test_obj
+	_current_test.collected_script = weakref(collected_script)
 
 	_lgr.inc_indent()
 	await test_script.before_all()
@@ -694,6 +697,7 @@ func _call_after_all(test_script, collected_script):
 
 	collected_script.setup_teardown_tests.append(after_all_test_obj)
 	_current_test = after_all_test_obj
+	_current_test.collected_script = weakref(collected_script)
 
 	_lgr.inc_indent()
 	await test_script.after_all()

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -2089,9 +2089,7 @@ func assert_no_new_orphans(text=''):
 	var msg = ''
 	if(text != ''):
 		msg = ':  ' + text
-	# Note that get_counter will return -1 if the counter does not exist.  This
-	# can happen with a misplaced assert_no_new_orphans.  Checking for > 0
-	# ensures this will not cause some weird failure.
+
 	if(count > 0):
 		msg += str("\n", _strutils.indent_text(gut.get_orphan_counter().get_orphan_list_text(orphan_ids), 1, '    '))
 		_fail(str('Expected no orphans, but found ', count, msg))

--- a/test/integration/test_test_and_orphans.gd
+++ b/test/integration/test_test_and_orphans.gd
@@ -46,6 +46,9 @@ func assert_total_fail_pass(totals, fail_count, pass_count):
 	assert_eq(totals.passing, pass_count, 'Expected pass count')
 
 
+# --------------------------
+# Test related counts
+# --------------------------
 func test_orphans_made_in_test_cause_failure():
 	var src = """
 	func test_the_test():
@@ -57,6 +60,52 @@ func test_orphans_made_in_test_cause_failure():
 	_free_orphans()
 
 
+func test_script_level_orphans_do_not_appear_as_test_orphans():
+	var src = """
+	var n = make_node('script_level')
+
+	func test_the_test():
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 0, 1)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+func test_orphans_are_not_counted_twice_in_a_test():
+	var src = """
+	func test_the_test():
+		make_node('made_an_orphan')
+		assert_no_new_orphans()
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+func test_orphans_no_orphans_then_orphans_again_in_a_test():
+	var src = """
+	func test_the_test():
+		make_node('made_an_orphan')
+		assert_no_new_orphans()
+
+		assert_no_new_orphans()
+
+		make_node('made_an_orphan')
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 2, 1)
+	assert_total_orphans_recorded(_gut, 2)
+	_free_orphans()
+
+
+# --------------------------
+# after_all
+# --------------------------
 func test_checking_for_orphans_in_after_all_is_ok():
 	var src = """
 	func after_all():
@@ -83,9 +132,21 @@ func test_orphans_made_after_test_found_in_after_all():
 	_free_orphans()
 
 
-# Orphans are "counted" at the end of a test to generate output, so they will
-# not appear in after_all as uncounted.
-func test_non_asserted_orphans_not_found_in_after_all():
+func test_orphans_made_in_after_all_are_found_in_after_all():
+	var src = """
+	func after_all():
+		make_node('made_in_after_all')
+		assert_no_new_orphans()
+
+	func test_the_test():
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	_free_orphans()
+
+
+func test_non_asserted_orphans_are_found_in_after_all():
 	var src = """
 	func after_all():
 		assert_no_new_orphans()
@@ -95,11 +156,103 @@ func test_non_asserted_orphans_not_found_in_after_all():
 		pass_test('this is passing')
 	"""
 	var t = await _run_test_script_source(src, _gut)
-	assert_total_fail_pass(t, 0, 2)
+	assert_total_fail_pass(t, 1, 1)
 	assert_total_orphans_recorded(_gut, 1)
 	_free_orphans()
 
 
+func test_asserted_orphans_are_found_in_after_all():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func test_the_test():
+		make_node('test_the_test')
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 2, 0)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+func test_orphans_made_in_after_each_are_found_in_after_all():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func after_each():
+		make_node('test_the_test')
+
+	func test_the_test():
+		make_node('test_the_test')
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 2)
+	_free_orphans()
+
+
+func test_script_level_orphans_found_in_after_all():
+	var src = """
+	var n = make_node('script_level')
+
+	func after_all():
+		assert_no_new_orphans('after_all')
+		gut.get_orphan_counter().log_all()
+
+	func test_the_test():
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+func test_orphans_no_orphans_then_orphans_again_in_a_test_then_after_all():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func test_the_test():
+		make_node('made_an_orphan')
+		assert_no_new_orphans()
+
+		assert_no_new_orphans()
+
+		make_node('made_an_orphan')
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 3, 1)
+	assert_total_orphans_recorded(_gut, 2)
+	_free_orphans()
+
+
+func test_freed_orphans_do_not_cause_failure_in_after_all():
+	var src = """
+	var n = null
+	func after_all():
+		assert_no_new_orphans()
+
+	func after_each():
+		n.free()
+
+	func test_the_test():
+		n = make_node('made_an_orphan')
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 0)
+	_free_orphans()
+
+
+# --------------------------
+# after_each
+# --------------------------
 func test_non_asserted_orphans_are_found_in_after_each():
 	var src = """
 	func after_each():
@@ -115,22 +268,22 @@ func test_non_asserted_orphans_are_found_in_after_each():
 	_free_orphans()
 
 
-# I thought it would work the other way, but it works this way, so here is a
-# test that just verifies how it works.  IDK if it SHOULD work the other way
-# or not.
-func test_orphans_made_in_after_each_are_not_found_in_after_all():
+# --------------------------
+# before_all
+# --------------------------
+func test_script_level_orphans_found_in_before_all():
 	var src = """
-	func after_all():
+	var n = make_node('script_level')
+
+	func before_all():
 		assert_no_new_orphans()
 
-	func after_each():
-		make_node('test_the_test')
-
 	func test_the_test():
-		make_node('test_the_test')
 		pass_test('this is passing')
 	"""
 	var t = await _run_test_script_source(src, _gut)
-	assert_total_fail_pass(t, 0, 2)
-	assert_total_orphans_recorded(_gut, 2)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 1)
 	_free_orphans()
+
+

--- a/test/integration/test_test_and_orphans.gd
+++ b/test/integration/test_test_and_orphans.gd
@@ -9,7 +9,7 @@ func make_node(node_name):
 """
 
 func before_all():
-	verbose = true
+	verbose = false
 
 
 func before_each():

--- a/test/integration/test_test_and_orphans.gd
+++ b/test/integration/test_test_and_orphans.gd
@@ -1,0 +1,136 @@
+extends GutInternalTester
+
+var _gut = null
+var _base_src = """
+func make_node(node_name):
+	var n = Node.new()
+	n.name = node_name
+	return n
+"""
+
+func before_all():
+	verbose = true
+
+
+func before_each():
+	_gut = add_child_autofree(new_gut(verbose))
+	var l = _gut.get_logger()
+	l.set_type_enabled(l.types.orphan, verbose)
+	if(!verbose):
+		_gut.log_level = 0
+
+
+func _free_orphans():
+	var ids = Node.get_orphan_node_ids()
+	for id in ids:
+		if(is_instance_id_valid(id)):
+			var n = instance_from_id(id)
+			n.free()
+
+
+func _run_test_script_source(src, g):
+	var s = autofree(DynamicGutTest.new())
+	s.add_source(_base_src)
+	s.add_source(src)
+	return await s.run_tests_in_gut_await(g)
+
+
+func assert_total_orphans_recorded(g, count):
+	var oc = g.get_orphan_counter()
+	var ids = oc.get_orphan_ids()
+	assert_eq(ids.size(), count, "Recorded orphan count")
+
+
+func assert_total_fail_pass(totals, fail_count, pass_count):
+	assert_eq(totals.failing, fail_count, 'Expected fail count')
+	assert_eq(totals.passing, pass_count, 'Expected pass count')
+
+
+func test_orphans_made_in_test_cause_failure():
+	var src = """
+	func test_the_test():
+		var n = make_node('test_the_test')
+		assert_no_new_orphans()
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 0)
+	_free_orphans()
+
+
+func test_checking_for_orphans_in_after_all_is_ok():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func test_the_test():
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 0, 2)
+
+
+func test_orphans_made_after_test_found_in_after_all():
+	var src = """
+	func after_all():
+		await wait_frames(10)
+		assert_no_new_orphans()
+
+	func test_the_test():
+		make_node.call_deferred('test_the_test')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 0)
+	_free_orphans()
+
+
+# Orphans are "counted" at the end of a test to generate output, so they will
+# not appear in after_all as uncounted.
+func test_non_asserted_orphans_not_found_in_after_all():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func test_the_test():
+		make_node('test_the_test')
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 0, 2)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+func test_non_asserted_orphans_are_found_in_after_each():
+	var src = """
+	func after_each():
+		assert_no_new_orphans()
+
+	func test_the_test():
+		make_node('test_the_test')
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 1, 1)
+	assert_total_orphans_recorded(_gut, 1)
+	_free_orphans()
+
+
+# I thought it would work the other way, but it works this way, so here is a
+# test that just verifies how it works.  IDK if it SHOULD work the other way
+# or not.
+func test_orphans_made_in_after_each_are_not_found_in_after_all():
+	var src = """
+	func after_all():
+		assert_no_new_orphans()
+
+	func after_each():
+		make_node('test_the_test')
+
+	func test_the_test():
+		make_node('test_the_test')
+		pass_test('this is passing')
+	"""
+	var t = await _run_test_script_source(src, _gut)
+	assert_total_fail_pass(t, 0, 2)
+	assert_total_orphans_recorded(_gut, 2)
+	_free_orphans()

--- a/test/integration/test_test_and_orphans.gd.uid
+++ b/test/integration/test_test_and_orphans.gd.uid
@@ -1,0 +1,1 @@
+uid://d3f2kj612lc7p

--- a/test/output_tests/test_orphan_output.gd
+++ b/test/output_tests/test_orphan_output.gd
@@ -183,3 +183,58 @@ class TestWithAsserts:
 
 	func test_risky():
 		var n = new_node("test_risky")
+		
+
+	func test_two_asserts():
+		var n = new_node("two_asserts")
+		assert_no_new_orphans('assert 1')
+		assert_no_new_orphans('assert 2')
+
+
+class TestAfterAll:
+	extends GutTest
+	
+	func new_node(node_name):
+		var n = Node.new()
+		n.name = node_name
+		return n
+
+
+	func after_all():
+		#var n = new_node("made_in_after_all")
+		assert_no_new_orphans('no orphans found in after_all')
+		
+		
+	func after_each():
+		var n = new_node("made_in_after_each")
+		#pass_test('passing')
+		#assert_no_new_orphans('no orphans found in after_each')
+
+		
+	func test_makes_two_orphans():
+		var n1 = new_node('n1')
+		var n2 = new_node('n2')
+		#pass_test('passing')
+		#assert_no_new_orphans()
+
+
+class TestAfterAllComplex:
+	extends GutTest
+	
+	func new_node(node_name):
+		var n = Node.new()
+		n.name = node_name
+		return n
+
+
+	func after_all():
+		await wait_idle_frames(10)
+		assert_no_new_orphans('no orphans found in after_all')
+
+	func after_each():
+		await wait_idle_frames(10)
+		assert_no_new_orphans('no orphans found in after_each')
+
+	func test_delayed_orphan():
+		new_node.call_deferred('made_deferred')
+		pass_test('passing')


### PR DESCRIPTION
Fixes #824.

Calling `assert_no_new_orphans` in `after_all`
*  no longer causes an error.
* will now fail if any orphans generated by the script still exist when it is called.  Prior to this change, only orphans created between the end of the last test and when assert_no_new_orphans was called would cause the assertion to fail