### PR TITLE
Use a global InnerClassRegestry to get inner class paths

### DIFF
--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -10,7 +10,7 @@ var _singleton_parser = GutUtils.SingletonParser.new()
 
 # used by tests for debugging purposes.
 var print_source = false
-var inner_class_registry = GutUtils.InnerClassRegistry.new()
+var inner_class_registry = GutUtils.inner_class_registry
 
 # ###############
 # Properties

--- a/addons/gut/inner_class_registry.gd
+++ b/addons/gut/inner_class_registry.gd
@@ -64,7 +64,7 @@ func get_full_path(inner_class):
 		var entry = _registry[inner_class]
 		return str(entry.base_path.get_file(), entry.subpath.replace('.', '/'))
 	else:
-		return "Unknown Inner-Class"
+		return "/Unregistered-Inner-Class"
 
 func to_s():
 	var text = ""

--- a/addons/gut/inner_class_registry.gd
+++ b/addons/gut/inner_class_registry.gd
@@ -59,6 +59,12 @@ func get_base_resource(inner_class):
 	if(_registry.has(inner_class)):
 		return _registry[inner_class].base_resource
 
+func get_full_path(inner_class):
+	if(_registry.has(inner_class)):
+		var entry = _registry[inner_class]
+		return str(entry.base_path.get_file(), entry.subpath.replace('.', '/'))
+	else:
+		return "Unknown Inner-Class"
 
 func to_s():
 	var text = ""

--- a/addons/gut/strutils.gd
+++ b/addons/gut/strutils.gd
@@ -83,10 +83,10 @@ func _get_obj_filename(thing):
 			# we do nothing.  This just reads better.
 			pass
 	elif(!GutUtils.is_native_class(thing)):
-		var dict = inst_to_dict(thing)
-		filename = _get_filename(dict['@path'])
-		if(str(dict['@subpath']) != ''):
-			filename += str('/', dict['@subpath'])
+		if(GutUtils.is_inner_class(thing.get_script())):
+			filename = GutUtils.inner_class_registry.get_full_path(thing.get_script())
+		else:
+			filename = thing.get_script().resource_path.get_file()
 
 	return filename
 

--- a/addons/gut/test_collector.gd
+++ b/addons/gut/test_collector.gd
@@ -77,6 +77,7 @@ func _parse_script(test_script):
 		test_script.path,
 		GutUtils.warnings_when_loading_test_scripts)
 
+	GutUtils.inner_class_registry.register(loaded)
 	if(_does_inherit_from_test(loaded)):
 		_populate_tests(test_script)
 		scripts_found.append(test_script.path)

--- a/addons/gut/utils.gd
+++ b/addons/gut/utils.gd
@@ -235,7 +235,7 @@ static func get_error_tracker():
 		_error_tracker = GutErrorTracker.new()
 	return _error_tracker
 
-
+static var inner_class_registry = InnerClassRegistry.new()
 
 
 # ##############################################################################

--- a/test/unit/test_doubler.gd
+++ b/test/unit/test_doubler.gd
@@ -425,6 +425,7 @@ class TestDoubleInnerClasses:
 	func before_each():
 		doubler = Doubler.new()
 		doubler.set_stubber(GutUtils.Stubber.new())
+		doubler.inner_class_registry = GutUtils.InnerClassRegistry.new()
 		var lgr = GutUtils.GutLogger.new()
 		lgr.set_gut(gut)
 		doubler.set_logger(lgr)

--- a/test/unit/test_inner_class_registry.gd
+++ b/test/unit/test_inner_class_registry.gd
@@ -68,3 +68,14 @@ func test_does_not_contain_a_ref_to_external_classes():
 	reg.register(CyclicRefA)
 	var result = reg.get_base_path(CyclicRefA.b_ref)
 	assert_null(result)
+
+func test_get_full_path_value_when_class_registered():
+	var reg = GutUtils.InnerClassRegistry.new()
+	reg.register(InnerClasses)
+	var result = reg.get_full_path(InnerClasses.InnerB.InnerB1)
+	assert_eq(result, "inner_classes.gd/InnerB/InnerB1")
+
+func test_get_full_path_value_when_class_not_registered():
+	var reg = GutUtils.InnerClassRegistry.new()
+	var result = reg.get_full_path(InnerClasses.InnerB)
+	assert_eq(result, "/Unregistered-Inner-Class")

--- a/test/unit/test_strutils.gd
+++ b/test/unit/test_strutils.gd
@@ -1,5 +1,6 @@
 extends GutInternalTester
 
+
 class TestType2Str:
 	extends GutInternalTester
 
@@ -70,6 +71,7 @@ class TestType2Str:
 
 	func test_script():
 		assert_eq(strutils.type2str(self), str(self, '(test_strutils.gd/TestType2Str)'))
+		print(GutUtils.inner_class_registry.to_s())
 
 	func test_script_2():
 		var dm = autofree(DoubleMe.new())
@@ -118,13 +120,13 @@ class TestType2Str:
 		var d = partial_double(DoubleMe).new()
 		assert_string_contains(strutils.type2str(d), "partial-double")
 
-	# # func test_singleton_double_includes_singleton_name():
-	# # 	var d = double_singleton("Input").new()
-	# # 	assert_string_contains(strutils.type2str(d), "double of Input")
+	func test_singleton_double_includes_singleton_name():
+		var d = double_singleton(Input).new()
+		assert_string_contains(strutils.type2str(d), "double of Input")
 
-	# # func test_singleton_double_includes_word_singleton():
-	# # 	var d = double_singleton("Input").new()
-	# # 	assert_string_contains(strutils.type2str(d), "Singleton")
+	func test_singleton_double_includes_word_singleton():
+		var d = double_singleton(Input).new()
+		assert_string_contains(strutils.type2str(d), "Singleton")
 
 	func test_assert_null():
 		assert_eq(strutils.type2str(null), str(null))

--- a/test/unit/test_strutils.gd
+++ b/test/unit/test_strutils.gd
@@ -71,7 +71,6 @@ class TestType2Str:
 
 	func test_script():
 		assert_eq(strutils.type2str(self), str(self, '(test_strutils.gd/TestType2Str)'))
-		print(GutUtils.inner_class_registry.to_s())
 
 	func test_script_2():
 		var dm = autofree(DoubleMe.new())


### PR DESCRIPTION
Implements #706.

* The last reference to `inst_to_dict` has been removed.  
* `str_utils.gd` now uses a global `InnerClassRegistry` to get Inner Class names.  If the class has not been registered then a different message will be printed.  
* Whenever a script is doubled, GUT automatically registers its Inner Classes in the global registry.
* Some assert messages could be less specific now, such as using `assert_is` with an Inner Class that has not been registered.