### PR TITLE
I842 ignore unresolved return

### DIFF
--- a/addons/gut/error_tracker.gd
+++ b/addons/gut/error_tracker.gd
@@ -75,6 +75,17 @@ func _is_error_failable(error : GutTrackedError):
 			is_it = treat_engine_errors_as == GutUtils.TREAT_AS.FAILURE
 	return is_it
 
+
+# Marks any errors that GUT should not fail a test for based on internal,
+# non-alterable rules.  This is idealogically differnet than _is_error_failable.
+func _auto_handle_error(err : GutTrackedError):
+	# Issue 842, when the source has an await and a declared return type this
+	# error can occur when doubling.  It does not appear to affect anything.
+	if(err.file == 'modules/gdscript/gdscript_byte_codegen.cpp' and err.function == 'write_return'):
+		err.handled = true
+		print("[GUT]  \"Unresolved return\" has been ignored.  See https://github.com/bitwes/Gut/issues/842 for details.")
+
+
 # ----------------
 #endregion
 #region Godot's Logger Overrides
@@ -186,7 +197,10 @@ func add_error(function: String, file: String, line: int,
 		err.line = line
 
 		errors.add(_current_test_id, err)
+		_auto_handle_error(err)
 
 		_mutex.unlock()
 
 		return err
+
+

--- a/addons/gut/gut_tracked_error.gd
+++ b/addons/gut/gut_tracked_error.gd
@@ -36,6 +36,8 @@ func to_s() -> String:
 		file, '->', function, '@', line, "\n",
 		"handled: ", handled, "\n",
 		"gut type: ", get_error_type_name(),"\n",
+		"error_type: ", error_type, "\n",
+		"editor_notify:", editor_notify, "\n",
 		backtrace, "\n")
 
 

--- a/test/unit/test_bugs/test_i842_unresolved_return.gd
+++ b/test/unit/test_bugs/test_i842_unresolved_return.gd
@@ -1,0 +1,93 @@
+extends GutInternalTester
+
+
+class FailTestClass:
+	extends Node
+
+	var should_stop_waiting: bool = false
+
+
+	func returns_bool_with_await() -> bool:
+		await get_tree().process_frame
+		return true
+
+	func test_no_return_type():
+		pass
+
+	func returns_node2d() -> Node2D:
+		return Node2D.new()
+
+	func returns_node2d_with_await() -> Node2D:
+		await get_tree().process_frame
+		return Node2D.new()
+
+	func returns_variant_with_await() -> Variant:
+		await get_tree().process_frame
+		return 4
+
+	func returns_ref_counted_with_await() -> RefCounted:
+		await get_tree().process_frame
+		return RefCounted.new()
+
+	func returns_object_with_await() -> Object:
+		await get_tree().process_frame
+		return RefCounted.new()
+
+	func returns_FailTestClass() -> FailTestClass:
+		return FailTestClass.new()
+
+	func returns_FailTestClass_with_await() -> FailTestClass:
+		await get_tree().process_frame
+		return FailTestClass.new()
+
+
+
+func before_all():
+	register_inner_classes(get_script())
+
+
+func after_each():
+	pass
+	# gut.get_doubler()._method_return_types.clear()
+
+func after_all():
+	gut.get_doubler().print_source = false
+
+
+func test_it() -> void:
+	var dbl: FailTestClass = partial_double(FailTestClass).new()
+	assert_not_null(dbl)
+
+
+func test_it_with_setting_returns():
+	var dbl: FailTestClass = double(FailTestClass).new()
+	assert_not_null(dbl)
+
+
+func test_it_again_since_this_was_failing_occassionally():
+	var dbl: FailTestClass = partial_double(FailTestClass).new()
+	assert_not_null(dbl)
+
+
+func test_it_with_setting_return():
+	var dbl: FailTestClass = double(FailTestClass).new()
+	assert_not_null(dbl)
+
+
+func test_all_returns():
+	var Dbl = double(TestResourceAllReturnTypes)
+	assert_false(typeof(Dbl) == TYPE_INT)
+	var inst = Dbl.new()
+	assert_not_null(inst)
+
+
+func test_double_of_InputSender_wait_parses_frames():
+	var sender = double(InputSender).new()
+	stub(sender, 'wait').to_call_super()
+	sender.wait('3f')
+	assert_called(sender, 'wait_frames', [3.0])
+
+
+func test_double_GutTest():
+	var Dbl = double(GutTest)
+	assert_not_null(Dbl)

--- a/test/unit/test_error_tracker.gd
+++ b/test/unit/test_error_tracker.gd
@@ -228,6 +228,5 @@ func test_unresolved_return_is_ignored():
 		'modules/gdscript/gdscript_byte_codegen.cpp',
 		-1,
 		'Compiler bug: Unresolved return.', '',
-
 		false, 0, [])
 	assert_true(err.handled)

--- a/test/unit/test_error_tracker.gd
+++ b/test/unit/test_error_tracker.gd
@@ -220,3 +220,14 @@ func test_get_errors_for_test_contains_warnings():
 	push_warning("emergency evacuation protest")
 	var errors = _added_tracker.errors.items[GutUtils.NO_TEST]
 	assert_eq(errors.size(), 1)
+
+
+func test_unresolved_return_is_ignored():
+	var err = _added_tracker.add_error(
+		'write_return',
+		'modules/gdscript/gdscript_byte_codegen.cpp',
+		-1,
+		'Compiler bug: Unresolved return.', '',
+
+		false, 0, [])
+	assert_true(err.handled)


### PR DESCRIPTION
GUT will now ignore the "Compiler bug: Unresolved return." error.  It still appears in the output (cannot be prevented), but GUT prints a message after the error indicating it was ignored and provides a link to issue #842. 

I discovered some issues with adding the return type clauses to doubled methods.  The class info about the return type that Godot's metadata provides is not specific enough in some cases (e.g. `RefCounted` is in the metadata but the actual return type inherits from `RefCounted`).  When this happens, the double won't compile and tests cannot be run.  

This is a temporary solution so tests will at leas run until a more bulletproof solution can be found for the return types.

