### PR TITLE
Avoid wrapping methods that return Signal

### DIFF
--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -265,8 +265,7 @@ func _create_singleton_double(singleton, is_partial):
 func _stub_method_default_values(parsed):
 	for method in parsed.get_local_methods():
 		if(method.is_eligible_for_doubling() and \
-			!_ignored_methods.has(parsed.resource, method.meta.name) and \
-			!_method_returns_signal(method)):
+			!_ignored_methods.has(parsed.resource, method.meta.name)):
 			_stubber.stub_defaults_from_meta(parsed.script_path, method.meta)
 
 

--- a/addons/gut/doubler.gd
+++ b/addons/gut/doubler.gd
@@ -167,10 +167,27 @@ func _get_singleton_text(parsed, included_methods, is_partial):
 	return src
 
 
+func _method_returns_signal(parsed_method):
+	var return_meta = parsed_method.meta.get('return', {})
+	return typeof(return_meta) == TYPE_DICTIONARY and \
+		return_meta.get('type', TYPE_NIL) == TYPE_SIGNAL
+
+
 func _is_method_eligible_for_doubling(parsed_script, parsed_method):
-	return !parsed_method.is_accessor() and \
-		parsed_method.is_eligible_for_doubling() and \
-		!_ignored_methods.has(parsed_script.resource, parsed_method.meta.name)
+	var method_name = parsed_method.meta.name
+	if(parsed_method.is_accessor() or \
+		!parsed_method.is_eligible_for_doubling() or \
+		_ignored_methods.has(parsed_script.resource, method_name)):
+		return false
+
+	if(_method_returns_signal(parsed_method)):
+		_lgr.error(str(
+			"Cannot double method '", method_name,
+			"' because it returns a Signal.  Call ignore_method_when_doubling on ",
+			"this method before creating the double."))
+		return false
+
+	return true
 
 
 # Disable the native_method_override setting so that doubles do not generate
@@ -247,7 +264,9 @@ func _create_singleton_double(singleton, is_partial):
 
 func _stub_method_default_values(parsed):
 	for method in parsed.get_local_methods():
-		if(method.is_eligible_for_doubling() and !_ignored_methods.has(parsed.resource, method.meta.name)):
+		if(method.is_eligible_for_doubling() and \
+			!_ignored_methods.has(parsed.resource, method.meta.name) and \
+			!_method_returns_signal(method)):
 			_stubber.stub_defaults_from_meta(parsed.script_path, method.meta)
 
 

--- a/documentation/docs/Doubles.md
+++ b/documentation/docs/Doubles.md
@@ -107,6 +107,19 @@ These ignored methods are cleared after each test is ran to avoid any unexpected
 There's more info and examples on this method on the [[Methods|Asserts-and-Methods]] page.
 
 
+## Doubling Methods that Return Signals
+GUT cannot wrap a method declared with a `Signal` return type.  Generated wrappers must await calls to the original method because Godot does not identify coroutines in method metadata.  Awaiting a returned `Signal` waits for that signal to emit and can stall the test run.  GUT reports an error and leaves the method out of the double instead.
+
+Use `ignore_method_when_doubling` to explicitly accept that the original method will remain available but cannot be stubbed or spied on:
+
+```gdscript
+func before_each():
+    ignore_method_when_doubling(MyClass, 'get_my_signal')
+```
+
+GUT can only detect this situation when the method has a declared `Signal` return type.  An untyped method that returns a `Signal` must be ignored manually as shown above.
+
+
 ## Doubled method default parameters
 GUT stubs all parameters in doubled user methods to be `null`.  This is because Godot only provides defaults for built-in methods.  When using Partial Doubles or stubbing a method `to_call_super`, `null` can get passed around when you wouldn't expect it causing errors such as `Invalid operands 'int' and 'Nil'`.  See the "Stubbing Method Parameter Defaults" in [Stubbing](Stubbing) for a way to stub method default values.
 

--- a/test/unit/test_bugs/test_i833_signal_return.gd
+++ b/test/unit/test_bugs/test_i833_signal_return.gd
@@ -1,0 +1,28 @@
+extends GutInternalTester
+
+
+class ReturnsSignal:
+	signal finished
+
+	func get_finished() -> Signal:
+		return finished
+
+
+func before_all():
+	register_inner_classes(get_script())
+
+
+func test_typed_signal_return_is_not_wrapped():
+	var doubled = partial_double(ReturnsSignal).new()
+	assert_tracked_gut_error_text(gut,
+		"Cannot double method 'get_finished' because it returns a Signal.")
+	assert_does_not_have(doubled.__gutdbl_values.doubled_methods, 'get_finished')
+	assert_typeof(doubled.get_finished(), TYPE_SIGNAL)
+
+
+func test_typed_signal_return_can_be_explicitly_ignored():
+	ignore_method_when_doubling(ReturnsSignal, 'get_finished')
+	var doubled = partial_double(ReturnsSignal).new()
+	assert_tracked_gut_error(gut, 0)
+	assert_does_not_have(doubled.__gutdbl_values.doubled_methods, 'get_finished')
+	assert_typeof(doubled.get_finished(), TYPE_SIGNAL)

--- a/test/unit/test_bugs/test_i833_signal_return.gd.uid
+++ b/test/unit/test_bugs/test_i833_signal_return.gd.uid
@@ -1,0 +1,1 @@
+uid://c7tfem1bmwjla


### PR DESCRIPTION
## Summary

- detect declared `Signal` return metadata before generating a doubled wrapper
- report an actionable GUT error and leave the method inherited instead of generating an `await` that can stall
- document `ignore_method_when_doubling` and the limitation for untyped Signal-returning methods

## Verification

- focused regression on Godot 4.6.3 / GUT 9.6.1: 2 tests passed, 6 assertions
- complete headless suite: 248 scripts, 1,745 tests, 1,742 passing, 7 existing pending/risky, 3,036 assertions; exit code 0
- GDScript LSP: no errors in the changed source or regression test
- `gdlint` on the new regression test: no problems
- `git diff --check`: clean

Fixes #833