### PR TITLE
Add null checks in assert_almost_* methods

### DIFF
--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -977,7 +977,7 @@ func _is_almost_eq(got, expected, error_interval) -> bool:
 
 	return(result)
 
-## assserts got > expected
+## asserts got > expected
 ## [codeblock]
 ##    var bigger = 5
 ##    var smaller = 0

--- a/addons/gut/test.gd
+++ b/addons/gut/test.gd
@@ -201,6 +201,16 @@ func _do_datatypes_match__fail_if_not(got, expected, text):
 	return did_pass
 
 
+# Checks if the input is not null. If it is, a fail occurs. Otherwise, TRUE is
+# returned.
+func _fail_if_null(got, input_name, text):
+	if(got == null):
+		_fail(str(input_name, ' cannot be NULL.'))
+		return false
+	
+	return true
+
+
 # Create a string that lists all the methods that were called on an spied
 # instance.
 func _get_desc_of_calls_to_instance(inst):
@@ -928,7 +938,10 @@ func assert_ne(got, not_expected, text=""):
 ## [/codeblock]
 func assert_almost_eq(got, expected, error_interval, text=''):
 	var disp = "[" + _str_precision(got, 20) + "] expected to equal [" + _str(expected) + "] +/- [" + str(error_interval) + "]:  " + text
-	if(_do_datatypes_match__fail_if_not(got, expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)):
+	if(
+		_fail_if_null(got, '[Got]', text) and _fail_if_null(expected, '[Expected]', text) and _fail_if_null(error_interval, '[Error Interval]', text) and
+		_do_datatypes_match__fail_if_not(got, expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)
+	):
 		if not _is_almost_eq(got, expected, error_interval):
 			_fail(disp)
 		else:
@@ -939,7 +952,10 @@ func assert_almost_eq(got, expected, error_interval, text=''):
 ## outside the range of [param not_expected] +/- [param error_interval].
 func assert_almost_ne(got, not_expected, error_interval, text=''):
 	var disp = "[" + _str_precision(got, 20) + "] expected to not equal [" + _str(not_expected) + "] +/- [" + str(error_interval) + "]:  " + text
-	if(_do_datatypes_match__fail_if_not(got, not_expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)):
+	if(
+		_fail_if_null(got, '[Got]', text) and _fail_if_null(not_expected, '[Not Expected]', text) and _fail_if_null(error_interval, '[Error Interval]', text) and
+		_do_datatypes_match__fail_if_not(got, not_expected, text) and _do_datatypes_match__fail_if_not(got, error_interval, text)
+	):
 		if _is_almost_eq(got, not_expected, error_interval):
 			_fail(disp)
 		else:

--- a/test/unit/test_test.gd
+++ b/test/unit/test_test.gd
@@ -342,6 +342,32 @@ class TestAssertAlmostEq:
 		assert_fail_msg_contains(gr.test, '03450')
 		assert_fail_msg_contains(gr.test, '03210')
 
+	var datatype_data = [
+		[Vector3(1, 2, 3), 2.0, 3.0],
+		[1.0, Vector3(1, 2, 3), 3.0],
+		[1, 2, Vector3(1, 2, 3)],
+		[Vector3(1, 2, 3), Vector3(1, 2, 3), Vector2(1, 2)],
+	]
+	func test_datatype_checks(params = use_parameters(datatype_data)):
+		gr.test.assert_almost_eq(params[0], params[1], params[2])
+		assert_engine_error_count(0)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, "Cannot compare")
+
+	var null_data = [
+		[1, 2, null],
+		[1, null, 3],
+		[null, 2, 3],
+		[1, null, null],
+		[null, 2, null],
+		[null, null, 3],
+		[null, null, null],
+	]
+	func test_null_checks(params = use_parameters(null_data)):
+		gr.test.assert_almost_eq(params[0], params[1], params[2])
+		assert_engine_error_count(0)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, "cannot be NULL")
 
 # ------------------------------------------------------------------------------
 class TestAssertAlmostNe:
@@ -415,6 +441,33 @@ class TestAssertAlmostNe:
 		gr.test.assert_almost_ne(.500000000012300000, .5, .001)
 		assert_fail(gr.test)
 		assert_fail_msg_contains(gr.test, '01230')
+
+	var datatype_data = [
+		[Vector3(1, 2, 3), 2.0, 3.0],
+		[1.0, Vector3(1, 2, 3), 3.0],
+		[1, 2, Vector3(1, 2, 3)],
+		[Vector3(1, 2, 3), Vector3(1, 2, 3), Vector2(1, 2)],
+	]
+	func test_datatype_checks(params = use_parameters(datatype_data)):
+		gr.test.assert_almost_ne(params[0], params[1], params[2])
+		assert_engine_error_count(0)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, "Cannot compare")
+
+	var null_data = [
+		[1, 2, null],
+		[1, null, 3],
+		[null, 2, 3],
+		[1, null, null],
+		[null, 2, null],
+		[null, null, 3],
+		[null, null, null],
+	]
+	func test_null_checks(params = use_parameters(null_data)):
+		gr.test.assert_almost_ne(params[0], params[1], params[2])
+		assert_engine_error_count(0)
+		assert_fail(gr.test)
+		assert_fail_msg_contains(gr.test, "cannot be NULL")
 
 # ------------------------------------------------------------------------------
 class TestAssertGt:


### PR DESCRIPTION
- pre-check inputs for nulls before running comparison: report nulls as failed tests vs crashing

This closes issue https://github.com/bitwes/Gut/issues/855
Please feel free to edit this PR / reply here if I'm missing anything.

e.g., I'd assume that nulls in the inputs should just be reported as failed tests vs. crashing, but if not, that's fine. (Though, I'll at least keep these changes in my own project.)

-----

### Note here:

This PR causes passing `null` for `got`, `expected`, or `error_interval` to *either* `assert_almost_eq` *or* `assert_almost_ne` to fail the test. I'd assume both cases are correct, but, to be clear, this does mean that `assert_almost_ne(null, null, 1)` **fails** rather than passes. If that sounds wrong, let me know, or just edit it. Either way, maybe we add a note to the docs for these methods?

Thanks for this amazing tool!