### PR TITLE
Fix syntax for returning dictionary in error_tracker

### DIFF
--- a/addons/gut/error_tracker.gd
+++ b/addons/gut/error_tracker.gd
@@ -59,8 +59,8 @@ func _get_stack_data(current_test_name):
 			stackTrace.remove_at(0)
 
 	return {
-		"test_entry" = test_entry,
-		"full_stack" = stackTrace
+		"test_entry": test_entry,
+		"full_stack": stackTrace
 	}
 
 


### PR DESCRIPTION
found this when running gdformat on my project that was using GUT.